### PR TITLE
document game corner

### DIFF
--- a/scripts/celadongamecorner.asm
+++ b/scripts/celadongamecorner.asm
@@ -1,26 +1,26 @@
 CeladonGameCornerScript: ; 48bbd (12:4bbd)
-	call CeladonGameCornerScript_48bcf
+	call InitialiseUnknownSlotVar
 	call CeladonGameCornerScript_48bec
 	call EnableAutoTextBoxDrawing
 	ld hl, CeladonGameCornerScriptPointers
 	ld a, [W_CELADONGAMECORNERCURSCRIPT]
 	jp CallFunctionInTable
 
-CeladonGameCornerScript_48bcf: ; 48bcf (12:4bcf)
+InitialiseUnknownSlotVar: ; 48bcf (12:4bcf)
 	ld hl, wd126
 	bit 6, [hl]
 	res 6, [hl]
-	ret z
+	ret z ; run only once
 	call Random
-	ld a, [$ffd3]
+	ld a, [hRandomAdd] ; redundant
 	cp $7
-	jr nc, .asm_48be2
+	jr nc, .EightOrLess
 	ld a, $8
-.asm_48be2
+.EightOrLess
 	srl a
 	srl a
 	srl a
-	ld [wUnknownSlotVar], a
+	ld [wUnknownSlotVar], a ; 1/8 chance
 	ret
 
 CeladonGameCornerScript_48bec: ; 48bec (12:4bec)


### PR DESCRIPTION
I'm not sure how far I'll get, but at least I improved this subroutine a bit.

I'm not sure about `wd126`.

I dug until I reached the main loop of `engine/slot_machine.asm` but I don't understand a lot of things.

I think that `wTrainerFacingDirection` might contain something else then it says it does, looking at its usage in `engine/game_corner_slots.asm`