### PR TITLE
Use correct variable in EngageMapTrainer

### DIFF
--- a/home.asm
+++ b/home.asm
@@ -2528,7 +2528,7 @@ EngageMapTrainer::
 	ld a, [hli]    ; load trainer class
 	ld [wEngagedTrainerClass], a
 	ld a, [hl]     ; load trainer mon set
-	ld [wEnemyMonAttackMod], a
+	ld [wEngagedTrainerSet], a
 	jp PlayTrainerMusic
 
 PrintEndBattleText::


### PR DESCRIPTION
EngageMapTrainer should write to wEngagedTrainerClass and
wEngagedTrainerSet, not wEngagedTrainerClass and
wEnemyMonAttackMod. wEnemyMonAttackMod doesn't make any
sense in this context. Use the correct variable.

These two variables happen to have the same address, so
there is no functional difference between using
wEnemyMonAttackMod versus using wEngagedTrainerSet.