### PR TITLE
Enable continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: c
+install:
+  - sudo easy_install pypng
+  - path="$(pwd)"; cd; git clone git://github.com/bentley/rgbds.git && cd rgbds && sudo make install; cd "$path"
+before_script:
+  - |-
+    function check_status() {
+      if ! git diff-index --quiet HEAD --; then
+        echo 'Uncommitted changes detected.';
+        return 1;
+      fi;
+    }
+  - |-
+    function verify() {
+      actual="$(md5sum "${1}" | cut -c 1-32)";
+      expected="${2}";
+      if [ "${actual}" != "${expected}" ]; then
+        echo "md5(${1}): expected ${2}, but got ${actual} instead.";
+        return 1;
+      fi;
+    }
+script:
+  - make
+  - verify pokeblue.gbc 50927e843568814f7ed45ec4f944bd8b
+  - verify pokered.gbc 3d45c1ee9abd5738df46d2bdda8b57dc
+  - check_status


### PR DESCRIPTION
With this change, every commit pushed to master and every pull request received triggers a build. If anything breaks, e.g. if the MD5 hashes for generated ROMs are incorrect, it automatically reports an error straight in the GitHub pull request UI.

Example build log: https://travis-ci.org/PoCs/pokered/builds/151586998

For this to work, you’d have to enable Travis for this repository: https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A
