### PR TITLE
Misc style fixes

### DIFF
--- a/constants/status_constants.asm
+++ b/constants/status_constants.asm
@@ -6,27 +6,27 @@ FRZ EQU 5
 PAR EQU 6
 
 ; volatile statuses 1
-StoringEnergy          EQU 0 ; Bide
-ThrashingAbout         EQU 1 ; e.g. Thrash
-AttackingMultipleTimes EQU 2 ; e.g. Double Kick, Fury Attack
-Flinched               EQU 3
-ChargingUp             EQU 4 ; e.g. Solar Beam, Fly
-UsingTrappingMove      EQU 5 ; e.g. Wrap
-Invulnerable           EQU 6 ; charging up Fly/Dig
-Confused               EQU 7
+STORING_ENERGY           EQU 0 ; Bide
+THRASHING_ABOUT          EQU 1 ; e.g. Thrash
+ATTACKING_MULTIPLE_TIMES EQU 2 ; e.g. Double Kick, Fury Attack
+FLINCHED                 EQU 3
+CHARGING_UP              EQU 4 ; e.g. Solar Beam, Fly
+USING_TRAPPING_MOVE      EQU 5 ; e.g. Wrap
+INVULNERABLE             EQU 6 ; charging up Fly/Dig
+CONFUSED                 EQU 7
 
 ; volatile statuses 2
-UsingXAccuracy    EQU 0
-ProtectedByMist   EQU 1
-GettingPumped     EQU 2 ; Focus Energy
-;                 EQU 3 ; unused?
-HasSubstituteUp   EQU 4
-NeedsToRecharge   EQU 5 ; Hyper Beam
-UsingRage         EQU 6
-Seeded            EQU 7
+USING_X_ACCURACY    EQU 0
+PROTECTED_BY_MIST   EQU 1
+GETTING_PUMPED      EQU 2 ; Focus Energy
+;                   EQU 3 ; unused
+HAS_SUBSTITUTE_UP   EQU 4
+NEEDS_TO_RECHARGE   EQU 5 ; Hyper Beam
+USING_RAGE          EQU 6
+SEEDED              EQU 7
 
 ; volatile statuses 3
-BadlyPoisoned    EQU 0
-HasLightScreenUp EQU 1
-HasReflectUp     EQU 2
-Transformed      EQU 3
+BADLY_POISONED      EQU 0
+HAS_LIGHT_SCREEN_UP EQU 1
+HAS_REFLECT_UP      EQU 2
+TRANSFORMED         EQU 3

--- a/engine/HoF_room_pc.asm
+++ b/engine/HoF_room_pc.asm
@@ -47,61 +47,61 @@ FadeInCreditsText:
 
 DisplayCreditsMon:
 	xor a
-	ld [H_AUTOBGTRANSFERENABLED],a
+	ld [H_AUTOBGTRANSFERENABLED], a
 	call SaveScreenTilesToBuffer1
 	call FillMiddleOfScreenWithWhite
 
 	; display the next monster from CreditsMons
-	ld hl,wNumCreditsMonsDisplayed
-	ld c,[hl] ; how many monsters have we displayed so far?
+	ld hl, wNumCreditsMonsDisplayed
+	ld c, [hl] ; how many monsters have we displayed so far?
 	inc [hl]
-	ld b,0
-	ld hl,CreditsMons
-	add hl,bc ; go that far in the list of monsters and get the next one
-	ld a,[hl]
-	ld [wcf91],a
-	ld [wd0b5],a
+	ld b, 0
+	ld hl, CreditsMons
+	add hl, bc ; go that far in the list of monsters and get the next one
+	ld a, [hl]
+	ld [wcf91], a
+	ld [wd0b5], a
 	coord hl, 8, 6
 	call GetMonHeader
 	call LoadFrontSpriteByMonIndex
-	ld hl,vBGMap0 + $c
+	ld hl, vBGMap0 + $c
 	call CreditsCopyTileMapToVRAM
 	xor a
-	ld [H_AUTOBGTRANSFERENABLED],a
+	ld [H_AUTOBGTRANSFERENABLED], a
 	call LoadScreenTilesFromBuffer1
-	ld hl,vBGMap0
+	ld hl, vBGMap0
 	call CreditsCopyTileMapToVRAM
-	ld a,$A7
-	ld [rWX],a
-	ld hl,vBGMap1
+	ld a, $A7
+	ld [rWX], a
+	ld hl, vBGMap1
 	call CreditsCopyTileMapToVRAM
 	call FillMiddleOfScreenWithWhite
-	ld a,%11111100 ; make the mon a black silhouette
-	ld [rBGP],a
+	ld a, %11111100 ; make the mon a black silhouette
+	ld [rBGP], a
 
 ; scroll the mon left by one tile 7 times
-	ld bc,7
+	ld bc, 7
 .scrollLoop1
 	call ScrollCreditsMonLeft
 	dec c
-	jr nz,.scrollLoop1
+	jr nz, .scrollLoop1
 
 ; scroll the mon left by one tile 20 times
 ; This time, we have to move the window left too in order to hide the text that
 ; is wrapping around to the right side of the screen.
-	ld c,20
+	ld c, 20
 .scrollLoop2
 	call ScrollCreditsMonLeft
-	ld a,[rWX]
+	ld a, [rWX]
 	sub 8
-	ld [rWX],a
+	ld [rWX], a
 	dec c
-	jr nz,.scrollLoop2
+	jr nz, .scrollLoop2
 
 	xor a
-	ld [hWY],a
-	ld a,%11000000
-	ld [rBGP],a
+	ld [hWY], a
+	ld a, %11000000
+	ld [rBGP], a
 	ret
 
 INCLUDE "data/credit_mons.asm"

--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -2101,7 +2101,7 @@ HideSubstituteShowMonAnim:
 .next1
 	push hl
 ; if the substitute broke, slide it down, else slide it offscreen horizontally
-	bit HasSubstituteUp, a
+	bit HAS_SUBSTITUTE_UP, a
 	jr nz, .substituteStillUp
 	call AnimationSlideMonDown
 	jr .next2

--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -1,202 +1,202 @@
 ; Draws a "frame block". Frame blocks are blocks of tiles that are put
 ; together to form frames in battle animations.
 DrawFrameBlock:
-	ld l,c
-	ld h,b
-	ld a,[hli]
-	ld [wNumFBTiles],a
-	ld a,[wFBDestAddr + 1]
-	ld e,a
-	ld a,[wFBDestAddr]
-	ld d,a
+	ld l, c
+	ld h, b
+	ld a, [hli]
+	ld [wNumFBTiles], a
+	ld a, [wFBDestAddr + 1]
+	ld e, a
+	ld a, [wFBDestAddr]
+	ld d, a
 	xor a
-	ld [wFBTileCounter],a ; loop counter
+	ld [wFBTileCounter], a ; loop counter
 .loop
-	ld a,[wFBTileCounter]
+	ld a, [wFBTileCounter]
 	inc a
-	ld [wFBTileCounter],a
-	ld a,[wSubAnimTransform]
+	ld [wFBTileCounter], a
+	ld a, [wSubAnimTransform]
 	dec a
-	jr z,.flipHorizontalAndVertical   ; 1
+	jr z, .flipHorizontalAndVertical   ; 1
 	dec a
-	jp z,.flipHorizontalTranslateDown ; 2
+	jp z, .flipHorizontalTranslateDown ; 2
 	dec a
-	jr z,.flipBaseCoords              ; 3
+	jr z, .flipBaseCoords              ; 3
 .noTransformation
-	ld a,[wBaseCoordY]
+	ld a, [wBaseCoordY]
 	add [hl]
-	ld [de],a ; store Y
+	ld [de], a ; store Y
 	inc hl
 	inc de
-	ld a,[wBaseCoordX]
+	ld a, [wBaseCoordX]
 	jr .finishCopying
 .flipBaseCoords
-	ld a,[wBaseCoordY]
-	ld b,a
-	ld a,136
+	ld a, [wBaseCoordY]
+	ld b, a
+	ld a, 136
 	sub b ; flip Y base coordinate
 	add [hl] ; Y offset
-	ld [de],a ; store Y
+	ld [de], a ; store Y
 	inc hl
 	inc de
-	ld a,[wBaseCoordX]
-	ld b,a
-	ld a,168
+	ld a, [wBaseCoordX]
+	ld b, a
+	ld a, 168
 	sub b ; flip X base coordinate
 .finishCopying ; finish copying values to OAM (when [wSubAnimTransform] not 1 or 2)
 	add [hl] ; X offset
-	ld [de],a ; store X
+	ld [de], a ; store X
 	inc hl
 	inc de
-	ld a,[hli]
-	add a,$31 ; base tile ID for battle animations
-	ld [de],a ; store tile ID
+	ld a, [hli]
+	add $31 ; base tile ID for battle animations
+	ld [de], a ; store tile ID
 	inc de
-	ld a,[hli]
-	ld [de],a ; store flags
+	ld a, [hli]
+	ld [de], a ; store flags
 	inc de
 	jp .nextTile
 .flipHorizontalAndVertical
-	ld a,[wBaseCoordY]
+	ld a, [wBaseCoordY]
 	add [hl] ; Y offset
-	ld b,a
-	ld a,136
+	ld b, a
+	ld a, 136
 	sub b ; flip Y coordinate
-	ld [de],a ; store Y
+	ld [de], a ; store Y
 	inc hl
 	inc de
-	ld a,[wBaseCoordX]
+	ld a, [wBaseCoordX]
 	add [hl] ; X offset
-	ld b,a
-	ld a,168
+	ld b, a
+	ld a, 168
 	sub b ; flip X coordinate
-	ld [de],a ; store X
+	ld [de], a ; store X
 	inc hl
 	inc de
-	ld a,[hli]
-	add a,$31 ; base tile ID for battle animations
-	ld [de],a ; store tile ID
+	ld a, [hli]
+	add $31 ; base tile ID for battle animations
+	ld [de], a ; store tile ID
 	inc de
 ; toggle horizontal and vertical flip
-	ld a,[hli] ; flags
+	ld a, [hli] ; flags
 	and a
-	ld b,OAM_VFLIP | OAM_HFLIP
-	jr z,.storeFlags1
-	cp a,OAM_HFLIP
-	ld b,OAM_VFLIP
-	jr z,.storeFlags1
-	cp a,OAM_VFLIP
-	ld b,OAM_HFLIP
-	jr z,.storeFlags1
-	ld b,0
+	ld b, OAM_VFLIP | OAM_HFLIP
+	jr z, .storeFlags1
+	cp OAM_HFLIP
+	ld b, OAM_VFLIP
+	jr z, .storeFlags1
+	cp OAM_VFLIP
+	ld b, OAM_HFLIP
+	jr z, .storeFlags1
+	ld b, 0
 .storeFlags1
-	ld a,b
-	ld [de],a
+	ld a, b
+	ld [de], a
 	inc de
 	jp .nextTile
 .flipHorizontalTranslateDown
-	ld a,[wBaseCoordY]
+	ld a, [wBaseCoordY]
 	add [hl]
-	add a,40 ; translate Y coordinate downwards
-	ld [de],a ; store Y
+	add 40 ; translate Y coordinate downwards
+	ld [de], a ; store Y
 	inc hl
 	inc de
-	ld a,[wBaseCoordX]
+	ld a, [wBaseCoordX]
 	add [hl]
-	ld b,a
-	ld a,168
+	ld b, a
+	ld a, 168
 	sub b ; flip X coordinate
-	ld [de],a ; store X
+	ld [de], a ; store X
 	inc hl
 	inc de
-	ld a,[hli]
-	add a,$31 ; base tile ID for battle animations
-	ld [de],a ; store tile ID
+	ld a, [hli]
+	add $31 ; base tile ID for battle animations
+	ld [de], a ; store tile ID
 	inc de
-	ld a,[hli]
-	bit 5,a ; is horizontal flip enabled?
-	jr nz,.disableHorizontalFlip
+	ld a, [hli]
+	bit 5, a ; is horizontal flip enabled?
+	jr nz, .disableHorizontalFlip
 .enableHorizontalFlip
-	set 5,a
+	set 5, a
 	jr .storeFlags2
 .disableHorizontalFlip
-	res 5,a
+	res 5, a
 .storeFlags2
-	ld [de],a
+	ld [de], a
 	inc de
 .nextTile
-	ld a,[wFBTileCounter]
-	ld c,a
-	ld a,[wNumFBTiles]
+	ld a, [wFBTileCounter]
+	ld c, a
+	ld a, [wNumFBTiles]
 	cp c
-	jp nz,.loop ; go back up if there are more tiles to draw
+	jp nz, .loop ; go back up if there are more tiles to draw
 .afterDrawingTiles
-	ld a,[wFBMode]
-	cp a,2
-	jr z,.advanceFrameBlockDestAddr; skip delay and don't clean OAM buffer
-	ld a,[wSubAnimFrameDelay]
-	ld c,a
+	ld a, [wFBMode]
+	cp 2
+	jr z, .advanceFrameBlockDestAddr; skip delay and don't clean OAM buffer
+	ld a, [wSubAnimFrameDelay]
+	ld c, a
 	call DelayFrames
-	ld a,[wFBMode]
-	cp a,3
-	jr z,.advanceFrameBlockDestAddr ; skip cleaning OAM buffer
-	cp a,4
-	jr z,.done ; skip cleaning OAM buffer and don't advance the frame block destination address
-	ld a,[wAnimationID]
-	cp a,GROWL
-	jr z,.resetFrameBlockDestAddr
+	ld a, [wFBMode]
+	cp 3
+	jr z, .advanceFrameBlockDestAddr ; skip cleaning OAM buffer
+	cp 4
+	jr z, .done ; skip cleaning OAM buffer and don't advance the frame block destination address
+	ld a, [wAnimationID]
+	cp GROWL
+	jr z, .resetFrameBlockDestAddr
 	call AnimationCleanOAM
 .resetFrameBlockDestAddr
-	ld hl,wOAMBuffer ; OAM buffer
-	ld a,l
-	ld [wFBDestAddr + 1],a
-	ld a,h
-	ld [wFBDestAddr],a ; set destination address to beginning of OAM buffer
+	ld hl, wOAMBuffer ; OAM buffer
+	ld a, l
+	ld [wFBDestAddr + 1], a
+	ld a, h
+	ld [wFBDestAddr], a ; set destination address to beginning of OAM buffer
 	ret
 .advanceFrameBlockDestAddr
-	ld a,e
-	ld [wFBDestAddr + 1],a
-	ld a,d
-	ld [wFBDestAddr],a
+	ld a, e
+	ld [wFBDestAddr + 1], a
+	ld a, d
+	ld [wFBDestAddr], a
 .done
 	ret
 
 PlayAnimation:
 	xor a
-	ld [$FF8B],a ; it looks like nothing reads this
-	ld [wSubAnimTransform],a
-	ld a,[wAnimationID] ; get animation number
+	ld [$FF8B], a ; it looks like nothing reads this
+	ld [wSubAnimTransform], a
+	ld a, [wAnimationID] ; get animation number
 	dec a
-	ld l,a
-	ld h,0
-	add hl,hl
-	ld de,AttackAnimationPointers  ; animation command stream pointers
-	add hl,de
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld l, a
+	ld h, 0
+	add hl, hl
+	ld de, AttackAnimationPointers  ; animation command stream pointers
+	add hl, de
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 .animationLoop
-	ld a,[hli]
-	cp a,$FF
-	jr z,.AnimationOver
-	cp a,$C0 ; is this subanimation or a special effect?
-	jr c,.playSubanimation
+	ld a, [hli]
+	cp $FF
+	jr z, .AnimationOver
+	cp $C0 ; is this subanimation or a special effect?
+	jr c, .playSubanimation
 .doSpecialEffect
-	ld c,a
-	ld de,SpecialEffectPointers
+	ld c, a
+	ld de, SpecialEffectPointers
 .searchSpecialEffectTableLoop
-	ld a,[de]
+	ld a, [de]
 	cp c
-	jr z,.foundMatch
+	jr z, .foundMatch
 	inc de
 	inc de
 	inc de
 	jr .searchSpecialEffectTableLoop
 .foundMatch
-	ld a,[hli]
-	cp a,$FF ; is there a sound to play?
-	jr z,.skipPlayingSound
-	ld [wAnimSoundID],a ; store sound
+	ld a, [hli]
+	cp $FF ; is there a sound to play?
+	jr z, .skipPlayingSound
+	ld [wAnimSoundID], a ; store sound
 	push hl
 	push de
 	call GetMoveSound
@@ -206,50 +206,50 @@ PlayAnimation:
 .skipPlayingSound
 	push hl
 	inc de
-	ld a,[de]
-	ld l,a
+	ld a, [de]
+	ld l, a
 	inc de
-	ld a,[de]
-	ld h,a
-	ld de,.nextAnimationCommand
+	ld a, [de]
+	ld h, a
+	ld de, .nextAnimationCommand
 	push de
 	jp hl ; jump to special effect function
 .playSubanimation
-	ld c,a
-	and a,%00111111
-	ld [wSubAnimFrameDelay],a
+	ld c, a
+	and %00111111
+	ld [wSubAnimFrameDelay], a
 	xor a
 	sla c
 	rla
 	sla c
 	rla
-	ld [wWhichBattleAnimTileset],a
-	ld a,[hli] ; sound
-	ld [wAnimSoundID],a ; store sound
-	ld a,[hli] ; subanimation ID
-	ld c,l
-	ld b,h
-	ld l,a
-	ld h,0
-	add hl,hl
-	ld de,SubanimationPointers
-	add hl,de
-	ld a,l
-	ld [wSubAnimAddrPtr],a
-	ld a,h
-	ld [wSubAnimAddrPtr + 1],a
-	ld l,c
-	ld h,b
+	ld [wWhichBattleAnimTileset], a
+	ld a, [hli] ; sound
+	ld [wAnimSoundID], a ; store sound
+	ld a, [hli] ; subanimation ID
+	ld c, l
+	ld b, h
+	ld l, a
+	ld h, 0
+	add hl, hl
+	ld de, SubanimationPointers
+	add hl, de
+	ld a, l
+	ld [wSubAnimAddrPtr], a
+	ld a, h
+	ld [wSubAnimAddrPtr + 1], a
+	ld l, c
+	ld h, b
 	push hl
-	ld a,[rOBP0]
+	ld a, [rOBP0]
 	push af
-	ld a,[wAnimPalette]
-	ld [rOBP0],a
+	ld a, [wAnimPalette]
+	ld [rOBP0], a
 	call LoadAnimationTileset
 	call LoadSubanimation
 	call PlaySubanimation
 	pop af
-	ld [rOBP0],a
+	ld [rOBP0], a
 .nextAnimationCommand
 	pop hl
 	jr .animationLoop
@@ -257,22 +257,22 @@ PlayAnimation:
 	ret
 
 LoadSubanimation:
-	ld a,[wSubAnimAddrPtr + 1]
-	ld h,a
-	ld a,[wSubAnimAddrPtr]
-	ld l,a
-	ld a,[hli]
-	ld e,a
-	ld a,[hl]
-	ld d,a ; de = address of subanimation
-	ld a,[de]
-	ld b,a
-	and a,31
-	ld [wSubAnimCounter],a ; number of frame blocks
-	ld a,b
-	and a,%11100000
-	cp a,5 << 5 ; is subanimation type 5?
-	jr nz,.isNotType5
+	ld a, [wSubAnimAddrPtr + 1]
+	ld h, a
+	ld a, [wSubAnimAddrPtr]
+	ld l, a
+	ld a, [hli]
+	ld e, a
+	ld a, [hl]
+	ld d, a ; de = address of subanimation
+	ld a, [de]
+	ld b, a
+	and 31
+	ld [wSubAnimCounter], a ; number of frame blocks
+	ld a, b
+	and %11100000
+	cp 5 << 5 ; is subanimation type 5?
+	jr nz, .isNotType5
 .isType5
 	call GetSubanimationTransform2
 	jr .saveTransformation
@@ -282,35 +282,35 @@ LoadSubanimation:
 ; place the upper 3 bits of a into bits 0-2 of a before storing
 	srl a
 	swap a
-	ld [wSubAnimTransform],a
-	cp a,4 ; is the animation reversed?
-	ld hl,0
-	jr nz,.storeSubentryAddr
+	ld [wSubAnimTransform], a
+	cp 4 ; is the animation reversed?
+	ld hl, 0
+	jr nz, .storeSubentryAddr
 ; if the animation is reversed, then place the initial subentry address at the end of the list of subentries
-	ld a,[wSubAnimCounter]
+	ld a, [wSubAnimCounter]
 	dec a
-	ld bc,3
+	ld bc, 3
 .loop
-	add hl,bc
+	add hl, bc
 	dec a
-	jr nz,.loop
+	jr nz, .loop
 .storeSubentryAddr
 	inc de
-	add hl,de
-	ld a,l
-	ld [wSubAnimSubEntryAddr],a
-	ld a,h
-	ld [wSubAnimSubEntryAddr + 1],a
+	add hl, de
+	ld a, l
+	ld [wSubAnimSubEntryAddr], a
+	ld a, h
+	ld [wSubAnimSubEntryAddr + 1], a
 	ret
 
 ; called if the subanimation type is not 5
 ; sets the transform to 0 (i.e. no transform) if it's the player's turn
 ; sets the transform to the subanimation type if it's the enemy's turn
 GetSubanimationTransform1:
-	ld b,a
-	ld a,[H_WHOSETURN]
+	ld b, a
+	ld a, [H_WHOSETURN]
 	and a
-	ld a,b
+	ld a, b
 	ret nz
 	xor a
 	ret
@@ -319,32 +319,32 @@ GetSubanimationTransform1:
 ; sets the transform to 2 (i.e. horizontal and vertical flip) if it's the player's turn
 ; sets the transform to 0 (i.e. no transform) if it's the enemy's turn
 GetSubanimationTransform2:
-	ld a,[H_WHOSETURN]
+	ld a, [H_WHOSETURN]
 	and a
-	ld a,2 << 5
+	ld a, 2 << 5
 	ret z
 	xor a
 	ret
 
 ; loads tile patterns for battle animations
 LoadAnimationTileset:
-	ld a,[wWhichBattleAnimTileset]
+	ld a, [wWhichBattleAnimTileset]
 	add a
 	add a
-	ld hl,AnimationTilesetPointers
-	ld e,a
-	ld d,0
-	add hl,de
-	ld a,[hli]
-	ld [wTempTilesetNumTiles],a ; number of tiles
-	ld a,[hli]
-	ld e,a
-	ld a,[hl]
-	ld d,a ; de = address of tileset
-	ld hl,vSprites + $310
+	ld hl, AnimationTilesetPointers
+	ld e, a
+	ld d, 0
+	add hl, de
+	ld a, [hli]
+	ld [wTempTilesetNumTiles], a ; number of tiles
+	ld a, [hli]
+	ld e, a
+	ld a, [hl]
+	ld d, a ; de = address of tileset
+	ld hl, vSprites + $310
 	ld b, BANK(AnimationTileset1) ; ROM bank
-	ld a,[wTempTilesetNumTiles]
-	ld c,a ; number of tiles
+	ld a, [wTempTilesetNumTiles]
+	ld c, a ; number of tiles
 	jp CopyVideoData ; load tileset
 
 AnimationTilesetPointers:
@@ -381,12 +381,12 @@ MoveAnimation:
 	push af
 	call WaitForSoundToFinish
 	call SetAnimationPalette
-	ld a,[wAnimationID]
+	ld a, [wAnimationID]
 	and a
 	jr z, .animationFinished
 
 	; if throwing a Poké Ball, skip the regular animation code
-	cp a,TOSS_ANIM
+	cp TOSS_ANIM
 	jr nz, .moveAnimation
 	ld de, .animationFinished
 	push de
@@ -394,25 +394,25 @@ MoveAnimation:
 
 .moveAnimation
 	; check if battle animations are disabled in the options
-	ld a,[wOptions]
-	bit 7,a
+	ld a, [wOptions]
+	bit 7, a
 	jr nz, .animationsDisabled
 	call ShareMoveAnimations
 	call PlayAnimation
 	jr .next4
 .animationsDisabled
-	ld c,30
+	ld c, 30
 	call DelayFrames
 .next4
 	call PlayApplyingAttackAnimation ; shake the screen or flash the pic in and out (to show damage)
 .animationFinished
 	call WaitForSoundToFinish
 	xor a
-	ld [wSubAnimSubEntryAddr],a
-	ld [wUnusedD09B],a
-	ld [wSubAnimTransform],a
+	ld [wSubAnimSubEntryAddr], a
+	ld [wUnusedD09B], a
+	ld [wSubAnimTransform], a
 	dec a
-	ld [wAnimSoundID],a
+	ld [wAnimSoundID], a
 	pop af
 	pop bc
 	pop de
@@ -421,42 +421,42 @@ MoveAnimation:
 
 ShareMoveAnimations:
 ; some moves just reuse animations from status conditions
-	ld a,[H_WHOSETURN]
+	ld a, [H_WHOSETURN]
 	and a
 	ret z
 
 	; opponent’s turn
 
-	ld a,[wAnimationID]
+	ld a, [wAnimationID]
 
-	cp a,AMNESIA
-	ld b,CONF_ANIM
+	cp AMNESIA
+	ld b, CONF_ANIM
 	jr z, .replaceAnim
 
-	cp a,REST
-	ld b,SLP_ANIM
+	cp REST
+	ld b, SLP_ANIM
 	ret nz
 
 .replaceAnim
-	ld a,b
-	ld [wAnimationID],a
+	ld a, b
+	ld [wAnimationID], a
 	ret
 
 PlayApplyingAttackAnimation:
 ; Generic animation that shows after the move's individual animation
 ; Different animation depending on whether the move has an additional effect and on whose turn it is
-	ld a,[wAnimationType]
+	ld a, [wAnimationType]
 	and a
 	ret z
 	dec a
 	add a
-	ld c,a
-	ld b,0
-	ld hl,AnimationTypePointerTable
-	add hl,bc
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld c, a
+	ld b, 0
+	ld hl, AnimationTypePointerTable
+	add hl, bc
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 	jp hl
 
 AnimationTypePointerTable:
@@ -547,69 +547,69 @@ SetAnimationPalette:
 	ret
 
 PlaySubanimation:
-	ld a,[wAnimSoundID]
-	cp a,$FF
-	jr z,.skipPlayingSound
+	ld a, [wAnimSoundID]
+	cp $FF
+	jr z, .skipPlayingSound
 	call GetMoveSound
 	call PlaySound
 .skipPlayingSound
-	ld hl,wOAMBuffer ; base address of OAM buffer
-	ld a,l
-	ld [wFBDestAddr + 1],a
-	ld a,h
-	ld [wFBDestAddr],a
-	ld a,[wSubAnimSubEntryAddr + 1]
-	ld h,a
-	ld a,[wSubAnimSubEntryAddr]
-	ld l,a
+	ld hl, wOAMBuffer ; base address of OAM buffer
+	ld a, l
+	ld [wFBDestAddr + 1], a
+	ld a, h
+	ld [wFBDestAddr], a
+	ld a, [wSubAnimSubEntryAddr + 1]
+	ld h, a
+	ld a, [wSubAnimSubEntryAddr]
+	ld l, a
 .loop
 	push hl
-	ld c,[hl] ; frame block ID
-	ld b,0
-	ld hl,FrameBlockPointers
-	add hl,bc
-	add hl,bc
-	ld a,[hli]
-	ld c,a
-	ld a,[hli]
-	ld b,a
+	ld c, [hl] ; frame block ID
+	ld b, 0
+	ld hl, FrameBlockPointers
+	add hl, bc
+	add hl, bc
+	ld a, [hli]
+	ld c, a
+	ld a, [hli]
+	ld b, a
 	pop hl
 	inc hl
 	push hl
-	ld e,[hl] ; base coordinate ID
-	ld d,0
-	ld hl,FrameBlockBaseCoords  ; base coordinate table
-	add hl,de
-	add hl,de
-	ld a,[hli]
-	ld [wBaseCoordY],a
-	ld a,[hl]
-	ld [wBaseCoordX],a
+	ld e, [hl] ; base coordinate ID
+	ld d, 0
+	ld hl, FrameBlockBaseCoords  ; base coordinate table
+	add hl, de
+	add hl, de
+	ld a, [hli]
+	ld [wBaseCoordY], a
+	ld a, [hl]
+	ld [wBaseCoordX], a
 	pop hl
 	inc hl
-	ld a,[hl] ; frame block mode
-	ld [wFBMode],a
+	ld a, [hl] ; frame block mode
+	ld [wFBMode], a
 	call DrawFrameBlock
 	call DoSpecialEffectByAnimationId ; run animation-specific function (if there is one)
-	ld a,[wSubAnimCounter]
+	ld a, [wSubAnimCounter]
 	dec a
-	ld [wSubAnimCounter],a
+	ld [wSubAnimCounter], a
 	ret z
-	ld a,[wSubAnimSubEntryAddr + 1]
-	ld h,a
-	ld a,[wSubAnimSubEntryAddr]
-	ld l,a
-	ld a,[wSubAnimTransform]
-	cp a,4 ; is the animation reversed?
-	ld bc,3
-	jr nz,.nextSubanimationSubentry
-	ld bc,-3
+	ld a, [wSubAnimSubEntryAddr + 1]
+	ld h, a
+	ld a, [wSubAnimSubEntryAddr]
+	ld l, a
+	ld a, [wSubAnimTransform]
+	cp 4 ; is the animation reversed?
+	ld bc, 3
+	jr nz, .nextSubanimationSubentry
+	ld bc, -3
 .nextSubanimationSubentry
-	add hl,bc
-	ld a,h
-	ld [wSubAnimSubEntryAddr + 1],a
-	ld a,l
-	ld [wSubAnimSubEntryAddr],a
+	add hl, bc
+	ld a, h
+	ld [wSubAnimSubEntryAddr + 1], a
+	ld a, l
+	ld [wSubAnimSubEntryAddr], a
 	jp .loop
 
 AnimationCleanOAM:
@@ -631,16 +631,16 @@ DoSpecialEffectByAnimationId:
 	push hl
 	push de
 	push bc
-	ld a,[wAnimationID]
-	ld hl,AnimationIdSpecialEffects
-	ld de,3
+	ld a, [wAnimationID]
+	ld hl, AnimationIdSpecialEffects
+	ld de, 3
 	call IsInArray
-	jr nc,.done
+	jr nc, .done
 	inc hl
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
-	ld de,.done
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
+	ld de, .done
 	push de
 	jp hl
 .done
@@ -726,38 +726,38 @@ AnimationIdSpecialEffects:
 	db $FF ; terminator
 
 DoBallTossSpecialEffects:
-	ld a,[wcf91]
-	cp a,3 ; is it a Master Ball or Ultra Ball?
-	jr nc,.skipFlashingEffect
+	ld a, [wcf91]
+	cp 3 ; is it a Master Ball or Ultra Ball?
+	jr nc, .skipFlashingEffect
 .flashingEffect ; do a flashing effect if it's Master Ball or Ultra Ball
-	ld a,[rOBP0]
-	xor a,%00111100 ; complement colors 1 and 2
-	ld [rOBP0],a
+	ld a, [rOBP0]
+	xor %00111100 ; complement colors 1 and 2
+	ld [rOBP0], a
 .skipFlashingEffect
-	ld a,[wSubAnimCounter]
-	cp a,11 ; is it the beginning of the subanimation?
-	jr nz,.skipPlayingSound
+	ld a, [wSubAnimCounter]
+	cp 11 ; is it the beginning of the subanimation?
+	jr nz, .skipPlayingSound
 ; if it is the beginning of the subanimation, play a sound
-	ld a,SFX_BALL_TOSS
+	ld a, SFX_BALL_TOSS
 	call PlaySound
 .skipPlayingSound
-	ld a,[wIsInBattle]
-	cp a,02 ; is it a trainer battle?
-	jr z,.isTrainerBattle
-	ld a,[wd11e]
-	cp a,$10 ; is the enemy pokemon the Ghost Marowak?
+	ld a, [wIsInBattle]
+	cp 02 ; is it a trainer battle?
+	jr z, .isTrainerBattle
+	ld a, [wd11e]
+	cp $10 ; is the enemy pokemon the Ghost Marowak?
 	ret nz
 ; if the enemy pokemon is the Ghost Marowak, make it dodge during the last 3 frames
-	ld a,[wSubAnimCounter]
-	cp a,3
-	jr z,.moveGhostMarowakLeft
-	cp a,2
-	jr z,.moveGhostMarowakLeft
-	cp a,1
+	ld a, [wSubAnimCounter]
+	cp 3
+	jr z, .moveGhostMarowakLeft
+	cp 2
+	jr z, .moveGhostMarowakLeft
+	cp 1
 	ret nz
 .moveGhostMarowakLeft
 	coord hl, 17, 0
-	ld de,20
+	ld de, 20
 	lb bc, 7, 7
 .loop
 	push hl
@@ -765,152 +765,152 @@ DoBallTossSpecialEffects:
 	call AnimCopyRowRight ; move row of tiles left
 	pop bc
 	pop hl
-	add hl,de
+	add hl, de
 	dec b
-	jr nz,.loop
-	ld a,%00001000
-	ld [rNR10],a ; Channel 1 sweep register
+	jr nz, .loop
+	ld a, %00001000
+	ld [rNR10], a ; Channel 1 sweep register
 	ret
 .isTrainerBattle ; if it's a trainer battle, shorten the animation by one frame
-	ld a,[wSubAnimCounter]
-	cp a,3
+	ld a, [wSubAnimCounter]
+	cp 3
 	ret nz
 	dec a
-	ld [wSubAnimCounter],a
+	ld [wSubAnimCounter], a
 	ret
 
 DoBallShakeSpecialEffects:
-	ld a,[wSubAnimCounter]
-	cp a,4 ; is it the beginning of a shake?
-	jr nz,.skipPlayingSound
+	ld a, [wSubAnimCounter]
+	cp 4 ; is it the beginning of a shake?
+	jr nz, .skipPlayingSound
 ; if it is the beginning of a shake, play a sound and wait 2/3 of a second
-	ld a,SFX_TINK
+	ld a, SFX_TINK
 	call PlaySound
-	ld c,40
+	ld c, 40
 	call DelayFrames
 .skipPlayingSound
-	ld a,[wSubAnimCounter]
+	ld a, [wSubAnimCounter]
 	dec a
 	ret nz
 ; if it's the end of the ball shaking subanimation, check if more shakes are left and restart the subanimation
-	ld a,[wNumShakes] ; number of shakes
+	ld a, [wNumShakes] ; number of shakes
 	dec a ; decrement number of shakes
-	ld [wNumShakes],a
+	ld [wNumShakes], a
 	ret z
 ; if there are shakes left, restart the subanimation
-	ld a,[wSubAnimSubEntryAddr]
-	ld l,a
-	ld a,[wSubAnimSubEntryAddr + 1]
-	ld h,a
-	ld de,-(4 * 3) ; 4 subentries and 3 bytes per subentry
-	add hl,de
-	ld a,l
-	ld [wSubAnimSubEntryAddr],a
-	ld a,h
-	ld [wSubAnimSubEntryAddr + 1],a
-	ld a,5 ; number of subentries in the ball shaking subanimation plus one
-	ld [wSubAnimCounter],a
+	ld a, [wSubAnimSubEntryAddr]
+	ld l, a
+	ld a, [wSubAnimSubEntryAddr + 1]
+	ld h, a
+	ld de, -(4 * 3) ; 4 subentries and 3 bytes per subentry
+	add hl, de
+	ld a, l
+	ld [wSubAnimSubEntryAddr], a
+	ld a, h
+	ld [wSubAnimSubEntryAddr + 1], a
+	ld a, 5 ; number of subentries in the ball shaking subanimation plus one
+	ld [wSubAnimCounter], a
 	ret
 
 ; plays a sound after the second frame of the poof animation
 DoPoofSpecialEffects:
-	ld a,[wSubAnimCounter]
-	cp a,5
+	ld a, [wSubAnimCounter]
+	cp 5
 	ret nz
-	ld a,SFX_BALL_POOF
+	ld a, SFX_BALL_POOF
 	jp PlaySound
 
 DoRockSlideSpecialEffects:
-	ld a,[wSubAnimCounter]
-	cp a,12
+	ld a, [wSubAnimCounter]
+	cp 12
 	ret nc
-	cp a,8
-	jr nc,.shakeScreen
-	cp a,1
-	jp z,AnimationFlashScreen ; if it's the end of the subanimation, flash the screen
+	cp 8
+	jr nc, .shakeScreen
+	cp 1
+	jp z, AnimationFlashScreen ; if it's the end of the subanimation, flash the screen
 	ret
 ; if the subanimation counter is between 8 and 11, shake the screen horizontally and vertically
 .shakeScreen
-	ld b,1
+	ld b, 1
 	predef PredefShakeScreenHorizontally ; shake horizontally
-	ld b,1
+	ld b, 1
 	predef_jump PredefShakeScreenVertically ; shake vertically
 
 FlashScreenEveryEightFrameBlocks:
-	ld a,[wSubAnimCounter]
-	and a,7 ; is the subanimation counter exactly 8?
-	call z,AnimationFlashScreen ; if so, flash the screen
+	ld a, [wSubAnimCounter]
+	and 7 ; is the subanimation counter exactly 8?
+	call z, AnimationFlashScreen ; if so, flash the screen
 	ret
 
 ; flashes the screen if the subanimation counter is divisible by 4
 FlashScreenEveryFourFrameBlocks:
-	ld a,[wSubAnimCounter]
-	and a,3
-	call z,AnimationFlashScreen
+	ld a, [wSubAnimCounter]
+	and 3
+	call z, AnimationFlashScreen
 	ret
 
 ; used for Explosion and Selfdestruct
 DoExplodeSpecialEffects:
-	ld a,[wSubAnimCounter]
-	cp a,1 ; is it the end of the subanimation?
-	jr nz,FlashScreenEveryFourFrameBlocks
+	ld a, [wSubAnimCounter]
+	cp 1 ; is it the end of the subanimation?
+	jr nz, FlashScreenEveryFourFrameBlocks
 ; if it's the end of the subanimation, make the attacking pokemon disappear
 	coord hl, 1, 5
 	jp AnimationHideMonPic ; make pokemon disappear
 
 ; flashes the screen when subanimation counter is 1 modulo 4
 DoBlizzardSpecialEffects:
-	ld a,[wSubAnimCounter]
-	cp a,13
-	jp z,AnimationFlashScreen
-	cp a,9
-	jp z,AnimationFlashScreen
-	cp a,5
-	jp z,AnimationFlashScreen
-	cp a,1
-	jp z,AnimationFlashScreen
+	ld a, [wSubAnimCounter]
+	cp 13
+	jp z, AnimationFlashScreen
+	cp 9
+	jp z, AnimationFlashScreen
+	cp 5
+	jp z, AnimationFlashScreen
+	cp 1
+	jp z, AnimationFlashScreen
 	ret
 
 ; flashes the screen at 3 points in the subanimation
 ; unused
 FlashScreenUnused:
-	ld a,[wSubAnimCounter]
-	cp a,14
-	jp z,AnimationFlashScreen
-	cp a,9
-	jp z,AnimationFlashScreen
-	cp a,2
-	jp z,AnimationFlashScreen
+	ld a, [wSubAnimCounter]
+	cp 14
+	jp z, AnimationFlashScreen
+	cp 9
+	jp z, AnimationFlashScreen
+	cp 2
+	jp z, AnimationFlashScreen
 	ret
 
 ; function to make the pokemon disappear at the beginning of the animation
 TradeHidePokemon:
-	ld a,[wSubAnimCounter]
-	cp a,6
+	ld a, [wSubAnimCounter]
+	cp 6
 	ret nz
-	ld a,2 * SCREEN_WIDTH + 7
+	ld a, 2 * SCREEN_WIDTH + 7
 	jp ClearMonPicFromTileMap ; make pokemon disappear
 
 ; function to make a shaking pokeball jump up at the end of the animation
 TradeShakePokeball:
-	ld a,[wSubAnimCounter]
-	cp a,1
+	ld a, [wSubAnimCounter]
+	cp 1
 	ret nz
 ; if it's the end of the animation, make the ball jump up
-	ld de,BallMoveDistances1
+	ld de, BallMoveDistances1
 .loop
-	ld hl,wOAMBuffer ; OAM buffer
-	ld bc,4
+	ld hl, wOAMBuffer ; OAM buffer
+	ld bc, 4
 .innerLoop
-	ld a,[de]
-	cp a,$ff
-	jr z,.done
+	ld a, [de]
+	cp $ff
+	jr z, .done
 	add [hl] ; add to Y value of OAM entry
-	ld [hl],a
-	add hl,bc
-	ld a,l
-	cp a,4 * 4 ; there are 4 entries, each 4 bytes
-	jr nz,.innerLoop
+	ld [hl], a
+	add hl, bc
+	ld a, l
+	cp 4 * 4 ; there are 4 entries, each 4 bytes
+	jr nz, .innerLoop
 	inc de
 	push bc
 	call Delay3
@@ -918,7 +918,7 @@ TradeShakePokeball:
 	jr .loop
 .done
 	call AnimationCleanOAM
-	ld a,SFX_TRADE_MACHINE
+	ld a, SFX_TRADE_MACHINE
 	jp PlaySound
 
 BallMoveDistances1:
@@ -927,38 +927,38 @@ BallMoveDistances1:
 
 ; function to make the pokeball jump up
 TradeJumpPokeball:
-	ld de,BallMoveDistances2
+	ld de, BallMoveDistances2
 .loop
-	ld hl,wOAMBuffer ; OAM buffer
-	ld bc,4
+	ld hl, wOAMBuffer ; OAM buffer
+	ld bc, 4
 .innerLoop
-	ld a,[de]
-	cp a,$ff
-	jp z,ClearScreen
+	ld a, [de]
+	cp $ff
+	jp z, ClearScreen
 	add [hl]
-	ld [hl],a
-	add hl,bc
-	ld a,l
-	cp a,4 * 4 ; there are 4 entries, each 4 bytes
-	jr nz,.innerLoop
+	ld [hl], a
+	add hl, bc
+	ld a, l
+	cp 4 * 4 ; there are 4 entries, each 4 bytes
+	jr nz, .innerLoop
 	inc de
 	push de
-	ld a,[de]
-	cp a,12
-	jr z,.playSound
-	cp a,$ff
-	jr nz,.skipPlayingSound
+	ld a, [de]
+	cp 12
+	jr z, .playSound
+	cp $ff
+	jr nz, .skipPlayingSound
 .playSound ; play sound if next move distance is 12 or this is the last one
-	ld a,SFX_BATTLE_18
+	ld a, SFX_BATTLE_18
 	call PlaySound
 .skipPlayingSound
 	push bc
-	ld c,5
+	ld c, 5
 	call DelayFrames
 	pop bc
-	ld a,[hSCX] ; background scroll X
-	sub a,8 ; scroll to the left
-	ld [hSCX],a
+	ld a, [hSCX] ; background scroll X
+	sub 8 ; scroll to the left
+	ld [hSCX], a
 	pop de
 	jr .loop
 
@@ -969,20 +969,20 @@ BallMoveDistances2:
 ; this function copies the current musical note graphic
 ; so that there are two musical notes flying towards the defending pokemon
 DoGrowlSpecialEffects:
-	ld hl,wOAMBuffer ; OAM buffer
-	ld de,wOAMBuffer + $10
-	ld bc,$10
+	ld hl, wOAMBuffer ; OAM buffer
+	ld de, wOAMBuffer + $10
+	ld bc, $10
 	call CopyData ; copy the musical note graphic
-	ld a,[wSubAnimCounter]
+	ld a, [wSubAnimCounter]
 	dec a
-	call z,AnimationCleanOAM ; clean up at the end of the subanimation
+	call z, AnimationCleanOAM ; clean up at the end of the subanimation
 	ret
 
 ; this is associated with Tail Whip, but Tail Whip doesn't use any subanimations
 TailWhipAnimationUnused:
-	ld a,1
-	ld [wSubAnimCounter],a
-	ld c,20
+	ld a, 1
+	ld [wSubAnimCounter], a
+	ld c, 20
 	jp DelayFrames
 
 ; Format: Special Effect ID (1 byte), Address (2 bytes)
@@ -1068,48 +1068,48 @@ SpecialEffectPointers:
 	db $FF
 
 AnimationDelay10:
-	ld c,10
+	ld c, 10
 	jp DelayFrames
 
 ; calls a function with the turn flipped from player to enemy or vice versa
 ; input - hl - address of function to call
 CallWithTurnFlipped:
-	ld a,[H_WHOSETURN]
+	ld a, [H_WHOSETURN]
 	push af
-	xor a,1
-	ld [H_WHOSETURN],a
-	ld de,.returnAddress
+	xor 1
+	ld [H_WHOSETURN], a
+	ld de, .returnAddress
 	push de
 	jp hl
 .returnAddress
 	pop af
-	ld [H_WHOSETURN],a
+	ld [H_WHOSETURN], a
 	ret
 
 ; flashes the screen for an extended period (48 frames)
 AnimationFlashScreenLong:
-	ld a,3 ; cycle through the palettes 3 times
-	ld [wFlashScreenLongCounter],a
-	ld a,[wOnSGB] ; running on SGB?
+	ld a, 3 ; cycle through the palettes 3 times
+	ld [wFlashScreenLongCounter], a
+	ld a, [wOnSGB] ; running on SGB?
 	and a
-	ld hl,FlashScreenLongMonochrome
-	jr z,.loop
-	ld hl,FlashScreenLongSGB
+	ld hl, FlashScreenLongMonochrome
+	jr z, .loop
+	ld hl, FlashScreenLongSGB
 .loop
 	push hl
 .innerLoop
-	ld a,[hli]
-	cp a,$01 ; is it the end of the palettes?
-	jr z,.endOfPalettes
-	ld [rBGP],a
+	ld a, [hli]
+	cp $01 ; is it the end of the palettes?
+	jr z, .endOfPalettes
+	ld [rBGP], a
 	call FlashScreenLongDelay
 	jr .innerLoop
 .endOfPalettes
-	ld a,[wFlashScreenLongCounter]
+	ld a, [wFlashScreenLongCounter]
 	dec a
-	ld [wFlashScreenLongCounter],a
+	ld [wFlashScreenLongCounter], a
 	pop hl
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 ; BG palettes
@@ -1147,31 +1147,31 @@ FlashScreenLongSGB:
 ; causes a delay of 2 frames for the first cycle
 ; causes a delay of 1 frame for the second and third cycles
 FlashScreenLongDelay:
-	ld a,[wFlashScreenLongCounter]
-	cp a,4 ; never true since [wFlashScreenLongCounter] starts at 3
-	ld c,4
-	jr z,.delayFrames
-	cp a,3
-	ld c,2
-	jr z,.delayFrames
-	cp a,2 ; nothing is done with this
-	ld c,1
+	ld a, [wFlashScreenLongCounter]
+	cp 4 ; never true since [wFlashScreenLongCounter] starts at 3
+	ld c, 4
+	jr z, .delayFrames
+	cp 3
+	ld c, 2
+	jr z, .delayFrames
+	cp 2 ; nothing is done with this
+	ld c, 1
 .delayFrames
 	jp DelayFrames
 
 AnimationFlashScreen:
-	ld a,[rBGP]
+	ld a, [rBGP]
 	push af ; save initial palette
-	ld a,%00011011 ; 0, 1, 2, 3 (inverted colors)
-	ld [rBGP],a
-	ld c,2
+	ld a, %00011011 ; 0, 1, 2, 3 (inverted colors)
+	ld [rBGP], a
+	ld c, 2
 	call DelayFrames
 	xor a ; white out background
-	ld [rBGP],a
-	ld c,2
+	ld [rBGP], a
+	ld c, 2
 	call DelayFrames
 	pop af
-	ld [rBGP],a ; restore initial palette
+	ld [rBGP], a ; restore initial palette
 	ret
 
 AnimationDarkScreenPalette:
@@ -2310,52 +2310,52 @@ GetMoveSoundB:
 	ret
 
 GetMoveSound:
-	ld hl,MoveSoundTable
-	ld e,a
-	ld d,0
-	add hl,de
-	add hl,de
-	add hl,de
-	ld a,[hli]
-	ld b,a
+	ld hl, MoveSoundTable
+	ld e, a
+	ld d, 0
+	add hl, de
+	add hl, de
+	add hl, de
+	ld a, [hli]
+	ld b, a
 	call IsCryMove
-	jr nc,.NotCryMove
-	ld a,[H_WHOSETURN]
+	jr nc, .NotCryMove
+	ld a, [H_WHOSETURN]
 	and a
-	jr nz,.next
-	ld a,[wBattleMonSpecies] ; get number of current monster
+	jr nz, .next
+	ld a, [wBattleMonSpecies] ; get number of current monster
 	jr .Continue
 .next
-	ld a,[wEnemyMonSpecies]
+	ld a, [wEnemyMonSpecies]
 .Continue
 	push hl
 	call GetCryData
-	ld b,a
+	ld b, a
 	pop hl
-	ld a,[wFrequencyModifier]
+	ld a, [wFrequencyModifier]
 	add [hl]
-	ld [wFrequencyModifier],a
+	ld [wFrequencyModifier], a
 	inc hl
-	ld a,[wTempoModifier]
+	ld a, [wTempoModifier]
 	add [hl]
-	ld [wTempoModifier],a
+	ld [wTempoModifier], a
 	jr .done
 .NotCryMove
-	ld a,[hli]
-	ld [wFrequencyModifier],a
-	ld a,[hli]
-	ld [wTempoModifier],a
+	ld a, [hli]
+	ld [wFrequencyModifier], a
+	ld a, [hli]
+	ld [wTempoModifier], a
 .done
-	ld a,b
+	ld a, b
 	ret
 
 IsCryMove:
 ; set carry if the move animation involves playing a monster cry
-	ld a,[wAnimationID]
-	cp a,GROWL
-	jr z,.CryMove
-	cp a,ROAR
-	jr z,.CryMove
+	ld a, [wAnimationID]
+	cp GROWL
+	jr z, .CryMove
+	cp ROAR
+	jr z, .CryMove
 	and a ; clear carry
 	ret
 .CryMove
@@ -2951,46 +2951,46 @@ BattleAnimCopyTileMapToVRAM:
 	jp Delay3
 
 TossBallAnimation:
-	ld a,[wIsInBattle]
-	cp a,2
-	jr z,.BlockBall ; if in trainer battle, play different animation
-	ld a,[wPokeBallAnimData]
-	ld b,a
+	ld a, [wIsInBattle]
+	cp 2
+	jr z, .BlockBall ; if in trainer battle, play different animation
+	ld a, [wPokeBallAnimData]
+	ld b, a
 
 	; upper nybble: how many animations (from PokeBallAnimations) to play
 	; this will be 4 for successful capture, 6 for breakout
-	and a,$F0
+	and $F0
 	swap a
-	ld c,a
+	ld c, a
 
 	; lower nybble: number of shakes
 	; store these for later
-	ld a,b
-	and a,$F
-	ld [wNumShakes],a
+	ld a, b
+	and $F
+	ld [wNumShakes], a
 
-	ld hl,.PokeBallAnimations
+	ld hl, .PokeBallAnimations
 	; choose which toss animation to use
-	ld a,[wcf91]
-	cp a,POKE_BALL
-	ld b,TOSS_ANIM
-	jr z,.done
-	cp a,GREAT_BALL
-	ld b,GREATTOSS_ANIM
-	jr z,.done
-	ld b,ULTRATOSS_ANIM
+	ld a, [wcf91]
+	cp POKE_BALL
+	ld b, TOSS_ANIM
+	jr z, .done
+	cp GREAT_BALL
+	ld b, GREATTOSS_ANIM
+	jr z, .done
+	ld b, ULTRATOSS_ANIM
 .done
-	ld a,b
+	ld a, b
 .PlayNextAnimation
-	ld [wAnimationID],a
+	ld [wAnimationID], a
 	push bc
 	push hl
 	call PlayAnimation
 	pop hl
-	ld a,[hli]
+	ld a, [hli]
 	pop bc
 	dec c
-	jr nz,.PlayNextAnimation
+	jr nz, .PlayNextAnimation
 	ret
 
 .PokeBallAnimations:
@@ -2998,13 +2998,13 @@ TossBallAnimation:
 	db POOF_ANIM,HIDEPIC_ANIM,SHAKE_ANIM,POOF_ANIM,SHOWPIC_ANIM
 
 .BlockBall
-	ld a,TOSS_ANIM
-	ld [wAnimationID],a
+	ld a, TOSS_ANIM
+	ld [wAnimationID], a
 	call PlayAnimation
-	ld a,SFX_FAINT_THUD
+	ld a, SFX_FAINT_THUD
 	call PlaySound
-	ld a,BLOCKBALL_ANIM
-	ld [wAnimationID],a
+	ld a, BLOCKBALL_ANIM
+	ld [wAnimationID], a
 	jp PlayAnimation
 
 PlayApplyingAttackSound:

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -579,7 +579,7 @@ HandlePoisonBurnLeechSeed:
 	call PrintText
 	xor a
 	ld [wAnimationType], a
-	ld a,BURN_PSN_ANIM
+	ld a, BURN_PSN_ANIM
 	call PlayMoveAnimation   ; play burn/poison animation
 	pop hl
 	call HandlePoisonBurnLeechSeed_DecreaseOwnHP
@@ -600,7 +600,7 @@ HandlePoisonBurnLeechSeed:
 	ld [H_WHOSETURN], a
 	xor a
 	ld [wAnimationType], a
-	ld a,ABSORB
+	ld a, ABSORB
 	call PlayMoveAnimation ; play leech seed animation (from opposing mon)
 	pop af
 	ld [H_WHOSETURN], a
@@ -1363,138 +1363,138 @@ SlideTrainerPicOffScreen:
 
 ; send out a trainer's mon
 EnemySendOut:
-	ld hl,wPartyGainExpFlags
+	ld hl, wPartyGainExpFlags
 	xor a
-	ld [hl],a
-	ld a,[wPlayerMonNumber]
-	ld c,a
-	ld b,FLAG_SET
+	ld [hl], a
+	ld a, [wPlayerMonNumber]
+	ld c, a
+	ld b, FLAG_SET
 	push bc
 	predef FlagActionPredef
-	ld hl,wPartyFoughtCurrentEnemyFlags
+	ld hl, wPartyFoughtCurrentEnemyFlags
 	xor a
-	ld [hl],a
+	ld [hl], a
 	pop bc
 	predef FlagActionPredef
 
 ; don't change wPartyGainExpFlags or wPartyFoughtCurrentEnemyFlags
 EnemySendOutFirstMon:
 	xor a
-	ld hl,wEnemyStatsToDouble ; clear enemy statuses
-	ld [hli],a
-	ld [hli],a
-	ld [hli],a
-	ld [hli],a
-	ld [hl],a
-	ld [wEnemyDisabledMove],a
-	ld [wEnemyDisabledMoveNumber],a
-	ld [wEnemyMonMinimized],a
-	ld hl,wPlayerUsedMove
-	ld [hli],a
-	ld [hl],a
+	ld hl, wEnemyStatsToDouble ; clear enemy statuses
+	ld [hli], a
+	ld [hli], a
+	ld [hli], a
+	ld [hli], a
+	ld [hl], a
+	ld [wEnemyDisabledMove], a
+	ld [wEnemyDisabledMoveNumber], a
+	ld [wEnemyMonMinimized], a
+	ld hl, wPlayerUsedMove
+	ld [hli], a
+	ld [hl], a
 	dec a
-	ld [wAICount],a
-	ld hl,wPlayerBattleStatus1
-	res 5,[hl]
+	ld [wAICount], a
+	ld hl, wPlayerBattleStatus1
+	res 5, [hl]
 	coord hl, 18, 0
-	ld a,8
+	ld a, 8
 	call SlideTrainerPicOffScreen
 	call PrintEmptyString
 	call SaveScreenTilesToBuffer1
-	ld a,[wLinkState]
+	ld a, [wLinkState]
 	cp LINK_STATE_BATTLING
-	jr nz,.next
-	ld a,[wSerialExchangeNybbleReceiveData]
+	jr nz, .next
+	ld a, [wSerialExchangeNybbleReceiveData]
 	sub 4
-	ld [wWhichPokemon],a
+	ld [wWhichPokemon], a
 	jr .next3
 .next
-	ld b,$FF
+	ld b, $FF
 .next2
 	inc b
-	ld a,[wEnemyMonPartyPos]
+	ld a, [wEnemyMonPartyPos]
 	cp b
-	jr z,.next2
-	ld hl,wEnemyMon1
-	ld a,b
-	ld [wWhichPokemon],a
+	jr z, .next2
+	ld hl, wEnemyMon1
+	ld a, b
+	ld [wWhichPokemon], a
 	push bc
-	ld bc,wEnemyMon2 - wEnemyMon1
+	ld bc, wEnemyMon2 - wEnemyMon1
 	call AddNTimes
 	pop bc
 	inc hl
-	ld a,[hli]
-	ld c,a
-	ld a,[hl]
+	ld a, [hli]
+	ld c, a
+	ld a, [hl]
 	or c
-	jr z,.next2
+	jr z, .next2
 .next3
-	ld a,[wWhichPokemon]
-	ld hl,wEnemyMon1Level
-	ld bc,wEnemyMon2 - wEnemyMon1
+	ld a, [wWhichPokemon]
+	ld hl, wEnemyMon1Level
+	ld bc, wEnemyMon2 - wEnemyMon1
 	call AddNTimes
-	ld a,[hl]
-	ld [wCurEnemyLVL],a
-	ld a,[wWhichPokemon]
+	ld a, [hl]
+	ld [wCurEnemyLVL], a
+	ld a, [wWhichPokemon]
 	inc a
-	ld hl,wEnemyPartyCount
-	ld c,a
-	ld b,0
-	add hl,bc
-	ld a,[hl]
-	ld [wEnemyMonSpecies2],a
-	ld [wcf91],a
+	ld hl, wEnemyPartyCount
+	ld c, a
+	ld b, 0
+	add hl, bc
+	ld a, [hl]
+	ld [wEnemyMonSpecies2], a
+	ld [wcf91], a
 	call LoadEnemyMonData
-	ld hl,wEnemyMonHP
-	ld a,[hli]
-	ld [wLastSwitchInEnemyMonHP],a
-	ld a,[hl]
-	ld [wLastSwitchInEnemyMonHP + 1],a
-	ld a,1
-	ld [wCurrentMenuItem],a
-	ld a,[wFirstMonsNotOutYet]
+	ld hl, wEnemyMonHP
+	ld a, [hli]
+	ld [wLastSwitchInEnemyMonHP], a
+	ld a, [hl]
+	ld [wLastSwitchInEnemyMonHP + 1], a
+	ld a, 1
+	ld [wCurrentMenuItem], a
+	ld a, [wFirstMonsNotOutYet]
 	dec a
-	jr z,.next4
-	ld a,[wPartyCount]
+	jr z, .next4
+	ld a, [wPartyCount]
 	dec a
-	jr z,.next4
-	ld a,[wLinkState]
+	jr z, .next4
+	ld a, [wLinkState]
 	cp LINK_STATE_BATTLING
-	jr z,.next4
-	ld a,[wOptions]
-	bit 6,a
-	jr nz,.next4
+	jr z, .next4
+	ld a, [wOptions]
+	bit 6, a
+	jr nz, .next4
 	ld hl, TrainerAboutToUseText
 	call PrintText
 	coord hl, 0, 7
 	lb bc, 8, 1
-	ld a,TWO_OPTION_MENU
-	ld [wTextBoxID],a
+	ld a, TWO_OPTION_MENU
+	ld [wTextBoxID], a
 	call DisplayTextBoxID
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	and a
-	jr nz,.next4
-	ld a,BATTLE_PARTY_MENU
-	ld [wPartyMenuTypeOrMessageID],a
+	jr nz, .next4
+	ld a, BATTLE_PARTY_MENU
+	ld [wPartyMenuTypeOrMessageID], a
 	call DisplayPartyMenu
 .next9
-	ld a,1
-	ld [wCurrentMenuItem],a
-	jr c,.next7
-	ld hl,wPlayerMonNumber
-	ld a,[wWhichPokemon]
+	ld a, 1
+	ld [wCurrentMenuItem], a
+	jr c, .next7
+	ld hl, wPlayerMonNumber
+	ld a, [wWhichPokemon]
 	cp [hl]
-	jr nz,.next6
-	ld hl,AlreadyOutText
+	jr nz, .next6
+	ld hl, AlreadyOutText
 	call PrintText
 .next8
 	call GoBackToPartyMenu
 	jr .next9
 .next6
 	call HasMonFainted
-	jr z,.next8
+	jr z, .next8
 	xor a
-	ld [wCurrentMenuItem],a
+	ld [wCurrentMenuItem], a
 .next7
 	call GBPalWhiteOut
 	call LoadHudTilePatterns
@@ -1507,27 +1507,27 @@ EnemySendOutFirstMon:
 	ld b, SET_PAL_BATTLE
 	call RunPaletteCommand
 	call GBPalNormal
-	ld hl,TrainerSentOutText
+	ld hl, TrainerSentOutText
 	call PrintText
-	ld a,[wEnemyMonSpecies2]
-	ld [wcf91],a
-	ld [wd0b5],a
+	ld a, [wEnemyMonSpecies2]
+	ld [wcf91], a
+	ld [wd0b5], a
 	call GetMonHeader
-	ld de,vFrontPic
+	ld de, vFrontPic
 	call LoadMonFrontSprite
-	ld a,-$31
-	ld [hStartTileID],a
+	ld a, -$31
+	ld [hStartTileID], a
 	coord hl, 15, 6
 	predef AnimateSendingOutMon
-	ld a,[wEnemyMonSpecies2]
+	ld a, [wEnemyMonSpecies2]
 	call PlayCry
 	call DrawEnemyHUDAndHPBar
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	and a
 	ret nz
 	xor a
-	ld [wPartyGainExpFlags],a
-	ld [wPartyFoughtCurrentEnemyFlags],a
+	ld [wPartyGainExpFlags], a
+	ld [wPartyFoughtCurrentEnemyFlags], a
 	call SaveScreenTilesToBuffer1
 	jp SwitchPlayerMon
 
@@ -3169,160 +3169,160 @@ CheckIfPlayerNeedsToChargeUp:
 
 ; in-battle stuff
 PlayerCanExecuteChargingMove:
-	ld hl,wPlayerBattleStatus1
-	res CHARGING_UP,[hl] ; reset charging up and invulnerability statuses if mon was charging up for an attack
+	ld hl, wPlayerBattleStatus1
+	res CHARGING_UP, [hl] ; reset charging up and invulnerability statuses if mon was charging up for an attack
 	                    ; being fully paralyzed or hurting oneself in confusion removes charging up status
 	                    ; resulting in the Pokemon being invulnerable for the whole battle
-	res INVULNERABLE,[hl]
+	res INVULNERABLE, [hl]
 PlayerCanExecuteMove:
 	call PrintMonName1Text
-	ld hl,DecrementPP
-	ld de,wPlayerSelectedMove ; pointer to the move just used
-	ld b,BANK(DecrementPP)
+	ld hl, DecrementPP
+	ld de, wPlayerSelectedMove ; pointer to the move just used
+	ld b, BANK(DecrementPP)
 	call Bankswitch
-	ld a,[wPlayerMoveEffect] ; effect of the move just used
-	ld hl,ResidualEffects1
-	ld de,1
+	ld a, [wPlayerMoveEffect] ; effect of the move just used
+	ld hl, ResidualEffects1
+	ld de, 1
 	call IsInArray
-	jp c,JumpMoveEffect ; ResidualEffects1 moves skip damage calculation and accuracy tests
+	jp c, JumpMoveEffect ; ResidualEffects1 moves skip damage calculation and accuracy tests
 	                    ; unless executed as part of their exclusive effect functions
-	ld a,[wPlayerMoveEffect]
-	ld hl,SpecialEffectsCont
-	ld de,1
+	ld a, [wPlayerMoveEffect]
+	ld hl, SpecialEffectsCont
+	ld de, 1
 	call IsInArray
-	call c,JumpMoveEffect ; execute the effects of SpecialEffectsCont moves (e.g. Wrap, Thrash) but don't skip anything
+	call c, JumpMoveEffect ; execute the effects of SpecialEffectsCont moves (e.g. Wrap, Thrash) but don't skip anything
 PlayerCalcMoveDamage:
-	ld a,[wPlayerMoveEffect]
-	ld hl,SetDamageEffects
-	ld de,1
+	ld a, [wPlayerMoveEffect]
+	ld hl, SetDamageEffects
+	ld de, 1
 	call IsInArray
-	jp c,.moveHitTest ; SetDamageEffects moves (e.g. Seismic Toss and Super Fang) skip damage calculation
+	jp c, .moveHitTest ; SetDamageEffects moves (e.g. Seismic Toss and Super Fang) skip damage calculation
 	call CriticalHitTest
 	call HandleCounterMove
-	jr z,handleIfPlayerMoveMissed
+	jr z, handleIfPlayerMoveMissed
 	call GetDamageVarsForPlayerAttack
 	call CalculateDamage
-	jp z,playerCheckIfFlyOrChargeEffect ; for moves with 0 BP, skip any further damage calculation and, for now, skip MoveHitTest
+	jp z, playerCheckIfFlyOrChargeEffect ; for moves with 0 BP, skip any further damage calculation and, for now, skip MoveHitTest
 	               ; for these moves, accuracy tests will only occur if they are called as part of the effect itself
 	call AdjustDamageForMoveType
 	call RandomizeDamage
 .moveHitTest
 	call MoveHitTest
 handleIfPlayerMoveMissed:
-	ld a,[wMoveMissed]
+	ld a, [wMoveMissed]
 	and a
-	jr z,getPlayerAnimationType
-	ld a,[wPlayerMoveEffect]
-	sub a,EXPLODE_EFFECT
-	jr z,playPlayerMoveAnimation ; don't play any animation if the move missed, unless it was EXPLODE_EFFECT
+	jr z, getPlayerAnimationType
+	ld a, [wPlayerMoveEffect]
+	sub EXPLODE_EFFECT
+	jr z, playPlayerMoveAnimation ; don't play any animation if the move missed, unless it was EXPLODE_EFFECT
 	jr playerCheckIfFlyOrChargeEffect
 getPlayerAnimationType:
-	ld a,[wPlayerMoveEffect]
+	ld a, [wPlayerMoveEffect]
 	and a
-	ld a,4 ; move has no effect other than dealing damage
-	jr z,playPlayerMoveAnimation
-	ld a,5 ; move has effect
+	ld a, 4 ; move has no effect other than dealing damage
+	jr z, playPlayerMoveAnimation
+	ld a, 5 ; move has effect
 playPlayerMoveAnimation:
 	push af
-	ld a,[wPlayerBattleStatus2]
-	bit HAS_SUBSTITUTE_UP,a
-	ld hl,HideSubstituteShowMonAnim
-	ld b,BANK(HideSubstituteShowMonAnim)
-	call nz,Bankswitch
+	ld a, [wPlayerBattleStatus2]
+	bit HAS_SUBSTITUTE_UP, a
+	ld hl, HideSubstituteShowMonAnim
+	ld b, BANK(HideSubstituteShowMonAnim)
+	call nz, Bankswitch
 	pop af
-	ld [wAnimationType],a
-	ld a,[wPlayerMoveNum]
+	ld [wAnimationType], a
+	ld a, [wPlayerMoveNum]
 	call PlayMoveAnimation
 	call HandleExplodingAnimation
 	call DrawPlayerHUDAndHPBar
-	ld a,[wPlayerBattleStatus2]
-	bit HAS_SUBSTITUTE_UP,a
-	ld hl,ReshowSubstituteAnim
-	ld b,BANK(ReshowSubstituteAnim)
-	call nz,Bankswitch
+	ld a, [wPlayerBattleStatus2]
+	bit HAS_SUBSTITUTE_UP, a
+	ld hl, ReshowSubstituteAnim
+	ld b, BANK(ReshowSubstituteAnim)
+	call nz, Bankswitch
 	jr MirrorMoveCheck
 playerCheckIfFlyOrChargeEffect:
-	ld c,30
+	ld c, 30
 	call DelayFrames
-	ld a,[wPlayerMoveEffect]
-	cp a,FLY_EFFECT
-	jr z,.playAnim
-	cp a,CHARGE_EFFECT
-	jr z,.playAnim
+	ld a, [wPlayerMoveEffect]
+	cp FLY_EFFECT
+	jr z, .playAnim
+	cp CHARGE_EFFECT
+	jr z, .playAnim
 	jr MirrorMoveCheck
 .playAnim
 	xor a
-	ld [wAnimationType],a
-	ld a,STATUS_AFFECTED_ANIM
+	ld [wAnimationType], a
+	ld a, STATUS_AFFECTED_ANIM
 	call PlayMoveAnimation
 MirrorMoveCheck:
-	ld a,[wPlayerMoveEffect]
-	cp a,MIRROR_MOVE_EFFECT
-	jr nz,.metronomeCheck
+	ld a, [wPlayerMoveEffect]
+	cp MIRROR_MOVE_EFFECT
+	jr nz, .metronomeCheck
 	call MirrorMoveCopyMove
-	jp z,ExecutePlayerMoveDone
+	jp z, ExecutePlayerMoveDone
 	xor a
-	ld [wMonIsDisobedient],a
+	ld [wMonIsDisobedient], a
 	jp CheckIfPlayerNeedsToChargeUp ; if Mirror Move was successful go back to damage calculation for copied move
 .metronomeCheck
-	cp a,METRONOME_EFFECT
-	jr nz,.next
+	cp METRONOME_EFFECT
+	jr nz, .next
 	call MetronomePickMove
 	jp CheckIfPlayerNeedsToChargeUp ; Go back to damage calculation for the move picked by Metronome
 .next
-	ld a,[wPlayerMoveEffect]
-	ld hl,ResidualEffects2
-	ld de,1
+	ld a, [wPlayerMoveEffect]
+	ld hl, ResidualEffects2
+	ld de, 1
 	call IsInArray
-	jp c,JumpMoveEffect ; done here after executing effects of ResidualEffects2
-	ld a,[wMoveMissed]
+	jp c, JumpMoveEffect ; done here after executing effects of ResidualEffects2
+	ld a, [wMoveMissed]
 	and a
-	jr z,.moveDidNotMiss
+	jr z, .moveDidNotMiss
 	call PrintMoveFailureText
-	ld a,[wPlayerMoveEffect]
-	cp a,EXPLODE_EFFECT ; even if Explosion or Selfdestruct missed, its effect still needs to be activated
-	jr z,.notDone
+	ld a, [wPlayerMoveEffect]
+	cp EXPLODE_EFFECT ; even if Explosion or Selfdestruct missed, its effect still needs to be activated
+	jr z, .notDone
 	jp ExecutePlayerMoveDone ; otherwise, we're done if the move missed
 .moveDidNotMiss
 	call ApplyAttackToEnemyPokemon
 	call PrintCriticalOHKOText
 	callab DisplayEffectiveness
-	ld a,1
-	ld [wMoveDidntMiss],a
+	ld a, 1
+	ld [wMoveDidntMiss], a
 .notDone
-	ld a,[wPlayerMoveEffect]
-	ld hl,AlwaysHappenSideEffects
-	ld de,1
+	ld a, [wPlayerMoveEffect]
+	ld hl, AlwaysHappenSideEffects
+	ld de, 1
 	call IsInArray
-	call c,JumpMoveEffect ; not done after executing effects of AlwaysHappenSideEffects
-	ld hl,wEnemyMonHP
-	ld a,[hli]
-	ld b,[hl]
+	call c, JumpMoveEffect ; not done after executing effects of AlwaysHappenSideEffects
+	ld hl, wEnemyMonHP
+	ld a, [hli]
+	ld b, [hl]
 	or b
 	ret z ; don't do anything else if the enemy fainted
 	call HandleBuildingRage
 
-	ld hl,wPlayerBattleStatus1
-	bit ATTACKING_MULTIPLE_TIMES,[hl]
-	jr z,.executeOtherEffects
-	ld a,[wPlayerNumAttacksLeft]
+	ld hl, wPlayerBattleStatus1
+	bit ATTACKING_MULTIPLE_TIMES, [hl]
+	jr z, .executeOtherEffects
+	ld a, [wPlayerNumAttacksLeft]
 	dec a
-	ld [wPlayerNumAttacksLeft],a
-	jp nz,getPlayerAnimationType ; for multi-hit moves, apply attack until PlayerNumAttacksLeft hits 0 or the enemy faints.
+	ld [wPlayerNumAttacksLeft], a
+	jp nz, getPlayerAnimationType ; for multi-hit moves, apply attack until PlayerNumAttacksLeft hits 0 or the enemy faints.
 	                             ; damage calculation and accuracy tests only happen for the first hit
-	res ATTACKING_MULTIPLE_TIMES,[hl] ; clear attacking multiple times status when all attacks are over
-	ld hl,MultiHitText
+	res ATTACKING_MULTIPLE_TIMES, [hl] ; clear attacking multiple times status when all attacks are over
+	ld hl, MultiHitText
 	call PrintText
 	xor a
-	ld [wPlayerNumHits],a
+	ld [wPlayerNumHits], a
 .executeOtherEffects
-	ld a,[wPlayerMoveEffect]
+	ld a, [wPlayerMoveEffect]
 	and a
-	jp z,ExecutePlayerMoveDone
-	ld hl,SpecialEffects
-	ld de,1
+	jp z, ExecutePlayerMoveDone
+	ld hl, SpecialEffects
+	ld de, 1
 	call IsInArray
-	call nc,JumpMoveEffect ; move effects not included in SpecialEffects or in either of the ResidualEffect arrays,
+	call nc, JumpMoveEffect ; move effects not included in SpecialEffects or in either of the ResidualEffect arrays,
 	; which are the effects not covered yet. Rage effect will be executed for a second time (though it's irrelevant).
 	; Includes side effects that only need to be called if the target didn't faint.
 	; Responsible for executing Twineedle's second side effect (poison).
@@ -3334,26 +3334,26 @@ MultiHitText:
 
 ExecutePlayerMoveDone:
 	xor a
-	ld [wActionResultOrTookBattleTurn],a
-	ld b,1
+	ld [wActionResultOrTookBattleTurn], a
+	ld b, 1
 	ret
 
 PrintGhostText:
 ; print the ghost battle messages
 	call IsGhostBattle
 	ret nz
-	ld a,[H_WHOSETURN]
+	ld a, [H_WHOSETURN]
 	and a
-	jr nz,.Ghost
-	ld a,[wBattleMonStatus] ; player’s turn
-	and a,SLP | (1 << FRZ)
+	jr nz, .Ghost
+	ld a, [wBattleMonStatus] ; player’s turn
+	and SLP | (1 << FRZ)
 	ret nz
-	ld hl,ScaredText
+	ld hl, ScaredText
 	call PrintText
 	xor a
 	ret
 .Ghost ; ghost’s turn
-	ld hl,GetOutText
+	ld hl, GetOutText
 	call PrintText
 	xor a
 	ret
@@ -3367,261 +3367,261 @@ GetOutText:
 	db "@"
 
 IsGhostBattle:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	dec a
 	ret nz
-	ld a,[wCurMap]
-	cp a,POKEMONTOWER_1
-	jr c,.next
-	cp a,LAVENDER_HOUSE_1
-	jr nc,.next
-	ld b,SILPH_SCOPE
+	ld a, [wCurMap]
+	cp POKEMONTOWER_1
+	jr c, .next
+	cp LAVENDER_HOUSE_1
+	jr nc, .next
+	ld b, SILPH_SCOPE
 	call IsItemInBag
 	ret z
 .next
-	ld a,1
+	ld a, 1
 	and a
 	ret
 
 ; checks for various status conditions affecting the player mon
 ; stores whether the mon cannot use a move this turn in Z flag
 CheckPlayerStatusConditions:
-	ld hl,wBattleMonStatus
-	ld a,[hl]
-	and a,SLP ; sleep mask
-	jr z,.FrozenCheck
+	ld hl, wBattleMonStatus
+	ld a, [hl]
+	and SLP ; sleep mask
+	jr z, .FrozenCheck
 ; sleeping
 	dec a
-	ld [wBattleMonStatus],a ; decrement number of turns left
+	ld [wBattleMonStatus], a ; decrement number of turns left
 	and a
-	jr z,.WakeUp ; if the number of turns hit 0, wake up
+	jr z, .WakeUp ; if the number of turns hit 0, wake up
 ; fast asleep
 	xor a
-	ld [wAnimationType],a
-	ld a,SLP_ANIM - 1
+	ld [wAnimationType], a
+	ld a, SLP_ANIM - 1
 	call PlayMoveAnimation
-	ld hl,FastAsleepText
+	ld hl, FastAsleepText
 	call PrintText
 	jr .sleepDone
 .WakeUp
-	ld hl,WokeUpText
+	ld hl, WokeUpText
 	call PrintText
 .sleepDone
 	xor a
-	ld [wPlayerUsedMove],a
-	ld hl,ExecutePlayerMoveDone ; player can't move this turn
+	ld [wPlayerUsedMove], a
+	ld hl, ExecutePlayerMoveDone ; player can't move this turn
 	jp .returnToHL
 
 .FrozenCheck
-	bit FRZ,[hl] ; frozen?
-	jr z,.HeldInPlaceCheck
-	ld hl,IsFrozenText
+	bit FRZ, [hl] ; frozen?
+	jr z, .HeldInPlaceCheck
+	ld hl, IsFrozenText
 	call PrintText
 	xor a
-	ld [wPlayerUsedMove],a
-	ld hl,ExecutePlayerMoveDone ; player can't move this turn
+	ld [wPlayerUsedMove], a
+	ld hl, ExecutePlayerMoveDone ; player can't move this turn
 	jp .returnToHL
 
 .HeldInPlaceCheck
-	ld a,[wEnemyBattleStatus1]
-	bit USING_TRAPPING_MOVE,a ; is enemy using a mult-turn move like wrap?
-	jp z,.FlinchedCheck
-	ld hl,CantMoveText
+	ld a, [wEnemyBattleStatus1]
+	bit USING_TRAPPING_MOVE, a ; is enemy using a mult-turn move like wrap?
+	jp z, .FlinchedCheck
+	ld hl, CantMoveText
 	call PrintText
-	ld hl,ExecutePlayerMoveDone ; player can't move this turn
+	ld hl, ExecutePlayerMoveDone ; player can't move this turn
 	jp .returnToHL
 
 .FlinchedCheck
-	ld hl,wPlayerBattleStatus1
-	bit FLINCHED,[hl]
-	jp z,.HyperBeamCheck
-	res FLINCHED,[hl] ; reset player's flinch status
-	ld hl,FlinchedText
+	ld hl, wPlayerBattleStatus1
+	bit FLINCHED, [hl]
+	jp z, .HyperBeamCheck
+	res FLINCHED, [hl] ; reset player's flinch status
+	ld hl, FlinchedText
 	call PrintText
-	ld hl,ExecutePlayerMoveDone ; player can't move this turn
+	ld hl, ExecutePlayerMoveDone ; player can't move this turn
 	jp .returnToHL
 
 .HyperBeamCheck
-	ld hl,wPlayerBattleStatus2
-	bit NEEDS_TO_RECHARGE,[hl]
-	jr z,.AnyMoveDisabledCheck
-	res NEEDS_TO_RECHARGE,[hl] ; reset player's recharge status
-	ld hl,MustRechargeText
+	ld hl, wPlayerBattleStatus2
+	bit NEEDS_TO_RECHARGE, [hl]
+	jr z, .AnyMoveDisabledCheck
+	res NEEDS_TO_RECHARGE, [hl] ; reset player's recharge status
+	ld hl, MustRechargeText
 	call PrintText
-	ld hl,ExecutePlayerMoveDone ; player can't move this turn
+	ld hl, ExecutePlayerMoveDone ; player can't move this turn
 	jp .returnToHL
 
 .AnyMoveDisabledCheck
-	ld hl,wPlayerDisabledMove
-	ld a,[hl]
+	ld hl, wPlayerDisabledMove
+	ld a, [hl]
 	and a
-	jr z,.ConfusedCheck
+	jr z, .ConfusedCheck
 	dec a
-	ld [hl],a
+	ld [hl], a
 	and $f ; did Disable counter hit 0?
-	jr nz,.ConfusedCheck
-	ld [hl],a
-	ld [wPlayerDisabledMoveNumber],a
-	ld hl,DisabledNoMoreText
+	jr nz, .ConfusedCheck
+	ld [hl], a
+	ld [wPlayerDisabledMoveNumber], a
+	ld hl, DisabledNoMoreText
 	call PrintText
 
 .ConfusedCheck
-	ld a,[wPlayerBattleStatus1]
+	ld a, [wPlayerBattleStatus1]
 	add a ; is player confused?
-	jr nc,.TriedToUseDisabledMoveCheck
-	ld hl,wPlayerConfusedCounter
+	jr nc, .TriedToUseDisabledMoveCheck
+	ld hl, wPlayerConfusedCounter
 	dec [hl]
-	jr nz,.IsConfused
-	ld hl,wPlayerBattleStatus1
-	res CONFUSED,[hl] ; if confused counter hit 0, reset confusion status
-	ld hl,ConfusedNoMoreText
+	jr nz, .IsConfused
+	ld hl, wPlayerBattleStatus1
+	res CONFUSED, [hl] ; if confused counter hit 0, reset confusion status
+	ld hl, ConfusedNoMoreText
 	call PrintText
 	jr .TriedToUseDisabledMoveCheck
 .IsConfused
-	ld hl,IsConfusedText
+	ld hl, IsConfusedText
 	call PrintText
 	xor a
-	ld [wAnimationType],a
-	ld a,CONF_ANIM - 1
+	ld [wAnimationType], a
+	ld a, CONF_ANIM - 1
 	call PlayMoveAnimation
 	call BattleRandom
-	cp a,$80 ; 50% chance to hurt itself
-	jr c,.TriedToUseDisabledMoveCheck
-	ld hl,wPlayerBattleStatus1
-	ld a,[hl]
-	and a, 1 << CONFUSED ; if mon hurts itself, clear every other status from wPlayerBattleStatus1
-	ld [hl],a
+	cp $80 ; 50% chance to hurt itself
+	jr c, .TriedToUseDisabledMoveCheck
+	ld hl, wPlayerBattleStatus1
+	ld a, [hl]
+	and 1 << CONFUSED ; if mon hurts itself, clear every other status from wPlayerBattleStatus1
+	ld [hl], a
 	call HandleSelfConfusionDamage
 	jr .MonHurtItselfOrFullyParalysed
 
 .TriedToUseDisabledMoveCheck
 ; prevents a disabled move that was selected before being disabled from being used
-	ld a,[wPlayerDisabledMoveNumber]
+	ld a, [wPlayerDisabledMoveNumber]
 	and a
-	jr z,.ParalysisCheck
-	ld hl,wPlayerSelectedMove
+	jr z, .ParalysisCheck
+	ld hl, wPlayerSelectedMove
 	cp [hl]
-	jr nz,.ParalysisCheck
+	jr nz, .ParalysisCheck
 	call PrintMoveIsDisabledText
-	ld hl,ExecutePlayerMoveDone ; if a disabled move was somehow selected, player can't move this turn
+	ld hl, ExecutePlayerMoveDone ; if a disabled move was somehow selected, player can't move this turn
 	jp .returnToHL
 
 .ParalysisCheck
-	ld hl,wBattleMonStatus
-	bit PAR,[hl]
-	jr z,.BideCheck
+	ld hl, wBattleMonStatus
+	bit PAR, [hl]
+	jr z, .BideCheck
 	call BattleRandom
-	cp a,$3F ; 25% to be fully paralyzed
-	jr nc,.BideCheck
-	ld hl,FullyParalyzedText
+	cp $3F ; 25% to be fully paralyzed
+	jr nc, .BideCheck
+	ld hl, FullyParalyzedText
 	call PrintText
 
 .MonHurtItselfOrFullyParalysed
-	ld hl,wPlayerBattleStatus1
-	ld a,[hl]
+	ld hl, wPlayerBattleStatus1
+	ld a, [hl]
 	; clear bide, thrashing, charging up, and trapping moves such as warp (already cleared for confusion damage)
 	and $ff ^ ((1 << STORING_ENERGY) | (1 << THRASHING_ABOUT) | (1 << CHARGING_UP) | (1 << USING_TRAPPING_MOVE))
-	ld [hl],a
-	ld a,[wPlayerMoveEffect]
-	cp a,FLY_EFFECT
-	jr z,.FlyOrChargeEffect
-	cp a,CHARGE_EFFECT
-	jr z,.FlyOrChargeEffect
+	ld [hl], a
+	ld a, [wPlayerMoveEffect]
+	cp FLY_EFFECT
+	jr z, .FlyOrChargeEffect
+	cp CHARGE_EFFECT
+	jr z, .FlyOrChargeEffect
 	jr .NotFlyOrChargeEffect
 
 .FlyOrChargeEffect
 	xor a
-	ld [wAnimationType],a
-	ld a,STATUS_AFFECTED_ANIM
+	ld [wAnimationType], a
+	ld a, STATUS_AFFECTED_ANIM
 	call PlayMoveAnimation
 .NotFlyOrChargeEffect
-	ld hl,ExecutePlayerMoveDone
+	ld hl, ExecutePlayerMoveDone
 	jp .returnToHL ; if using a two-turn move, we need to recharge the first turn
 
 .BideCheck
-	ld hl,wPlayerBattleStatus1
-	bit STORING_ENERGY,[hl] ; is mon using bide?
-	jr z,.ThrashingAboutCheck
+	ld hl, wPlayerBattleStatus1
+	bit STORING_ENERGY, [hl] ; is mon using bide?
+	jr z, .ThrashingAboutCheck
 	xor a
-	ld [wPlayerMoveNum],a
-	ld hl,wDamage
-	ld a,[hli]
-	ld b,a
-	ld c,[hl]
-	ld hl,wPlayerBideAccumulatedDamage + 1
-	ld a,[hl]
+	ld [wPlayerMoveNum], a
+	ld hl, wDamage
+	ld a, [hli]
+	ld b, a
+	ld c, [hl]
+	ld hl, wPlayerBideAccumulatedDamage + 1
+	ld a, [hl]
 	add c ; accumulate damage taken
-	ld [hld],a
-	ld a,[hl]
+	ld [hld], a
+	ld a, [hl]
 	adc b
-	ld [hl],a
-	ld hl,wPlayerNumAttacksLeft
+	ld [hl], a
+	ld hl, wPlayerNumAttacksLeft
 	dec [hl] ; did Bide counter hit 0?
-	jr z,.UnleashEnergy
-	ld hl,ExecutePlayerMoveDone
+	jr z, .UnleashEnergy
+	ld hl, ExecutePlayerMoveDone
 	jp .returnToHL ; unless mon unleashes energy, can't move this turn
 .UnleashEnergy
-	ld hl,wPlayerBattleStatus1
-	res STORING_ENERGY,[hl] ; not using bide any more
-	ld hl,UnleashedEnergyText
+	ld hl, wPlayerBattleStatus1
+	res STORING_ENERGY, [hl] ; not using bide any more
+	ld hl, UnleashedEnergyText
 	call PrintText
-	ld a,1
-	ld [wPlayerMovePower],a
-	ld hl,wPlayerBideAccumulatedDamage + 1
-	ld a,[hld]
+	ld a, 1
+	ld [wPlayerMovePower], a
+	ld hl, wPlayerBideAccumulatedDamage + 1
+	ld a, [hld]
 	add a
-	ld b,a
-	ld [wDamage + 1],a
-	ld a,[hl]
+	ld b, a
+	ld [wDamage + 1], a
+	ld a, [hl]
 	rl a ; double the damage
-	ld [wDamage],a
+	ld [wDamage], a
 	or b
-	jr nz,.next
-	ld a,1
-	ld [wMoveMissed],a
+	jr nz, .next
+	ld a, 1
+	ld [wMoveMissed], a
 .next
 	xor a
-	ld [hli],a
-	ld [hl],a
-	ld a,BIDE
-	ld [wPlayerMoveNum],a
-	ld hl,handleIfPlayerMoveMissed ; skip damage calculation, DecrementPP and MoveHitTest
+	ld [hli], a
+	ld [hl], a
+	ld a, BIDE
+	ld [wPlayerMoveNum], a
+	ld hl, handleIfPlayerMoveMissed ; skip damage calculation, DecrementPP and MoveHitTest
 	jp .returnToHL
 
 .ThrashingAboutCheck
-	bit THRASHING_ABOUT,[hl] ; is mon using thrash or petal dance?
-	jr z,.MultiturnMoveCheck
-	ld a,THRASH
-	ld [wPlayerMoveNum],a
-	ld hl,ThrashingAboutText
+	bit THRASHING_ABOUT, [hl] ; is mon using thrash or petal dance?
+	jr z, .MultiturnMoveCheck
+	ld a, THRASH
+	ld [wPlayerMoveNum], a
+	ld hl, ThrashingAboutText
 	call PrintText
-	ld hl,wPlayerNumAttacksLeft
+	ld hl, wPlayerNumAttacksLeft
 	dec [hl] ; did Thrashing About counter hit 0?
-	ld hl,PlayerCalcMoveDamage ; skip DecrementPP
-	jp nz,.returnToHL
+	ld hl, PlayerCalcMoveDamage ; skip DecrementPP
+	jp nz, .returnToHL
 	push hl
-	ld hl,wPlayerBattleStatus1
-	res THRASHING_ABOUT,[hl] ; no longer thrashing about
-	set CONFUSED,[hl] ; confused
+	ld hl, wPlayerBattleStatus1
+	res THRASHING_ABOUT, [hl] ; no longer thrashing about
+	set CONFUSED, [hl] ; confused
 	call BattleRandom
-	and a,3
+	and 3
 	inc a
 	inc a ; confused for 2-5 turns
-	ld [wPlayerConfusedCounter],a
+	ld [wPlayerConfusedCounter], a
 	pop hl ; skip DecrementPP
 	jp .returnToHL
 
 .MultiturnMoveCheck
-	bit USING_TRAPPING_MOVE,[hl] ; is mon using multi-turn move?
-	jp z,.RageCheck
-	ld hl,AttackContinuesText
+	bit USING_TRAPPING_MOVE, [hl] ; is mon using multi-turn move?
+	jp z, .RageCheck
+	ld hl, AttackContinuesText
 	call PrintText
-	ld a,[wPlayerNumAttacksLeft]
+	ld a, [wPlayerNumAttacksLeft]
 	dec a ; did multi-turn move end?
-	ld [wPlayerNumAttacksLeft],a
-	ld hl,getPlayerAnimationType ; if it didn't, skip damage calculation (deal damage equal to last hit),
+	ld [wPlayerNumAttacksLeft], a
+	ld hl, getPlayerAnimationType ; if it didn't, skip damage calculation (deal damage equal to last hit),
 	                ; DecrementPP and MoveHitTest
-	jp nz,.returnToHL
+	jp nz, .returnToHL
 	jp .returnToHL
 
 .RageCheck
@@ -4515,7 +4515,7 @@ CalculateDamage:
 .effect
 
 ; EXPLODE_EFFECT halves defense.
-	cp a, EXPLODE_EFFECT
+	cp EXPLODE_EFFECT
 	jr nz, .ok
 	srl c
 	jr nz, .ok
@@ -4523,13 +4523,13 @@ CalculateDamage:
 .ok
 
 ; Multi-hit attacks may or may not have 0 bp.
-	cp a, TWO_TO_FIVE_ATTACKS_EFFECT
+	cp TWO_TO_FIVE_ATTACKS_EFFECT
 	jr z, .skipbp
-	cp a, $1e
+	cp $1e
 	jr z, .skipbp
 
 ; Calculate OHKO damage based on remaining HP.
-	cp a, OHKO_EFFECT
+	cp OHKO_EFFECT
 	jp z, JumpToOHKOMoveEffect
 
 ; Don't calculate damage for moves that don't do any.
@@ -4762,297 +4762,297 @@ HandleCounterMove:
 ; the outcome may be affected by the player's actions in the move selection menu prior to switching the Pokemon.
 ; This might also lead to desync glitches in link battles.
 
-	ld a,[H_WHOSETURN] ; whose turn
+	ld a, [H_WHOSETURN] ; whose turn
 	and a
 ; player's turn
-	ld hl,wEnemySelectedMove
-	ld de,wEnemyMovePower
-	ld a,[wPlayerSelectedMove]
-	jr z,.next
+	ld hl, wEnemySelectedMove
+	ld de, wEnemyMovePower
+	ld a, [wPlayerSelectedMove]
+	jr z, .next
 ; enemy's turn
-	ld hl,wPlayerSelectedMove
-	ld de,wPlayerMovePower
-	ld a,[wEnemySelectedMove]
+	ld hl, wPlayerSelectedMove
+	ld de, wPlayerMovePower
+	ld a, [wEnemySelectedMove]
 .next
-	cp a,COUNTER
+	cp COUNTER
 	ret nz ; return if not using Counter
-	ld a,$01
-	ld [wMoveMissed],a ; initialize the move missed variable to true (it is set to false below if the move hits)
-	ld a,[hl]
-	cp a,COUNTER
+	ld a, $01
+	ld [wMoveMissed], a ; initialize the move missed variable to true (it is set to false below if the move hits)
+	ld a, [hl]
+	cp COUNTER
 	ret z ; miss if the opponent's last selected move is Counter.
-	ld a,[de]
+	ld a, [de]
 	and a
 	ret z ; miss if the opponent's last selected move's Base Power is 0.
 ; check if the move the target last selected was Normal or Fighting type
 	inc de
-	ld a,[de]
+	ld a, [de]
 	and a ; normal type
-	jr z,.counterableType
-	cp a,FIGHTING
-	jr z,.counterableType
+	jr z, .counterableType
+	cp FIGHTING
+	jr z, .counterableType
 ; if the move wasn't Normal or Fighting type, miss
 	xor a
 	ret
 .counterableType
-	ld hl,wDamage
-	ld a,[hli]
+	ld hl, wDamage
+	ld a, [hli]
 	or [hl]
 	ret z ; If we made it here, Counter still misses if the last move used in battle did no damage to its target.
 	      ; wDamage is shared by both players, so Counter may strike back damage dealt by the Counter user itself
 	      ; if the conditions meet, even though 99% of the times damage will come from the target.
 ; if it did damage, double it
-	ld a,[hl]
+	ld a, [hl]
 	add a
-	ldd [hl],a
-	ld a,[hl]
+	ldd [hl], a
+	ld a, [hl]
 	adc a
-	ld [hl],a
-	jr nc,.noCarry
+	ld [hl], a
+	jr nc, .noCarry
 ; damage is capped at 0xFFFF
-	ld a,$ff
-	ld [hli],a
-	ld [hl],a
+	ld a, $ff
+	ld [hli], a
+	ld [hl], a
 .noCarry
 	xor a
-	ld [wMoveMissed],a
+	ld [wMoveMissed], a
 	call MoveHitTest ; do the normal move hit test in addition to Counter's special rules
 	xor a
 	ret
 
 ApplyAttackToEnemyPokemon:
-	ld a,[wPlayerMoveEffect]
-	cp a,OHKO_EFFECT
-	jr z,ApplyDamageToEnemyPokemon
-	cp a,SUPER_FANG_EFFECT
-	jr z,.superFangEffect
-	cp a,SPECIAL_DAMAGE_EFFECT
-	jr z,.specialDamage
-	ld a,[wPlayerMovePower]
+	ld a, [wPlayerMoveEffect]
+	cp OHKO_EFFECT
+	jr z, ApplyDamageToEnemyPokemon
+	cp SUPER_FANG_EFFECT
+	jr z, .superFangEffect
+	cp SPECIAL_DAMAGE_EFFECT
+	jr z, .specialDamage
+	ld a, [wPlayerMovePower]
 	and a
-	jp z,ApplyAttackToEnemyPokemonDone ; no attack to apply if base power is 0
+	jp z, ApplyAttackToEnemyPokemonDone ; no attack to apply if base power is 0
 	jr ApplyDamageToEnemyPokemon
 .superFangEffect
 ; set the damage to half the target's HP
-	ld hl,wEnemyMonHP
-	ld de,wDamage
-	ld a,[hli]
+	ld hl, wEnemyMonHP
+	ld de, wDamage
+	ld a, [hli]
 	srl a
-	ld [de],a
+	ld [de], a
 	inc de
-	ld b,a
-	ld a,[hl]
+	ld b, a
+	ld a, [hl]
 	rr a
-	ld [de],a
+	ld [de], a
 	or b
-	jr nz,ApplyDamageToEnemyPokemon
+	jr nz, ApplyDamageToEnemyPokemon
 ; make sure Super Fang's damage is always at least 1
-	ld a,$01
-	ld [de],a
+	ld a, $01
+	ld [de], a
 	jr ApplyDamageToEnemyPokemon
 .specialDamage
-	ld hl,wBattleMonLevel
-	ld a,[hl]
-	ld b,a ; Seismic Toss deals damage equal to the user's level
-	ld a,[wPlayerMoveNum]
-	cp a,SEISMIC_TOSS
-	jr z,.storeDamage
-	cp a,NIGHT_SHADE
-	jr z,.storeDamage
-	ld b,SONICBOOM_DAMAGE ; 20
-	cp a,SONICBOOM
-	jr z,.storeDamage
-	ld b,DRAGON_RAGE_DAMAGE ; 40
-	cp a,DRAGON_RAGE
-	jr z,.storeDamage
+	ld hl, wBattleMonLevel
+	ld a, [hl]
+	ld b, a ; Seismic Toss deals damage equal to the user's level
+	ld a, [wPlayerMoveNum]
+	cp SEISMIC_TOSS
+	jr z, .storeDamage
+	cp NIGHT_SHADE
+	jr z, .storeDamage
+	ld b, SONICBOOM_DAMAGE ; 20
+	cp SONICBOOM
+	jr z, .storeDamage
+	ld b, DRAGON_RAGE_DAMAGE ; 40
+	cp DRAGON_RAGE
+	jr z, .storeDamage
 ; Psywave
-	ld a,[hl]
-	ld b,a
+	ld a, [hl]
+	ld b, a
 	srl a
 	add b
-	ld b,a ; b = level * 1.5
+	ld b, a ; b = level * 1.5
 ; loop until a random number in the range [1, b) is found
 .loop
 	call BattleRandom
 	and a
-	jr z,.loop
+	jr z, .loop
 	cp b
-	jr nc,.loop
-	ld b,a
+	jr nc, .loop
+	ld b, a
 .storeDamage ; store damage value at b
-	ld hl,wDamage
+	ld hl, wDamage
 	xor a
-	ld [hli],a
-	ld a,b
-	ld [hl],a
+	ld [hli], a
+	ld a, b
+	ld [hl], a
 
 ApplyDamageToEnemyPokemon:
-	ld hl,wDamage
-	ld a,[hli]
-	ld b,a
-	ld a,[hl]
+	ld hl, wDamage
+	ld a, [hli]
+	ld b, a
+	ld a, [hl]
 	or b
-	jr z,ApplyAttackToEnemyPokemonDone ; we're done if damage is 0
-	ld a,[wEnemyBattleStatus2]
-	bit HAS_SUBSTITUTE_UP,a ; does the enemy have a substitute?
-	jp nz,AttackSubstitute
+	jr z, ApplyAttackToEnemyPokemonDone ; we're done if damage is 0
+	ld a, [wEnemyBattleStatus2]
+	bit HAS_SUBSTITUTE_UP, a ; does the enemy have a substitute?
+	jp nz, AttackSubstitute
 ; subtract the damage from the pokemon's current HP
 ; also, save the current HP at wHPBarOldHP
-	ld a,[hld]
-	ld b,a
-	ld a,[wEnemyMonHP + 1]
-	ld [wHPBarOldHP],a
+	ld a, [hld]
+	ld b, a
+	ld a, [wEnemyMonHP + 1]
+	ld [wHPBarOldHP], a
 	sub b
-	ld [wEnemyMonHP + 1],a
-	ld a,[hl]
-	ld b,a
-	ld a,[wEnemyMonHP]
-	ld [wHPBarOldHP+1],a
+	ld [wEnemyMonHP + 1], a
+	ld a, [hl]
+	ld b, a
+	ld a, [wEnemyMonHP]
+	ld [wHPBarOldHP+1], a
 	sbc b
-	ld [wEnemyMonHP],a
-	jr nc,.animateHpBar
+	ld [wEnemyMonHP], a
+	jr nc, .animateHpBar
 ; if more damage was done than the current HP, zero the HP and set the damage (wDamage)
 ; equal to how much HP the pokemon had before the attack
-	ld a,[wHPBarOldHP+1]
-	ld [hli],a
-	ld a,[wHPBarOldHP]
-	ld [hl],a
+	ld a, [wHPBarOldHP+1]
+	ld [hli], a
+	ld a, [wHPBarOldHP]
+	ld [hl], a
 	xor a
-	ld hl,wEnemyMonHP
-	ld [hli],a
-	ld [hl],a
+	ld hl, wEnemyMonHP
+	ld [hli], a
+	ld [hl], a
 .animateHpBar
-	ld hl,wEnemyMonMaxHP
-	ld a,[hli]
-	ld [wHPBarMaxHP+1],a
-	ld a,[hl]
-	ld [wHPBarMaxHP],a
-	ld hl,wEnemyMonHP
-	ld a,[hli]
-	ld [wHPBarNewHP+1],a
-	ld a,[hl]
-	ld [wHPBarNewHP],a
+	ld hl, wEnemyMonMaxHP
+	ld a, [hli]
+	ld [wHPBarMaxHP+1], a
+	ld a, [hl]
+	ld [wHPBarMaxHP], a
+	ld hl, wEnemyMonHP
+	ld a, [hli]
+	ld [wHPBarNewHP+1], a
+	ld a, [hl]
+	ld [wHPBarNewHP], a
 	coord hl, 2, 2
 	xor a
-	ld [wHPBarType],a
+	ld [wHPBarType], a
 	predef UpdateHPBar2 ; animate the HP bar shortening
 ApplyAttackToEnemyPokemonDone:
 	jp DrawHUDsAndHPBars
 
 ApplyAttackToPlayerPokemon:
-	ld a,[wEnemyMoveEffect]
-	cp a,OHKO_EFFECT
-	jr z,ApplyDamageToPlayerPokemon
-	cp a,SUPER_FANG_EFFECT
-	jr z,.superFangEffect
-	cp a,SPECIAL_DAMAGE_EFFECT
-	jr z,.specialDamage
-	ld a,[wEnemyMovePower]
+	ld a, [wEnemyMoveEffect]
+	cp OHKO_EFFECT
+	jr z, ApplyDamageToPlayerPokemon
+	cp SUPER_FANG_EFFECT
+	jr z, .superFangEffect
+	cp SPECIAL_DAMAGE_EFFECT
+	jr z, .specialDamage
+	ld a, [wEnemyMovePower]
 	and a
-	jp z,ApplyAttackToPlayerPokemonDone
+	jp z, ApplyAttackToPlayerPokemonDone
 	jr ApplyDamageToPlayerPokemon
 .superFangEffect
 ; set the damage to half the target's HP
-	ld hl,wBattleMonHP
-	ld de,wDamage
-	ld a,[hli]
+	ld hl, wBattleMonHP
+	ld de, wDamage
+	ld a, [hli]
 	srl a
-	ld [de],a
+	ld [de], a
 	inc de
-	ld b,a
-	ld a,[hl]
+	ld b, a
+	ld a, [hl]
 	rr a
-	ld [de],a
+	ld [de], a
 	or b
-	jr nz,ApplyDamageToPlayerPokemon
+	jr nz, ApplyDamageToPlayerPokemon
 ; make sure Super Fang's damage is always at least 1
-	ld a,$01
-	ld [de],a
+	ld a, $01
+	ld [de], a
 	jr ApplyDamageToPlayerPokemon
 .specialDamage
-	ld hl,wEnemyMonLevel
-	ld a,[hl]
-	ld b,a
-	ld a,[wEnemyMoveNum]
-	cp a,SEISMIC_TOSS
-	jr z,.storeDamage
-	cp a,NIGHT_SHADE
-	jr z,.storeDamage
-	ld b,SONICBOOM_DAMAGE
-	cp a,SONICBOOM
-	jr z,.storeDamage
-	ld b,DRAGON_RAGE_DAMAGE
-	cp a,DRAGON_RAGE
-	jr z,.storeDamage
+	ld hl, wEnemyMonLevel
+	ld a, [hl]
+	ld b, a
+	ld a, [wEnemyMoveNum]
+	cp SEISMIC_TOSS
+	jr z, .storeDamage
+	cp NIGHT_SHADE
+	jr z, .storeDamage
+	ld b, SONICBOOM_DAMAGE
+	cp SONICBOOM
+	jr z, .storeDamage
+	ld b, DRAGON_RAGE_DAMAGE
+	cp DRAGON_RAGE
+	jr z, .storeDamage
 ; Psywave
-	ld a,[hl]
-	ld b,a
+	ld a, [hl]
+	ld b, a
 	srl a
 	add b
-	ld b,a ; b = attacker's level * 1.5
+	ld b, a ; b = attacker's level * 1.5
 ; loop until a random number in the range [0, b) is found
 ; this differs from the range when the player attacks, which is [1, b)
 ; it's possible for the enemy to do 0 damage with Psywave, but the player always does at least 1 damage
 .loop
 	call BattleRandom
 	cp b
-	jr nc,.loop
-	ld b,a
+	jr nc, .loop
+	ld b, a
 .storeDamage
-	ld hl,wDamage
+	ld hl, wDamage
 	xor a
-	ld [hli],a
-	ld a,b
-	ld [hl],a
+	ld [hli], a
+	ld a, b
+	ld [hl], a
 
 ApplyDamageToPlayerPokemon:
-	ld hl,wDamage
-	ld a,[hli]
-	ld b,a
-	ld a,[hl]
+	ld hl, wDamage
+	ld a, [hli]
+	ld b, a
+	ld a, [hl]
 	or b
-	jr z,ApplyAttackToPlayerPokemonDone ; we're done if damage is 0
-	ld a,[wPlayerBattleStatus2]
-	bit HAS_SUBSTITUTE_UP,a ; does the player have a substitute?
-	jp nz,AttackSubstitute
+	jr z, ApplyAttackToPlayerPokemonDone ; we're done if damage is 0
+	ld a, [wPlayerBattleStatus2]
+	bit HAS_SUBSTITUTE_UP, a ; does the player have a substitute?
+	jp nz, AttackSubstitute
 ; subtract the damage from the pokemon's current HP
 ; also, save the current HP at wHPBarOldHP and the new HP at wHPBarNewHP
-	ld a,[hld]
-	ld b,a
-	ld a,[wBattleMonHP + 1]
-	ld [wHPBarOldHP],a
+	ld a, [hld]
+	ld b, a
+	ld a, [wBattleMonHP + 1]
+	ld [wHPBarOldHP], a
 	sub b
-	ld [wBattleMonHP + 1],a
-	ld [wHPBarNewHP],a
-	ld b,[hl]
-	ld a,[wBattleMonHP]
-	ld [wHPBarOldHP+1],a
+	ld [wBattleMonHP + 1], a
+	ld [wHPBarNewHP], a
+	ld b, [hl]
+	ld a, [wBattleMonHP]
+	ld [wHPBarOldHP+1], a
 	sbc b
-	ld [wBattleMonHP],a
-	ld [wHPBarNewHP+1],a
-	jr nc,.animateHpBar
+	ld [wBattleMonHP], a
+	ld [wHPBarNewHP+1], a
+	jr nc, .animateHpBar
 ; if more damage was done than the current HP, zero the HP and set the damage (wDamage)
 ; equal to how much HP the pokemon had before the attack
-	ld a,[wHPBarOldHP+1]
-	ld [hli],a
-	ld a,[wHPBarOldHP]
-	ld [hl],a
+	ld a, [wHPBarOldHP+1]
+	ld [hli], a
+	ld a, [wHPBarOldHP]
+	ld [hl], a
 	xor a
-	ld hl,wBattleMonHP
-	ld [hli],a
-	ld [hl],a
-	ld hl,wHPBarNewHP
-	ld [hli],a
-	ld [hl],a
+	ld hl, wBattleMonHP
+	ld [hli], a
+	ld [hl], a
+	ld hl, wHPBarNewHP
+	ld [hli], a
+	ld [hl], a
 .animateHpBar
-	ld hl,wBattleMonMaxHP
-	ld a,[hli]
-	ld [wHPBarMaxHP+1],a
-	ld a,[hl]
-	ld [wHPBarMaxHP],a
+	ld hl, wBattleMonMaxHP
+	ld a, [hli]
+	ld [wHPBarMaxHP+1], a
+	ld a, [hl]
+	ld [wHPBarMaxHP], a
 	coord hl, 10, 9
-	ld a,$01
-	ld [wHPBarType],a
+	ld a, $01
+	ld [wHPBarType], a
 	predef UpdateHPBar2 ; animate the HP bar shortening
 ApplyAttackToPlayerPokemonDone:
 	jp DrawHUDsAndHPBars
@@ -5065,51 +5065,51 @@ AttackSubstitute:
 ; Normal recoil such as from Double-Edge isn't affected by this glitch,
 ; because this function is never called in that case.
 
-	ld hl,SubstituteTookDamageText
+	ld hl, SubstituteTookDamageText
 	call PrintText
 ; values for player turn
-	ld de,wEnemySubstituteHP
-	ld bc,wEnemyBattleStatus2
-	ld a,[H_WHOSETURN]
+	ld de, wEnemySubstituteHP
+	ld bc, wEnemyBattleStatus2
+	ld a, [H_WHOSETURN]
 	and a
-	jr z,.applyDamageToSubstitute
+	jr z, .applyDamageToSubstitute
 ; values for enemy turn
-	ld de,wPlayerSubstituteHP
-	ld bc,wPlayerBattleStatus2
+	ld de, wPlayerSubstituteHP
+	ld bc, wPlayerBattleStatus2
 .applyDamageToSubstitute
-	ld hl,wDamage
-	ld a,[hli]
+	ld hl, wDamage
+	ld a, [hli]
 	and a
-	jr nz,.substituteBroke ; damage > 0xFF always breaks substitutes
+	jr nz, .substituteBroke ; damage > 0xFF always breaks substitutes
 ; subtract damage from HP of substitute
-	ld a,[de]
+	ld a, [de]
 	sub [hl]
-	ld [de],a
+	ld [de], a
 	ret nc
 .substituteBroke
 ; If the target's Substitute breaks, wDamage isn't updated with the amount of HP
 ; the Substitute had before being attacked.
-	ld h,b
-	ld l,c
-	res HAS_SUBSTITUTE_UP,[hl] ; unset the substitute bit
-	ld hl,SubstituteBrokeText
+	ld h, b
+	ld l, c
+	res HAS_SUBSTITUTE_UP, [hl] ; unset the substitute bit
+	ld hl, SubstituteBrokeText
 	call PrintText
 ; flip whose turn it is for the next function call
-	ld a,[H_WHOSETURN]
-	xor a,$01
-	ld [H_WHOSETURN],a
+	ld a, [H_WHOSETURN]
+	xor $01
+	ld [H_WHOSETURN], a
 	callab HideSubstituteShowMonAnim ; animate the substitute breaking
 ; flip the turn back to the way it was
-	ld a,[H_WHOSETURN]
-	xor a,$01
-	ld [H_WHOSETURN],a
-	ld hl,wPlayerMoveEffect ; value for player's turn
+	ld a, [H_WHOSETURN]
+	xor $01
+	ld [H_WHOSETURN], a
+	ld hl, wPlayerMoveEffect ; value for player's turn
 	and a
-	jr z,.nullifyEffect
-	ld hl,wEnemyMoveEffect ; value for enemy's turn
+	jr z, .nullifyEffect
+	ld hl, wEnemyMoveEffect ; value for enemy's turn
 .nullifyEffect
 	xor a
-	ld [hl],a ; zero the effect of the attacker's move
+	ld [hl], a ; zero the effect of the attacker's move
 	jp DrawHUDsAndHPBars
 
 SubstituteTookDamageText:
@@ -5123,44 +5123,44 @@ SubstituteBrokeText:
 ; this function raises the attack modifier of a pokemon using Rage when that pokemon is attacked
 HandleBuildingRage:
 ; values for the player turn
-	ld hl,wEnemyBattleStatus2
-	ld de,wEnemyMonStatMods
-	ld bc,wEnemyMoveNum
-	ld a,[H_WHOSETURN]
+	ld hl, wEnemyBattleStatus2
+	ld de, wEnemyMonStatMods
+	ld bc, wEnemyMoveNum
+	ld a, [H_WHOSETURN]
 	and a
-	jr z,.next
+	jr z, .next
 ; values for the enemy turn
-	ld hl,wPlayerBattleStatus2
-	ld de,wPlayerMonStatMods
-	ld bc,wPlayerMoveNum
+	ld hl, wPlayerBattleStatus2
+	ld de, wPlayerMonStatMods
+	ld bc, wPlayerMoveNum
 .next
-	bit USING_RAGE,[hl] ; is the pokemon being attacked under the effect of Rage?
+	bit USING_RAGE, [hl] ; is the pokemon being attacked under the effect of Rage?
 	ret z ; return if not
-	ld a,[de]
-	cp a,$0d ; maximum stat modifier value
+	ld a, [de]
+	cp $0d ; maximum stat modifier value
 	ret z ; return if attack modifier is already maxed
-	ld a,[H_WHOSETURN]
-	xor a,$01 ; flip turn for the stat modifier raising function
-	ld [H_WHOSETURN],a
+	ld a, [H_WHOSETURN]
+	xor $01 ; flip turn for the stat modifier raising function
+	ld [H_WHOSETURN], a
 ; temporarily change the target pokemon's move to $00 and the effect to the one
 ; that causes the attack modifier to go up one stage
-	ld h,b
-	ld l,c
-	ld [hl],$00 ; null move number
+	ld h, b
+	ld l, c
+	ld [hl], $00 ; null move number
 	inc hl
-	ld [hl],ATTACK_UP1_EFFECT
+	ld [hl], ATTACK_UP1_EFFECT
 	push hl
-	ld hl,BuildingRageText
+	ld hl, BuildingRageText
 	call PrintText
 	call StatModifierUpEffect ; stat modifier raising function
 	pop hl
 	xor a
-	ldd [hl],a ; null move effect
-	ld a,RAGE
-	ld [hl],a ; restore the target pokemon's move number to Rage
-	ld a,[H_WHOSETURN]
-	xor a,$01 ; flip turn back to the way it was
-	ld [H_WHOSETURN],a
+	ldd [hl], a ; null move effect
+	ld a, RAGE
+	ld [hl], a ; restore the target pokemon's move number to Rage
+	ld a, [H_WHOSETURN]
+	xor $01 ; flip turn back to the way it was
+	ld [H_WHOSETURN], a
 	ret
 
 BuildingRageText:
@@ -5176,25 +5176,25 @@ MirrorMoveCopyMove:
 ; ccf1 is also set to 0 whenever the player is fast asleep or frozen solid.
 ; ccf2 is also set to 0 whenever the enemy is fast asleep or frozen solid.
 
-	ld a,[H_WHOSETURN]
+	ld a, [H_WHOSETURN]
 	and a
 ; values for player turn
-	ld a,[wEnemyUsedMove]
-	ld hl,wPlayerSelectedMove
-	ld de,wPlayerMoveNum
-	jr z,.next
+	ld a, [wEnemyUsedMove]
+	ld hl, wPlayerSelectedMove
+	ld de, wPlayerMoveNum
+	jr z, .next
 ; values for enemy turn
-	ld a,[wPlayerUsedMove]
-	ld de,wEnemyMoveNum
-	ld hl,wEnemySelectedMove
+	ld a, [wPlayerUsedMove]
+	ld de, wEnemyMoveNum
+	ld hl, wEnemySelectedMove
 .next
-	ld [hl],a
-	cp a,MIRROR_MOVE ; did the target Pokemon last use Mirror Move, and miss?
-	jr z,.mirrorMoveFailed
+	ld [hl], a
+	cp MIRROR_MOVE ; did the target Pokemon last use Mirror Move, and miss?
+	jr z, .mirrorMoveFailed
 	and a ; has the target selected any move yet?
-	jr nz,ReloadMoveData
+	jr nz, ReloadMoveData
 .mirrorMoveFailed
-	ld hl,MirrorMoveFailedText
+	ld hl, MirrorMoveFailedText
 	call PrintText
 	xor a
 	ret
@@ -5205,78 +5205,78 @@ MirrorMoveFailedText:
 
 ; function used to reload move data for moves like Mirror Move and Metronome
 ReloadMoveData:
-	ld [wd11e],a
+	ld [wd11e], a
 	dec a
-	ld hl,Moves
-	ld bc,MoveEnd - Moves
+	ld hl, Moves
+	ld bc, MoveEnd - Moves
 	call AddNTimes
-	ld a,BANK(Moves)
+	ld a, BANK(Moves)
 	call FarCopyData ; copy the move's stats
 	call IncrementMovePP
 ; the follow two function calls are used to reload the move name
 	call GetMoveName
 	call CopyStringToCF4B
-	ld a,$01
+	ld a, $01
 	and a
 	ret
 
 ; function that picks a random move for metronome
 MetronomePickMove:
 	xor a
-	ld [wAnimationType],a
-	ld a,METRONOME
+	ld [wAnimationType], a
+	ld a, METRONOME
 	call PlayMoveAnimation ; play Metronome's animation
 ; values for player turn
-	ld de,wPlayerMoveNum
-	ld hl,wPlayerSelectedMove
-	ld a,[H_WHOSETURN]
+	ld de, wPlayerMoveNum
+	ld hl, wPlayerSelectedMove
+	ld a, [H_WHOSETURN]
 	and a
-	jr z,.pickMoveLoop
+	jr z, .pickMoveLoop
 ; values for enemy turn
-	ld de,wEnemyMoveNum
-	ld hl,wEnemySelectedMove
+	ld de, wEnemyMoveNum
+	ld hl, wEnemySelectedMove
 ; loop to pick a random number in the range [1, $a5) to be the move used by Metronome
 .pickMoveLoop
 	call BattleRandom
 	and a
-	jr z,.pickMoveLoop
-	cp a,NUM_ATTACKS + 1 ; max normal move number + 1 (this is Struggle's move number)
-	jr nc,.pickMoveLoop
-	cp a,METRONOME
-	jr z,.pickMoveLoop
-	ld [hl],a
+	jr z, .pickMoveLoop
+	cp NUM_ATTACKS + 1 ; max normal move number + 1 (this is Struggle's move number)
+	jr nc, .pickMoveLoop
+	cp METRONOME
+	jr z, .pickMoveLoop
+	ld [hl], a
 	jr ReloadMoveData
 
 ; this function increments the current move's PP
 ; it's used to prevent moves that run another move within the same turn
 ; (like Mirror Move and Metronome) from losing 2 PP
 IncrementMovePP:
-	ld a,[H_WHOSETURN]
+	ld a, [H_WHOSETURN]
 	and a
 ; values for player turn
-	ld hl,wBattleMonPP
-	ld de,wPartyMon1PP
-	ld a,[wPlayerMoveListIndex]
-	jr z,.next
+	ld hl, wBattleMonPP
+	ld de, wPartyMon1PP
+	ld a, [wPlayerMoveListIndex]
+	jr z, .next
 ; values for enemy turn
-	ld hl,wEnemyMonPP
-	ld de,wEnemyMon1PP
-	ld a,[wEnemyMoveListIndex]
+	ld hl, wEnemyMonPP
+	ld de, wEnemyMon1PP
+	ld a, [wEnemyMoveListIndex]
 .next
-	ld b,$00
-	ld c,a
-	add hl,bc
+	ld b, $00
+	ld c, a
+	add hl, bc
 	inc [hl] ; increment PP in the currently battling pokemon memory location
-	ld h,d
-	ld l,e
-	add hl,bc
-	ld a,[H_WHOSETURN]
+	ld h, d
+	ld l, e
+	add hl, bc
+	ld a, [H_WHOSETURN]
 	and a
-	ld a,[wPlayerMonNumber] ; value for player turn
-	jr z,.updatePP
-	ld a,[wEnemyMonPartyPos] ; value for enemy turn
+	ld a, [wPlayerMonNumber] ; value for player turn
+	jr z, .updatePP
+	ld a, [wEnemyMonPartyPos] ; value for enemy turn
 .updatePP
-	ld bc,wEnemyMon2 - wEnemyMon1
+	ld bc, wEnemyMon2 - wEnemyMon1
 	call AddNTimes
 	inc [hl] ; increment PP in the party memory location
 	ret
@@ -5284,107 +5284,107 @@ IncrementMovePP:
 ; function to adjust the base damage of an attack to account for type effectiveness
 AdjustDamageForMoveType:
 ; values for player turn
-	ld hl,wBattleMonType
-	ld a,[hli]
-	ld b,a    ; b = type 1 of attacker
-	ld c,[hl] ; c = type 2 of attacker
-	ld hl,wEnemyMonType
-	ld a,[hli]
-	ld d,a    ; d = type 1 of defender
-	ld e,[hl] ; e = type 2 of defender
-	ld a,[wPlayerMoveType]
-	ld [wMoveType],a
-	ld a,[H_WHOSETURN]
+	ld hl, wBattleMonType
+	ld a, [hli]
+	ld b, a    ; b = type 1 of attacker
+	ld c, [hl] ; c = type 2 of attacker
+	ld hl, wEnemyMonType
+	ld a, [hli]
+	ld d, a    ; d = type 1 of defender
+	ld e, [hl] ; e = type 2 of defender
+	ld a, [wPlayerMoveType]
+	ld [wMoveType], a
+	ld a, [H_WHOSETURN]
 	and a
-	jr z,.next
+	jr z, .next
 ; values for enemy turn
-	ld hl,wEnemyMonType
-	ld a,[hli]
-	ld b,a    ; b = type 1 of attacker
-	ld c,[hl] ; c = type 2 of attacker
-	ld hl,wBattleMonType
-	ld a,[hli]
-	ld d,a    ; d = type 1 of defender
-	ld e,[hl] ; e = type 2 of defender
-	ld a,[wEnemyMoveType]
-	ld [wMoveType],a
+	ld hl, wEnemyMonType
+	ld a, [hli]
+	ld b, a    ; b = type 1 of attacker
+	ld c, [hl] ; c = type 2 of attacker
+	ld hl, wBattleMonType
+	ld a, [hli]
+	ld d, a    ; d = type 1 of defender
+	ld e, [hl] ; e = type 2 of defender
+	ld a, [wEnemyMoveType]
+	ld [wMoveType], a
 .next
-	ld a,[wMoveType]
+	ld a, [wMoveType]
 	cp b ; does the move type match type 1 of the attacker?
-	jr z,.sameTypeAttackBonus
+	jr z, .sameTypeAttackBonus
 	cp c ; does the move type match type 2 of the attacker?
-	jr z,.sameTypeAttackBonus
+	jr z, .sameTypeAttackBonus
 	jr .skipSameTypeAttackBonus
 .sameTypeAttackBonus
 ; if the move type matches one of the attacker's types
-	ld hl,wDamage + 1
-	ld a,[hld]
-	ld h,[hl]
-	ld l,a    ; hl = damage
-	ld b,h
-	ld c,l    ; bc = damage
+	ld hl, wDamage + 1
+	ld a, [hld]
+	ld h, [hl]
+	ld l, a    ; hl = damage
+	ld b, h
+	ld c, l    ; bc = damage
 	srl b
 	rr c      ; bc = floor(0.5 * damage)
-	add hl,bc ; hl = floor(1.5 * damage)
+	add hl, bc ; hl = floor(1.5 * damage)
 ; store damage
-	ld a,h
-	ld [wDamage],a
-	ld a,l
-	ld [wDamage + 1],a
-	ld hl,wDamageMultipliers
-	set 7,[hl]
+	ld a, h
+	ld [wDamage], a
+	ld a, l
+	ld [wDamage + 1], a
+	ld hl, wDamageMultipliers
+	set 7, [hl]
 .skipSameTypeAttackBonus
-	ld a,[wMoveType]
-	ld b,a
-	ld hl,TypeEffects
+	ld a, [wMoveType]
+	ld b, a
+	ld hl, TypeEffects
 .loop
-	ld a,[hli] ; a = "attacking type" of the current type pair
-	cp a,$ff
-	jr z,.done
+	ld a, [hli] ; a = "attacking type" of the current type pair
+	cp $ff
+	jr z, .done
 	cp b ; does move type match "attacking type"?
-	jr nz,.nextTypePair
-	ld a,[hl] ; a = "defending type" of the current type pair
+	jr nz, .nextTypePair
+	ld a, [hl] ; a = "defending type" of the current type pair
 	cp d ; does type 1 of defender match "defending type"?
-	jr z,.matchingPairFound
+	jr z, .matchingPairFound
 	cp e ; does type 2 of defender match "defending type"?
-	jr z,.matchingPairFound
+	jr z, .matchingPairFound
 	jr .nextTypePair
 .matchingPairFound
 ; if the move type matches the "attacking type" and one of the defender's types matches the "defending type"
 	push hl
 	push bc
 	inc hl
-	ld a,[wDamageMultipliers]
-	and a,$80
-	ld b,a
-	ld a,[hl] ; a = damage multiplier
-	ld [H_MULTIPLIER],a
+	ld a, [wDamageMultipliers]
+	and $80
+	ld b, a
+	ld a, [hl] ; a = damage multiplier
+	ld [H_MULTIPLIER], a
 	add b
-	ld [wDamageMultipliers],a
+	ld [wDamageMultipliers], a
 	xor a
-	ld [H_MULTIPLICAND],a
-	ld hl,wDamage
-	ld a,[hli]
-	ld [H_MULTIPLICAND + 1],a
-	ld a,[hld]
-	ld [H_MULTIPLICAND + 2],a
+	ld [H_MULTIPLICAND], a
+	ld hl, wDamage
+	ld a, [hli]
+	ld [H_MULTIPLICAND + 1], a
+	ld a, [hld]
+	ld [H_MULTIPLICAND + 2], a
 	call Multiply
-	ld a,10
-	ld [H_DIVISOR],a
-	ld b,$04
+	ld a, 10
+	ld [H_DIVISOR], a
+	ld b, $04
 	call Divide
-	ld a,[H_QUOTIENT + 2]
-	ld [hli],a
-	ld b,a
-	ld a,[H_QUOTIENT + 3]
-	ld [hl],a
+	ld a, [H_QUOTIENT + 2]
+	ld [hli], a
+	ld b, a
+	ld a, [H_QUOTIENT + 3]
+	ld [hl], a
 	or b ; is damage 0?
-	jr nz,.skipTypeImmunity
+	jr nz, .skipTypeImmunity
 .typeImmunity
 ; if damage is 0, make the move miss
 ; this only occurs if a move that would do 2 or 3 damage is 0.25x effective against the target
 	inc a
-	ld [wMoveMissed],a
+	ld [wMoveMissed], a
 .skipTypeImmunity
 	pop bc
 	pop hl
@@ -5402,26 +5402,26 @@ AdjustDamageForMoveType:
 ; ($05 is not very effective, $10 is neutral, $14 is super effective)
 ; as far is can tell, this is only used once in some AI code to help decide which move to use
 AIGetTypeEffectiveness:
-	ld a,[wEnemyMoveType]
-	ld d,a                    ; d = type of enemy move
-	ld hl,wBattleMonType
-	ld b,[hl]                 ; b = type 1 of player's pokemon
+	ld a, [wEnemyMoveType]
+	ld d, a                    ; d = type of enemy move
+	ld hl, wBattleMonType
+	ld b, [hl]                 ; b = type 1 of player's pokemon
 	inc hl
-	ld c,[hl]                 ; c = type 2 of player's pokemon
-	ld a,$10
-	ld [wTypeEffectiveness],a ; initialize to neutral effectiveness
-	ld hl,TypeEffects
+	ld c, [hl]                 ; c = type 2 of player's pokemon
+	ld a, $10
+	ld [wTypeEffectiveness], a ; initialize to neutral effectiveness
+	ld hl, TypeEffects
 .loop
-	ld a,[hli]
-	cp a,$ff
+	ld a, [hli]
+	cp $ff
 	ret z
 	cp d                      ; match the type of the move
-	jr nz,.nextTypePair1
-	ld a,[hli]
+	jr nz, .nextTypePair1
+	ld a, [hli]
 	cp b                      ; match with type 1 of pokemon
-	jr z,.done
+	jr z, .done
 	cp c                      ; or match with type 2 of pokemon
-	jr z,.done
+	jr z, .done
 	jr .nextTypePair2
 .nextTypePair1
 	inc hl
@@ -5429,8 +5429,8 @@ AIGetTypeEffectiveness:
 	inc hl
 	jr .loop
 .done
-	ld a,[hl]
-	ld [wTypeEffectiveness],a ; store damage multiplier
+	ld a, [hl]
+	ld [wTypeEffectiveness], a ; store damage multiplier
 	ret
 
 INCLUDE "data/type_effects.asm"
@@ -5438,52 +5438,52 @@ INCLUDE "data/type_effects.asm"
 ; some tests that need to pass for a move to hit
 MoveHitTest:
 ; player's turn
-	ld hl,wEnemyBattleStatus1
-	ld de,wPlayerMoveEffect
-	ld bc,wEnemyMonStatus
-	ld a,[H_WHOSETURN]
+	ld hl, wEnemyBattleStatus1
+	ld de, wPlayerMoveEffect
+	ld bc, wEnemyMonStatus
+	ld a, [H_WHOSETURN]
 	and a
-	jr z,.dreamEaterCheck
+	jr z, .dreamEaterCheck
 ; enemy's turn
-	ld hl,wPlayerBattleStatus1
-	ld de,wEnemyMoveEffect
-	ld bc,wBattleMonStatus
+	ld hl, wPlayerBattleStatus1
+	ld de, wEnemyMoveEffect
+	ld bc, wBattleMonStatus
 .dreamEaterCheck
-	ld a,[de]
-	cp a,DREAM_EATER_EFFECT
-	jr nz,.swiftCheck
-	ld a,[bc]
-	and a,SLP ; is the target pokemon sleeping?
-	jp z,.moveMissed
+	ld a, [de]
+	cp DREAM_EATER_EFFECT
+	jr nz, .swiftCheck
+	ld a, [bc]
+	and SLP ; is the target pokemon sleeping?
+	jp z, .moveMissed
 .swiftCheck
-	ld a,[de]
-	cp a,SWIFT_EFFECT
+	ld a, [de]
+	cp SWIFT_EFFECT
 	ret z ; Swift never misses (interestingly, Azure Heights lists this is a myth, but it appears to be true)
 	call CheckTargetSubstitute ; substitute check (note that this overwrites a)
-	jr z,.checkForDigOrFlyStatus
+	jr z, .checkForDigOrFlyStatus
 ; this code is buggy. it's supposed to prevent HP draining moves from working on substitutes.
 ; since $7b79 overwrites a with either $00 or $01, it never works.
-	cp a,DRAIN_HP_EFFECT
-	jp z,.moveMissed
-	cp a,DREAM_EATER_EFFECT
-	jp z,.moveMissed
+	cp DRAIN_HP_EFFECT
+	jp z, .moveMissed
+	cp DREAM_EATER_EFFECT
+	jp z, .moveMissed
 .checkForDigOrFlyStatus
-	bit INVULNERABLE,[hl]
-	jp nz,.moveMissed
-	ld a,[H_WHOSETURN]
+	bit INVULNERABLE, [hl]
+	jp nz, .moveMissed
+	ld a, [H_WHOSETURN]
 	and a
-	jr nz,.enemyTurn
+	jr nz, .enemyTurn
 .playerTurn
 ; this checks if the move effect is disallowed by mist
-	ld a,[wPlayerMoveEffect]
-	cp a,ATTACK_DOWN1_EFFECT
-	jr c,.skipEnemyMistCheck
-	cp a,HAZE_EFFECT + 1
-	jr c,.enemyMistCheck
-	cp a,ATTACK_DOWN2_EFFECT
-	jr c,.skipEnemyMistCheck
-	cp a,REFLECT_EFFECT + 1
-	jr c,.enemyMistCheck
+	ld a, [wPlayerMoveEffect]
+	cp ATTACK_DOWN1_EFFECT
+	jr c, .skipEnemyMistCheck
+	cp HAZE_EFFECT + 1
+	jr c, .enemyMistCheck
+	cp ATTACK_DOWN2_EFFECT
+	jr c, .skipEnemyMistCheck
+	cp REFLECT_EFFECT + 1
+	jr c, .enemyMistCheck
 	jr .skipEnemyMistCheck
 .enemyMistCheck
 ; if move effect is from $12 to $19 inclusive or $3a to $41 inclusive
@@ -5492,98 +5492,98 @@ MoveHitTest:
 ; FLASH, CONVERSION*, HAZE*, SCREECH, LIGHT SCREEN*, REFLECT*
 ; the moves that are marked with an asterisk are not affected since this
 ; function is not called when those moves are used
-	ld a,[wEnemyBattleStatus2]
-	bit PROTECTED_BY_MIST,a ; is mon protected by mist?
-	jp nz,.moveMissed
+	ld a, [wEnemyBattleStatus2]
+	bit PROTECTED_BY_MIST, a ; is mon protected by mist?
+	jp nz, .moveMissed
 .skipEnemyMistCheck
-	ld a,[wPlayerBattleStatus2]
-	bit USING_X_ACCURACY,a ; is the player using X Accuracy?
+	ld a, [wPlayerBattleStatus2]
+	bit USING_X_ACCURACY, a ; is the player using X Accuracy?
 	ret nz ; if so, always hit regardless of accuracy/evasion
 	jr .calcHitChance
 .enemyTurn
-	ld a,[wEnemyMoveEffect]
-	cp a,ATTACK_DOWN1_EFFECT
-	jr c,.skipPlayerMistCheck
-	cp a,HAZE_EFFECT + 1
-	jr c,.playerMistCheck
-	cp a,ATTACK_DOWN2_EFFECT
-	jr c,.skipPlayerMistCheck
-	cp a,REFLECT_EFFECT + 1
-	jr c,.playerMistCheck
+	ld a, [wEnemyMoveEffect]
+	cp ATTACK_DOWN1_EFFECT
+	jr c, .skipPlayerMistCheck
+	cp HAZE_EFFECT + 1
+	jr c, .playerMistCheck
+	cp ATTACK_DOWN2_EFFECT
+	jr c, .skipPlayerMistCheck
+	cp REFLECT_EFFECT + 1
+	jr c, .playerMistCheck
 	jr .skipPlayerMistCheck
 .playerMistCheck
 ; similar to enemy mist check
-	ld a,[wPlayerBattleStatus2]
-	bit PROTECTED_BY_MIST,a ; is mon protected by mist?
-	jp nz,.moveMissed
+	ld a, [wPlayerBattleStatus2]
+	bit PROTECTED_BY_MIST, a ; is mon protected by mist?
+	jp nz, .moveMissed
 .skipPlayerMistCheck
-	ld a,[wEnemyBattleStatus2]
-	bit USING_X_ACCURACY,a ; is the enemy using X Accuracy?
+	ld a, [wEnemyBattleStatus2]
+	bit USING_X_ACCURACY, a ; is the enemy using X Accuracy?
 	ret nz ; if so, always hit regardless of accuracy/evasion
 .calcHitChance
 	call CalcHitChance ; scale the move accuracy according to attacker's accuracy and target's evasion
-	ld a,[wPlayerMoveAccuracy]
-	ld b,a
-	ld a,[H_WHOSETURN]
+	ld a, [wPlayerMoveAccuracy]
+	ld b, a
+	ld a, [H_WHOSETURN]
 	and a
-	jr z,.doAccuracyCheck
-	ld a,[wEnemyMoveAccuracy]
-	ld b,a
+	jr z, .doAccuracyCheck
+	ld a, [wEnemyMoveAccuracy]
+	ld b, a
 .doAccuracyCheck
 ; if the random number generated is greater than or equal to the scaled accuracy, the move misses
 ; note that this means that even the highest accuracy is still just a 255/256 chance, not 100%
 	call BattleRandom
 	cp b
-	jr nc,.moveMissed
+	jr nc, .moveMissed
 	ret
 .moveMissed
 	xor a
-	ld hl,wDamage ; zero the damage
-	ld [hli],a
-	ld [hl],a
+	ld hl, wDamage ; zero the damage
+	ld [hli], a
+	ld [hl], a
 	inc a
-	ld [wMoveMissed],a
-	ld a,[H_WHOSETURN]
+	ld [wMoveMissed], a
+	ld a, [H_WHOSETURN]
 	and a
-	jr z,.playerTurn2
+	jr z, .playerTurn2
 .enemyTurn2
-	ld hl,wEnemyBattleStatus1
-	res USING_TRAPPING_MOVE,[hl] ; end multi-turn attack e.g. wrap
+	ld hl, wEnemyBattleStatus1
+	res USING_TRAPPING_MOVE, [hl] ; end multi-turn attack e.g. wrap
 	ret
 .playerTurn2
-	ld hl,wPlayerBattleStatus1
-	res USING_TRAPPING_MOVE,[hl] ; end multi-turn attack e.g. wrap
+	ld hl, wPlayerBattleStatus1
+	res USING_TRAPPING_MOVE, [hl] ; end multi-turn attack e.g. wrap
 	ret
 
 ; values for player turn
 CalcHitChance:
-	ld hl,wPlayerMoveAccuracy
-	ld a,[H_WHOSETURN]
+	ld hl, wPlayerMoveAccuracy
+	ld a, [H_WHOSETURN]
 	and a
-	ld a,[wPlayerMonAccuracyMod]
-	ld b,a
-	ld a,[wEnemyMonEvasionMod]
-	ld c,a
-	jr z,.next
+	ld a, [wPlayerMonAccuracyMod]
+	ld b, a
+	ld a, [wEnemyMonEvasionMod]
+	ld c, a
+	jr z, .next
 ; values for enemy turn
-	ld hl,wEnemyMoveAccuracy
-	ld a,[wEnemyMonAccuracyMod]
-	ld b,a
-	ld a,[wPlayerMonEvasionMod]
-	ld c,a
+	ld hl, wEnemyMoveAccuracy
+	ld a, [wEnemyMonAccuracyMod]
+	ld b, a
+	ld a, [wPlayerMonEvasionMod]
+	ld c, a
 .next
-	ld a,$0e
+	ld a, $0e
 	sub c
-	ld c,a ; c = 14 - EVASIONMOD (this "reflects" the value over 7, so that an increase in the target's evasion
+	ld c, a ; c = 14 - EVASIONMOD (this "reflects" the value over 7, so that an increase in the target's evasion
 	       ; decreases the hit chance instead of increasing the hit chance)
 ; zero the high bytes of the multiplicand
 	xor a
-	ld [H_MULTIPLICAND],a
-	ld [H_MULTIPLICAND + 1],a
-	ld a,[hl]
-	ld [H_MULTIPLICAND + 2],a ; set multiplicand to move accuracy
+	ld [H_MULTIPLICAND], a
+	ld [H_MULTIPLICAND + 1], a
+	ld a, [hl]
+	ld [H_MULTIPLICAND + 2], a ; set multiplicand to move accuracy
 	push hl
-	ld d,$02 ; loop has two iterations
+	ld d, $02 ; loop has two iterations
 ; loop to do the calculations, the first iteration multiplies by the accuracy ratio and
 ; the second iteration multiplies by the evasion ratio
 .loop
@@ -5591,40 +5591,40 @@ CalcHitChance:
 	ld hl, StatModifierRatios  ; stat modifier ratios
 	dec b
 	sla b
-	ld c,b
-	ld b,$00
-	add hl,bc ; hl = address of stat modifier ratio
+	ld c, b
+	ld b, $00
+	add hl, bc ; hl = address of stat modifier ratio
 	pop bc
-	ld a,[hli]
-	ld [H_MULTIPLIER],a ; set multiplier to the numerator of the ratio
+	ld a, [hli]
+	ld [H_MULTIPLIER], a ; set multiplier to the numerator of the ratio
 	call Multiply
-	ld a,[hl]
-	ld [H_DIVISOR],a ; set divisor to the the denominator of the ratio
+	ld a, [hl]
+	ld [H_DIVISOR], a ; set divisor to the the denominator of the ratio
 	                 ; (the dividend is the product of the previous multiplication)
-	ld b,$04 ; number of bytes in the dividend
+	ld b, $04 ; number of bytes in the dividend
 	call Divide
-	ld a,[H_QUOTIENT + 3]
-	ld b,a
-	ld a,[H_QUOTIENT + 2]
+	ld a, [H_QUOTIENT + 3]
+	ld b, a
+	ld a, [H_QUOTIENT + 2]
 	or b
-	jp nz,.nextCalculation
+	jp nz, .nextCalculation
 ; make sure the result is always at least one
-	ld [H_QUOTIENT + 2],a
-	ld a,$01
-	ld [H_QUOTIENT + 3],a
+	ld [H_QUOTIENT + 2], a
+	ld a, $01
+	ld [H_QUOTIENT + 3], a
 .nextCalculation
-	ld b,c
+	ld b, c
 	dec d
-	jr nz,.loop
-	ld a,[H_QUOTIENT + 2]
+	jr nz, .loop
+	ld a, [H_QUOTIENT + 2]
 	and a ; is the calculated hit chance over 0xFF?
-	ld a,[H_QUOTIENT + 3]
-	jr z,.storeAccuracy
+	ld a, [H_QUOTIENT + 3]
+	jr z, .storeAccuracy
 ; if calculated hit chance over 0xFF
-	ld a,$ff ; set the hit chance to 0xFF
+	ld a, $ff ; set the hit chance to 0xFF
 .storeAccuracy
 	pop hl
-	ld [hl],a ; store the hit chance in the move accuracy variable
+	ld [hl], a ; store the hit chance in the move accuracy variable
 	ret
 
 ; multiplies damage by a random percentage from ~85% to 100%
@@ -5805,7 +5805,7 @@ EnemyCheckIfFlyOrChargeEffect:
 .playAnim
 	xor a
 	ld [wAnimationType], a
-	ld a,STATUS_AFFECTED_ANIM
+	ld a, STATUS_AFFECTED_ANIM
 	call PlayMoveAnimation
 EnemyCheckIfMirrorMoveEffect:
 	ld a, [wEnemyMoveEffect]
@@ -5897,7 +5897,7 @@ CheckEnemyStatusConditions:
 	call PrintText
 	xor a
 	ld [wAnimationType], a
-	ld a,SLP_ANIM
+	ld a, SLP_ANIM
 	call PlayMoveAnimation
 	jr .sleepDone
 .wokeUp
@@ -5973,7 +5973,7 @@ CheckEnemyStatusConditions:
 	call PrintText
 	xor a
 	ld [wAnimationType], a
-	ld a,CONF_ANIM
+	ld a, CONF_ANIM
 	call PlayMoveAnimation
 	call BattleRandom
 	cp $80
@@ -6830,7 +6830,7 @@ HandleExplodingAnimation:
 	ld [wAnimationType], a
 
 PlayMoveAnimation:
-	ld [wAnimationID],a
+	ld [wAnimationID], a
 	call Delay3
 	predef_jump MoveAnimation
 
@@ -7417,11 +7417,11 @@ FreezeBurnParalyzeEffect:
 	cp b ; do target type 2 and move type match?
 	ret z  ; return if they match
 	ld a, [wPlayerMoveEffect]
-	cp a, PARALYZE_SIDE_EFFECT1 + 1 ; 10% status effects are 04, 05, 06 so 07 will set carry for those
+	cp PARALYZE_SIDE_EFFECT1 + 1 ; 10% status effects are 04, 05, 06 so 07 will set carry for those
 	ld b, $1a ; 0x1A/0x100 or 26/256 = 10.2%~ chance
 	jr c, .next1 ; branch ahead if this is a 10% chance effect..
 	ld b, $4d ; else use 0x4D/0x100 or 77/256 = 30.1%~ chance
-	sub a, $1e ; subtract $1E to map to equivalent 10% chance effects
+	sub $1e ; subtract $1E to map to equivalent 10% chance effects
 .next1
 	push af
 	call BattleRandom ; get random 8bit value for probability test
@@ -7429,9 +7429,9 @@ FreezeBurnParalyzeEffect:
 	pop bc
 	ret nc ; do nothing if random value is >= 1A or 4D [no status applied]
 	ld a, b ; what type of effect is this?
-	cp a, BURN_SIDE_EFFECT1
+	cp BURN_SIDE_EFFECT1
 	jr z, .burn
-	cp a, FREEZE_SIDE_EFFECT
+	cp FREEZE_SIDE_EFFECT
 	jr z, .freeze
 ; .paralyze
 	ld a, 1 << PAR
@@ -7469,11 +7469,11 @@ opponentAttacker:
 	cp b
 	ret z
 	ld a, [wEnemyMoveEffect]
-	cp a, PARALYZE_SIDE_EFFECT1 + 1
+	cp PARALYZE_SIDE_EFFECT1 + 1
 	ld b, $1a
 	jr c, .next1
 	ld b, $4d
-	sub a, $1e
+	sub $1e
 .next1
 	push af
 	call BattleRandom
@@ -7481,9 +7481,9 @@ opponentAttacker:
 	pop bc
 	ret nc
 	ld a, b
-	cp a, BURN_SIDE_EFFECT1
+	cp BURN_SIDE_EFFECT1
 	jr z, .burn
-	cp a, FREEZE_SIDE_EFFECT
+	cp FREEZE_SIDE_EFFECT
 	jr z, .freeze
 	ld a, 1 << PAR
 	ld [wBattleMonStatus], a
@@ -7512,14 +7512,14 @@ FrozenText:
 
 CheckDefrost:
 ; any fire-type move that has a chance inflict burn (all but Fire Spin) will defrost a frozen target
-	and a, 1 << FRZ ; are they frozen?
+	and 1 << FRZ ; are they frozen?
 	ret z ; return if so
 	ld a, [H_WHOSETURN]
 	and a
 	jr nz, .opponent
 	;player [attacker]
 	ld a, [wPlayerMoveType]
-	sub a, FIRE
+	sub FIRE
 	ret nz ; return if type of move used isn't fire
 	ld [wEnemyMonStatus], a ; set opponent status to 00 ["defrost" a frozen monster]
 	ld hl, wEnemyMon1Status
@@ -7532,7 +7532,7 @@ CheckDefrost:
 	jr .common
 .opponent
 	ld a, [wEnemyMoveType] ; same as above with addresses swapped
-	sub a, FIRE
+	sub FIRE
 	ret nz
 	ld [wBattleMonStatus], a
 	ld hl, wPartyMon1Status

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -381,15 +381,15 @@ MainInBattleLoop:
 	xor a
 	ld [wFirstMonsNotOutYet], a
 	ld a, [wPlayerBattleStatus2]
-	and (1 << NeedsToRecharge) | (1 << UsingRage) ; check if the player is using Rage or needs to recharge
+	and (1 << NEEDS_TO_RECHARGE) | (1 << USING_RAGE) ; check if the player is using Rage or needs to recharge
 	jr nz, .selectEnemyMove
 ; the player is not using Rage and doesn't need to recharge
 	ld hl, wEnemyBattleStatus1
-	res Flinched, [hl] ; reset flinch bit
+	res FLINCHED, [hl] ; reset flinch bit
 	ld hl, wPlayerBattleStatus1
-	res Flinched, [hl] ; reset flinch bit
+	res FLINCHED, [hl] ; reset flinch bit
 	ld a, [hl]
-	and (1 << ThrashingAbout) | (1 << ChargingUp) ; check if the player is thrashing about or charging for an attack
+	and (1 << THRASHING_ABOUT) | (1 << CHARGING_UP) ; check if the player is thrashing about or charging for an attack
 	jr nz, .selectEnemyMove ; if so, jump
 ; the player is neither thrashing about nor charging for an attack
 	call DisplayBattleMenu ; show battle menu
@@ -401,10 +401,10 @@ MainInBattleLoop:
 	and (1 << FRZ) | SLP ; is mon frozen or asleep?
 	jr nz, .selectEnemyMove ; if so, jump
 	ld a, [wPlayerBattleStatus1]
-	and (1 << StoringEnergy) | (1 << UsingTrappingMove) ; check player is using Bide or using a multi-turn attack like wrap
+	and (1 << STORING_ENERGY) | (1 << USING_TRAPPING_MOVE) ; check player is using Bide or using a multi-turn attack like wrap
 	jr nz, .selectEnemyMove ; if so, jump
 	ld a, [wEnemyBattleStatus1]
-	bit UsingTrappingMove, a ; check if enemy is using a multi-turn attack like wrap
+	bit USING_TRAPPING_MOVE, a ; check if enemy is using a multi-turn attack like wrap
 	jr z, .selectPlayerMove ; if not, jump
 ; enemy is using a multi-turn attack like wrap, so player is trapped and cannot execute a move
 	ld a, $ff
@@ -442,7 +442,7 @@ MainInBattleLoop:
 	jr c, .noLinkBattle
 ; the link battle enemy has switched mons
 	ld a, [wPlayerBattleStatus1]
-	bit UsingTrappingMove, a ; check if using multi-turn move like Wrap
+	bit USING_TRAPPING_MOVE, a ; check if using multi-turn move like Wrap
 	jr z, .specialMoveNotUsed
 	ld a, [wPlayerMoveListIndex]
 	ld hl, wBattleMonMoves
@@ -667,7 +667,7 @@ HandlePoisonBurnLeechSeed_DecreaseOwnHP:
 	ld hl, wEnemyBattleStatus3
 	ld de, wEnemyToxicCounter
 .playersTurn
-	bit BadlyPoisoned, [hl]
+	bit BADLY_POISONED, [hl]
 	jr z, .noToxic
 	ld a, [de]    ; increment toxic counter
 	inc a
@@ -776,14 +776,14 @@ CheckNumAttacksLeft:
 	jr nz, .checkEnemy
 ; player has 0 attacks left
 	ld hl, wPlayerBattleStatus1
-	res UsingTrappingMove, [hl] ; player not using multi-turn attack like wrap any more
+	res USING_TRAPPING_MOVE, [hl] ; player not using multi-turn attack like wrap any more
 .checkEnemy
 	ld a, [wEnemyNumAttacksLeft]
 	and a
 	ret nz
 ; enemy has 0 attacks left
 	ld hl, wEnemyBattleStatus1
-	res UsingTrappingMove, [hl] ; enemy not using multi-turn attack like wrap any more
+	res USING_TRAPPING_MOVE, [hl] ; enemy not using multi-turn attack like wrap any more
 	ret
 
 HandleEnemyMonFainted:
@@ -833,7 +833,7 @@ FaintEnemyPokemon:
 	ld [hl], a
 .wild
 	ld hl, wPlayerBattleStatus1
-	res AttackingMultipleTimes, [hl]
+	res ATTACKING_MULTIPLE_TIMES, [hl]
 ; Bug. This only zeroes the high byte of the player's accumulated damage,
 ; setting the accumulated damage to itself mod 256 instead of 0 as was probably
 ; intended. That alone is problematic, but this mistake has another more severe
@@ -1842,7 +1842,7 @@ SendOutMon:
 	ld b, SET_PAL_BATTLE
 	call RunPaletteCommand
 	ld hl, wEnemyBattleStatus1
-	res UsingTrappingMove, [hl]
+	res USING_TRAPPING_MOVE, [hl]
 	ld a, $1
 	ld [H_WHOSETURN], a
 	ld a, POOF_ANIM
@@ -2343,13 +2343,13 @@ UseBagItem:
 	jp z, BagWasSelected ; if not, go back to the bag menu
 
 	ld a, [wPlayerBattleStatus1]
-	bit UsingTrappingMove, a ; is the player using a multi-turn move like wrap?
+	bit USING_TRAPPING_MOVE, a ; is the player using a multi-turn move like wrap?
 	jr z, .checkIfMonCaptured
 	ld hl, wPlayerNumAttacksLeft
 	dec [hl]
 	jr nz, .checkIfMonCaptured
 	ld hl, wPlayerBattleStatus1
-	res UsingTrappingMove, [hl] ; not using multi-turn move any more
+	res USING_TRAPPING_MOVE, [hl] ; not using multi-turn move any more
 
 .checkIfMonCaptured
 	ld a, [wCapturedMonSpecies]
@@ -2456,7 +2456,7 @@ PartyMenuOrRockOrRun:
 	predef StatusScreen2
 ; now we need to reload the enemy mon pic
 	ld a, [wEnemyBattleStatus2]
-	bit HasSubstituteUp, a ; does the enemy mon have a substitute?
+	bit HAS_SUBSTITUTE_UP, a ; does the enemy mon have a substitute?
 	ld hl, AnimationSubstitute
 	jr nz, .doEnemyMonAnimation
 ; enemy mon doesn't have substitute
@@ -3014,20 +3014,20 @@ SelectEnemyMove:
 	jr .done
 .noLinkBattle
 	ld a, [wEnemyBattleStatus2]
-	and (1 << NeedsToRecharge) | (1 << UsingRage) ; need to recharge or using rage
+	and (1 << NEEDS_TO_RECHARGE) | (1 << USING_RAGE) ; need to recharge or using rage
 	ret nz
 	ld hl, wEnemyBattleStatus1
 	ld a, [hl]
-	and (1 << ChargingUp) | (1 << ThrashingAbout) ; using a charging move or thrash/petal dance
+	and (1 << CHARGING_UP) | (1 << THRASHING_ABOUT) ; using a charging move or thrash/petal dance
 	ret nz
 	ld a, [wEnemyMonStatus]
 	and SLP | 1 << FRZ ; sleeping or frozen
 	ret nz
 	ld a, [wEnemyBattleStatus1]
-	and (1 << UsingTrappingMove) | (1 << StoringEnergy) ; using a trapping move like wrap or bide
+	and (1 << USING_TRAPPING_MOVE) | (1 << STORING_ENERGY) ; using a trapping move like wrap or bide
 	ret nz
 	ld a, [wPlayerBattleStatus1]
-	bit UsingTrappingMove, a ; caught in player's trapping move (e.g. wrap)
+	bit USING_TRAPPING_MOVE, a ; caught in player's trapping move (e.g. wrap)
 	jr z, .canSelectMove
 .unableToSelectMove
 	ld a, $ff
@@ -3154,7 +3154,7 @@ ExecutePlayerMove:
 .playerHasNoSpecialCondition
 	call GetCurrentMove
 	ld hl, wPlayerBattleStatus1
-	bit ChargingUp, [hl] ; charging up for attack
+	bit CHARGING_UP, [hl] ; charging up for attack
 	jr nz, PlayerCanExecuteChargingMove
 	call CheckForDisobedience
 	jp z, ExecutePlayerMoveDone
@@ -3170,10 +3170,10 @@ CheckIfPlayerNeedsToChargeUp:
 ; in-battle stuff
 PlayerCanExecuteChargingMove:
 	ld hl,wPlayerBattleStatus1
-	res ChargingUp,[hl] ; reset charging up and invulnerability statuses if mon was charging up for an attack
+	res CHARGING_UP,[hl] ; reset charging up and invulnerability statuses if mon was charging up for an attack
 	                    ; being fully paralyzed or hurting oneself in confusion removes charging up status
 	                    ; resulting in the Pokemon being invulnerable for the whole battle
-	res Invulnerable,[hl]
+	res INVULNERABLE,[hl]
 PlayerCanExecuteMove:
 	call PrintMonName1Text
 	ld hl,DecrementPP
@@ -3225,7 +3225,7 @@ getPlayerAnimationType:
 playPlayerMoveAnimation:
 	push af
 	ld a,[wPlayerBattleStatus2]
-	bit HasSubstituteUp,a
+	bit HAS_SUBSTITUTE_UP,a
 	ld hl,HideSubstituteShowMonAnim
 	ld b,BANK(HideSubstituteShowMonAnim)
 	call nz,Bankswitch
@@ -3236,7 +3236,7 @@ playPlayerMoveAnimation:
 	call HandleExplodingAnimation
 	call DrawPlayerHUDAndHPBar
 	ld a,[wPlayerBattleStatus2]
-	bit HasSubstituteUp,a
+	bit HAS_SUBSTITUTE_UP,a
 	ld hl,ReshowSubstituteAnim
 	ld b,BANK(ReshowSubstituteAnim)
 	call nz,Bankswitch
@@ -3303,14 +3303,14 @@ MirrorMoveCheck:
 	call HandleBuildingRage
 
 	ld hl,wPlayerBattleStatus1
-	bit AttackingMultipleTimes,[hl]
+	bit ATTACKING_MULTIPLE_TIMES,[hl]
 	jr z,.executeOtherEffects
 	ld a,[wPlayerNumAttacksLeft]
 	dec a
 	ld [wPlayerNumAttacksLeft],a
 	jp nz,getPlayerAnimationType ; for multi-hit moves, apply attack until PlayerNumAttacksLeft hits 0 or the enemy faints.
 	                             ; damage calculation and accuracy tests only happen for the first hit
-	res AttackingMultipleTimes,[hl] ; clear attacking multiple times status when all attacks are over
+	res ATTACKING_MULTIPLE_TIMES,[hl] ; clear attacking multiple times status when all attacks are over
 	ld hl,MultiHitText
 	call PrintText
 	xor a
@@ -3424,7 +3424,7 @@ CheckPlayerStatusConditions:
 
 .HeldInPlaceCheck
 	ld a,[wEnemyBattleStatus1]
-	bit UsingTrappingMove,a ; is enemy using a mult-turn move like wrap?
+	bit USING_TRAPPING_MOVE,a ; is enemy using a mult-turn move like wrap?
 	jp z,.FlinchedCheck
 	ld hl,CantMoveText
 	call PrintText
@@ -3433,9 +3433,9 @@ CheckPlayerStatusConditions:
 
 .FlinchedCheck
 	ld hl,wPlayerBattleStatus1
-	bit Flinched,[hl]
+	bit FLINCHED,[hl]
 	jp z,.HyperBeamCheck
-	res Flinched,[hl] ; reset player's flinch status
+	res FLINCHED,[hl] ; reset player's flinch status
 	ld hl,FlinchedText
 	call PrintText
 	ld hl,ExecutePlayerMoveDone ; player can't move this turn
@@ -3443,9 +3443,9 @@ CheckPlayerStatusConditions:
 
 .HyperBeamCheck
 	ld hl,wPlayerBattleStatus2
-	bit NeedsToRecharge,[hl]
+	bit NEEDS_TO_RECHARGE,[hl]
 	jr z,.AnyMoveDisabledCheck
-	res NeedsToRecharge,[hl] ; reset player's recharge status
+	res NEEDS_TO_RECHARGE,[hl] ; reset player's recharge status
 	ld hl,MustRechargeText
 	call PrintText
 	ld hl,ExecutePlayerMoveDone ; player can't move this turn
@@ -3473,7 +3473,7 @@ CheckPlayerStatusConditions:
 	dec [hl]
 	jr nz,.IsConfused
 	ld hl,wPlayerBattleStatus1
-	res Confused,[hl] ; if confused counter hit 0, reset confusion status
+	res CONFUSED,[hl] ; if confused counter hit 0, reset confusion status
 	ld hl,ConfusedNoMoreText
 	call PrintText
 	jr .TriedToUseDisabledMoveCheck
@@ -3489,7 +3489,7 @@ CheckPlayerStatusConditions:
 	jr c,.TriedToUseDisabledMoveCheck
 	ld hl,wPlayerBattleStatus1
 	ld a,[hl]
-	and a, 1 << Confused ; if mon hurts itself, clear every other status from wPlayerBattleStatus1
+	and a, 1 << CONFUSED ; if mon hurts itself, clear every other status from wPlayerBattleStatus1
 	ld [hl],a
 	call HandleSelfConfusionDamage
 	jr .MonHurtItselfOrFullyParalysed
@@ -3520,7 +3520,7 @@ CheckPlayerStatusConditions:
 	ld hl,wPlayerBattleStatus1
 	ld a,[hl]
 	; clear bide, thrashing, charging up, and trapping moves such as warp (already cleared for confusion damage)
-	and $ff ^ ((1 << StoringEnergy) | (1 << ThrashingAbout) | (1 << ChargingUp) | (1 << UsingTrappingMove))
+	and $ff ^ ((1 << STORING_ENERGY) | (1 << THRASHING_ABOUT) | (1 << CHARGING_UP) | (1 << USING_TRAPPING_MOVE))
 	ld [hl],a
 	ld a,[wPlayerMoveEffect]
 	cp a,FLY_EFFECT
@@ -3540,7 +3540,7 @@ CheckPlayerStatusConditions:
 
 .BideCheck
 	ld hl,wPlayerBattleStatus1
-	bit StoringEnergy,[hl] ; is mon using bide?
+	bit STORING_ENERGY,[hl] ; is mon using bide?
 	jr z,.ThrashingAboutCheck
 	xor a
 	ld [wPlayerMoveNum],a
@@ -3562,7 +3562,7 @@ CheckPlayerStatusConditions:
 	jp .returnToHL ; unless mon unleashes energy, can't move this turn
 .UnleashEnergy
 	ld hl,wPlayerBattleStatus1
-	res StoringEnergy,[hl] ; not using bide any more
+	res STORING_ENERGY,[hl] ; not using bide any more
 	ld hl,UnleashedEnergyText
 	call PrintText
 	ld a,1
@@ -3589,7 +3589,7 @@ CheckPlayerStatusConditions:
 	jp .returnToHL
 
 .ThrashingAboutCheck
-	bit ThrashingAbout,[hl] ; is mon using thrash or petal dance?
+	bit THRASHING_ABOUT,[hl] ; is mon using thrash or petal dance?
 	jr z,.MultiturnMoveCheck
 	ld a,THRASH
 	ld [wPlayerMoveNum],a
@@ -3601,8 +3601,8 @@ CheckPlayerStatusConditions:
 	jp nz,.returnToHL
 	push hl
 	ld hl,wPlayerBattleStatus1
-	res ThrashingAbout,[hl] ; no longer thrashing about
-	set Confused,[hl] ; confused
+	res THRASHING_ABOUT,[hl] ; no longer thrashing about
+	set CONFUSED,[hl] ; confused
 	call BattleRandom
 	and a,3
 	inc a
@@ -3612,7 +3612,7 @@ CheckPlayerStatusConditions:
 	jp .returnToHL
 
 .MultiturnMoveCheck
-	bit UsingTrappingMove,[hl] ; is mon using multi-turn move?
+	bit USING_TRAPPING_MOVE,[hl] ; is mon using multi-turn move?
 	jp z,.RageCheck
 	ld hl,AttackContinuesText
 	call PrintText
@@ -3626,7 +3626,7 @@ CheckPlayerStatusConditions:
 
 .RageCheck
 	ld a, [wPlayerBattleStatus2]
-	bit UsingRage, a ; is mon using rage?
+	bit USING_RAGE, a ; is mon using rage?
 	jp z, .checkPlayerStatusConditionsDone ; if we made it this far, mon can move normally this turn
 	ld a, RAGE
 	ld [wd11e], a
@@ -3716,7 +3716,7 @@ PrintMoveIsDisabledText:
 	ld de, wEnemyBattleStatus1
 .removeChargingUp
 	ld a, [de]
-	res ChargingUp, a ; end the pokemon's
+	res CHARGING_UP, a ; end the pokemon's
 	ld [de], a
 	ld a, [hl]
 	ld [wd11e], a
@@ -4250,7 +4250,7 @@ GetDamageVarsForPlayerAttack:
 	ld b, a
 	ld c, [hl] ; bc = enemy defense
 	ld a, [wEnemyBattleStatus3]
-	bit HasReflectUp, a ; check for Reflect
+	bit HAS_REFLECT_UP, a ; check for Reflect
 	jr z, .physicalAttackCritCheck
 ; if the enemy has used Reflect, double the enemy's defense
 	sla c
@@ -4280,7 +4280,7 @@ GetDamageVarsForPlayerAttack:
 	ld b, a
 	ld c, [hl] ; bc = enemy special
 	ld a, [wEnemyBattleStatus3]
-	bit HasLightScreenUp, a ; check for Light Screen
+	bit HAS_LIGHT_SCREEN_UP, a ; check for Light Screen
 	jr z, .specialAttackCritCheck
 ; if the enemy has used Light Screen, double the enemy's special
 	sla c
@@ -4363,7 +4363,7 @@ GetDamageVarsForEnemyAttack:
 	ld b, a
 	ld c, [hl] ; bc = player defense
 	ld a, [wPlayerBattleStatus3]
-	bit HasReflectUp, a ; check for Reflect
+	bit HAS_REFLECT_UP, a ; check for Reflect
 	jr z, .physicalAttackCritCheck
 ; if the player has used Reflect, double the player's defense
 	sla c
@@ -4393,7 +4393,7 @@ GetDamageVarsForEnemyAttack:
 	ld b, a
 	ld c, [hl]
 	ld a, [wPlayerBattleStatus3]
-	bit HasLightScreenUp, a ; check for Light Screen
+	bit HAS_LIGHT_SCREEN_UP, a ; check for Light Screen
 	jr z, .specialAttackCritCheck
 ; if the player has used Light Screen, double the player's special
 	sla c
@@ -4707,7 +4707,7 @@ CriticalHitTest:
 	dec hl
 	ld c, [hl]                   ; read move id
 	ld a, [de]
-	bit GettingPumped, a         ; test for focus energy
+	bit GETTING_PUMPED, a         ; test for focus energy
 	jr nz, .focusEnergyUsed      ; bug: using focus energy causes a shift to the right instead of left,
 	                             ; resulting in 1/4 the usual crit chance
 	sla b                        ; (effective (base speed/2)*2)
@@ -4894,7 +4894,7 @@ ApplyDamageToEnemyPokemon:
 	or b
 	jr z,ApplyAttackToEnemyPokemonDone ; we're done if damage is 0
 	ld a,[wEnemyBattleStatus2]
-	bit HasSubstituteUp,a ; does the enemy have a substitute?
+	bit HAS_SUBSTITUTE_UP,a ; does the enemy have a substitute?
 	jp nz,AttackSubstitute
 ; subtract the damage from the pokemon's current HP
 ; also, save the current HP at wHPBarOldHP
@@ -5013,7 +5013,7 @@ ApplyDamageToPlayerPokemon:
 	or b
 	jr z,ApplyAttackToPlayerPokemonDone ; we're done if damage is 0
 	ld a,[wPlayerBattleStatus2]
-	bit HasSubstituteUp,a ; does the player have a substitute?
+	bit HAS_SUBSTITUTE_UP,a ; does the player have a substitute?
 	jp nz,AttackSubstitute
 ; subtract the damage from the pokemon's current HP
 ; also, save the current HP at wHPBarOldHP and the new HP at wHPBarNewHP
@@ -5091,7 +5091,7 @@ AttackSubstitute:
 ; the Substitute had before being attacked.
 	ld h,b
 	ld l,c
-	res HasSubstituteUp,[hl] ; unset the substitute bit
+	res HAS_SUBSTITUTE_UP,[hl] ; unset the substitute bit
 	ld hl,SubstituteBrokeText
 	call PrintText
 ; flip whose turn it is for the next function call
@@ -5134,7 +5134,7 @@ HandleBuildingRage:
 	ld de,wPlayerMonStatMods
 	ld bc,wPlayerMoveNum
 .next
-	bit UsingRage,[hl] ; is the pokemon being attacked under the effect of Rage?
+	bit USING_RAGE,[hl] ; is the pokemon being attacked under the effect of Rage?
 	ret z ; return if not
 	ld a,[de]
 	cp a,$0d ; maximum stat modifier value
@@ -5468,7 +5468,7 @@ MoveHitTest:
 	cp a,DREAM_EATER_EFFECT
 	jp z,.moveMissed
 .checkForDigOrFlyStatus
-	bit Invulnerable,[hl]
+	bit INVULNERABLE,[hl]
 	jp nz,.moveMissed
 	ld a,[H_WHOSETURN]
 	and a
@@ -5493,11 +5493,11 @@ MoveHitTest:
 ; the moves that are marked with an asterisk are not affected since this
 ; function is not called when those moves are used
 	ld a,[wEnemyBattleStatus2]
-	bit ProtectedByMist,a ; is mon protected by mist?
+	bit PROTECTED_BY_MIST,a ; is mon protected by mist?
 	jp nz,.moveMissed
 .skipEnemyMistCheck
 	ld a,[wPlayerBattleStatus2]
-	bit UsingXAccuracy,a ; is the player using X Accuracy?
+	bit USING_X_ACCURACY,a ; is the player using X Accuracy?
 	ret nz ; if so, always hit regardless of accuracy/evasion
 	jr .calcHitChance
 .enemyTurn
@@ -5514,11 +5514,11 @@ MoveHitTest:
 .playerMistCheck
 ; similar to enemy mist check
 	ld a,[wPlayerBattleStatus2]
-	bit ProtectedByMist,a ; is mon protected by mist?
+	bit PROTECTED_BY_MIST,a ; is mon protected by mist?
 	jp nz,.moveMissed
 .skipPlayerMistCheck
 	ld a,[wEnemyBattleStatus2]
-	bit UsingXAccuracy,a ; is the enemy using X Accuracy?
+	bit USING_X_ACCURACY,a ; is the enemy using X Accuracy?
 	ret nz ; if so, always hit regardless of accuracy/evasion
 .calcHitChance
 	call CalcHitChance ; scale the move accuracy according to attacker's accuracy and target's evasion
@@ -5548,11 +5548,11 @@ MoveHitTest:
 	jr z,.playerTurn2
 .enemyTurn2
 	ld hl,wEnemyBattleStatus1
-	res UsingTrappingMove,[hl] ; end multi-turn attack e.g. wrap
+	res USING_TRAPPING_MOVE,[hl] ; end multi-turn attack e.g. wrap
 	ret
 .playerTurn2
 	ld hl,wPlayerBattleStatus1
-	res UsingTrappingMove,[hl] ; end multi-turn attack e.g. wrap
+	res USING_TRAPPING_MOVE,[hl] ; end multi-turn attack e.g. wrap
 	ret
 
 ; values for player turn
@@ -5693,7 +5693,7 @@ ExecuteEnemyMove:
 	jp hl
 .enemyHasNoSpecialConditions
 	ld hl, wEnemyBattleStatus1
-	bit ChargingUp, [hl] ; is the enemy charging up for attack?
+	bit CHARGING_UP, [hl] ; is the enemy charging up for attack?
 	jr nz, EnemyCanExecuteChargingMove ; if so, jump
 	call GetCurrentMove
 
@@ -5706,8 +5706,8 @@ CheckIfEnemyNeedsToChargeUp:
 	jr EnemyCanExecuteMove
 EnemyCanExecuteChargingMove:
 	ld hl, wEnemyBattleStatus1
-	res ChargingUp, [hl] ; no longer charging up for attack
-	res Invulnerable, [hl] ; no longer invulnerable to typical attacks
+	res CHARGING_UP, [hl] ; no longer charging up for attack
+	res INVULNERABLE, [hl] ; no longer invulnerable to typical attacks
 	ld a, [wEnemyMoveNum]
 	ld [wd0b5], a
 	ld a, BANK(MoveNames)
@@ -5775,7 +5775,7 @@ handleExplosionMiss:
 playEnemyMoveAnimation:
 	push af
 	ld a, [wEnemyBattleStatus2]
-	bit HasSubstituteUp, a ; does mon have a substitute?
+	bit HAS_SUBSTITUTE_UP, a ; does mon have a substitute?
 	ld hl, HideSubstituteShowMonAnim
 	ld b, BANK(HideSubstituteShowMonAnim)
 	call nz, Bankswitch
@@ -5786,7 +5786,7 @@ playEnemyMoveAnimation:
 	call HandleExplodingAnimation
 	call DrawEnemyHUDAndHPBar
 	ld a, [wEnemyBattleStatus2]
-	bit HasSubstituteUp, a ; does mon have a substitute?
+	bit HAS_SUBSTITUTE_UP, a ; does mon have a substitute?
 	ld hl, ReshowSubstituteAnim
 	ld b, BANK(ReshowSubstituteAnim)
 	call nz, Bankswitch ; slide the substitute's sprite out
@@ -5852,14 +5852,14 @@ EnemyCheckIfMirrorMoveEffect:
 	ret z
 	call HandleBuildingRage
 	ld hl, wEnemyBattleStatus1
-	bit AttackingMultipleTimes, [hl] ; is mon hitting multiple times? (example: double kick)
+	bit ATTACKING_MULTIPLE_TIMES, [hl] ; is mon hitting multiple times? (example: double kick)
 	jr z, .notMultiHitMove
 	push hl
 	ld hl, wEnemyNumAttacksLeft
 	dec [hl]
 	pop hl
 	jp nz, GetEnemyAnimationType
-	res AttackingMultipleTimes, [hl] ; mon is no longer hitting multiple times
+	res ATTACKING_MULTIPLE_TIMES, [hl] ; mon is no longer hitting multiple times
 	ld hl, HitXTimesText
 	call PrintText
 	xor a
@@ -5919,7 +5919,7 @@ CheckEnemyStatusConditions:
 	jp .enemyReturnToHL
 .checkIfTrapped
 	ld a, [wPlayerBattleStatus1]
-	bit UsingTrappingMove, a ; is the player using a multi-turn attack like warp
+	bit USING_TRAPPING_MOVE, a ; is the player using a multi-turn attack like warp
 	jp z, .checkIfFlinched
 	ld hl, CantMoveText
 	call PrintText
@@ -5927,18 +5927,18 @@ CheckEnemyStatusConditions:
 	jp .enemyReturnToHL
 .checkIfFlinched
 	ld hl, wEnemyBattleStatus1
-	bit Flinched, [hl] ; check if enemy mon flinched
+	bit FLINCHED, [hl] ; check if enemy mon flinched
 	jp z, .checkIfMustRecharge
-	res Flinched, [hl]
+	res FLINCHED, [hl]
 	ld hl, FlinchedText
 	call PrintText
 	ld hl, ExecuteEnemyMoveDone ; enemy can't move this turn
 	jp .enemyReturnToHL
 .checkIfMustRecharge
 	ld hl, wEnemyBattleStatus2
-	bit NeedsToRecharge, [hl] ; check if enemy mon has to recharge after using a move
+	bit NEEDS_TO_RECHARGE, [hl] ; check if enemy mon has to recharge after using a move
 	jr z, .checkIfAnyMoveDisabled
-	res NeedsToRecharge, [hl]
+	res NEEDS_TO_RECHARGE, [hl]
 	ld hl, MustRechargeText
 	call PrintText
 	ld hl, ExecuteEnemyMoveDone ; enemy can't move this turn
@@ -5964,7 +5964,7 @@ CheckEnemyStatusConditions:
 	dec [hl]
 	jr nz, .isConfused
 	ld hl, wEnemyBattleStatus1
-	res Confused, [hl] ; if confused counter hit 0, reset confusion status
+	res CONFUSED, [hl] ; if confused counter hit 0, reset confusion status
 	ld hl, ConfusedNoMoreText
 	call PrintText
 	jp .checkIfTriedToUseDisabledMove
@@ -5980,7 +5980,7 @@ CheckEnemyStatusConditions:
 	jr c, .checkIfTriedToUseDisabledMove
 	ld hl, wEnemyBattleStatus1
 	ld a, [hl]
-	and 1 << Confused ; if mon hurts itself, clear every other status from wEnemyBattleStatus1
+	and 1 << CONFUSED ; if mon hurts itself, clear every other status from wEnemyBattleStatus1
 	ld [hl], a
 	ld hl, HurtItselfText
 	call PrintText
@@ -6047,7 +6047,7 @@ CheckEnemyStatusConditions:
 	ld hl, wEnemyBattleStatus1
 	ld a, [hl]
 	; clear bide, thrashing about, charging up, and multi-turn moves such as warp
-	and $ff ^ ((1 << StoringEnergy) | (1 << ThrashingAbout) | (1 << ChargingUp) | (1 << UsingTrappingMove))
+	and $ff ^ ((1 << STORING_ENERGY) | (1 << THRASHING_ABOUT) | (1 << CHARGING_UP) | (1 << USING_TRAPPING_MOVE))
 	ld [hl], a
 	ld a, [wEnemyMoveEffect]
 	cp FLY_EFFECT
@@ -6065,7 +6065,7 @@ CheckEnemyStatusConditions:
 	jp .enemyReturnToHL ; if using a two-turn move, enemy needs to recharge the first turn
 .checkIfUsingBide
 	ld hl, wEnemyBattleStatus1
-	bit StoringEnergy, [hl] ; is mon using bide?
+	bit STORING_ENERGY, [hl] ; is mon using bide?
 	jr z, .checkIfThrashingAbout
 	xor a
 	ld [wEnemyMoveNum], a
@@ -6087,7 +6087,7 @@ CheckEnemyStatusConditions:
 	jp .enemyReturnToHL ; unless mon unleashes energy, can't move this turn
 .unleashEnergy
 	ld hl, wEnemyBattleStatus1
-	res StoringEnergy, [hl] ; not using bide any more
+	res STORING_ENERGY, [hl] ; not using bide any more
 	ld hl, UnleashedEnergyText
 	call PrintText
 	ld a, $1
@@ -6114,7 +6114,7 @@ CheckEnemyStatusConditions:
 	ld hl, handleIfEnemyMoveMissed ; skip damage calculation, DecrementPP and MoveHitTest
 	jp .enemyReturnToHL
 .checkIfThrashingAbout
-	bit ThrashingAbout, [hl] ; is mon using thrash or petal dance?
+	bit THRASHING_ABOUT, [hl] ; is mon using thrash or petal dance?
 	jr z, .checkIfUsingMultiturnMove
 	ld a, THRASH
 	ld [wEnemyMoveNum], a
@@ -6126,8 +6126,8 @@ CheckEnemyStatusConditions:
 	jp nz, .enemyReturnToHL
 	push hl
 	ld hl, wEnemyBattleStatus1
-	res ThrashingAbout, [hl] ; mon is no longer using thrash or petal dance
-	set Confused, [hl] ; mon is now confused
+	res THRASHING_ABOUT, [hl] ; mon is no longer using thrash or petal dance
+	set CONFUSED, [hl] ; mon is now confused
 	call BattleRandom
 	and $3
 	inc a
@@ -6136,7 +6136,7 @@ CheckEnemyStatusConditions:
 	pop hl ; skip DecrementPP
 	jp .enemyReturnToHL
 .checkIfUsingMultiturnMove
-	bit UsingTrappingMove, [hl] ; is mon using multi-turn move?
+	bit USING_TRAPPING_MOVE, [hl] ; is mon using multi-turn move?
 	jp z, .checkIfUsingRage
 	ld hl, AttackContinuesText
 	call PrintText
@@ -6148,7 +6148,7 @@ CheckEnemyStatusConditions:
 	jp .enemyReturnToHL
 .checkIfUsingRage
 	ld a, [wEnemyBattleStatus2]
-	bit UsingRage, a ; is mon using rage?
+	bit USING_RAGE, a ; is mon using rage?
 	jp z, .checkEnemyStatusConditionsDone ; if we made it this far, mon can move normally this turn
 	ld a, RAGE
 	ld [wd11e], a
@@ -6206,7 +6206,7 @@ LoadEnemyMonData:
 	ld [wd0b5], a
 	call GetMonHeader
 	ld a, [wEnemyBattleStatus3]
-	bit Transformed, a ; is enemy mon transformed?
+	bit TRANSFORMED, a ; is enemy mon transformed?
 	ld hl, wTransformedEnemyMonOriginalDVs ; original DVs before transforming
 	ld a, [hli]
 	ld b, [hl]
@@ -6238,7 +6238,7 @@ LoadEnemyMonData:
 	cp $2 ; is it a trainer battle?
 	jr z, .copyHPAndStatusFromPartyData
 	ld a, [wEnemyBattleStatus3]
-	bit Transformed, a ; is enemy mon transformed?
+	bit TRANSFORMED, a ; is enemy mon transformed?
 	jr nz, .copyTypes ; if transformed, jump
 ; if it's a wild mon and not transformed, init the current HP to max HP and the status to 0
 	ld a, [wEnemyMonMaxHP]
@@ -6815,7 +6815,7 @@ HandleExplodingAnimation:
 	ret nz
 .isExplodingMove
 	ld a, [de]
-	bit Invulnerable, a ; fly/dig
+	bit INVULNERABLE, a ; fly/dig
 	ret nz
 	ld a, [hli]
 	cp GHOST
@@ -7240,8 +7240,8 @@ SleepEffect:
 
 .sleepEffect
 	ld a, [bc]
-	bit NeedsToRecharge, a ; does the target need to recharge? (hyper beam)
-	res NeedsToRecharge, a ; target no longer needs to recharge
+	bit NEEDS_TO_RECHARGE, a ; does the target need to recharge? (hyper beam)
+	res NEEDS_TO_RECHARGE, a ; target no longer needs to recharge
 	ld [bc], a
 	jr nz, .setSleepCounter ; if the target had to recharge, all hit tests will be skipped
 	                        ; including the event where the target already has another status
@@ -7340,7 +7340,7 @@ PoisonEffect:
 .ok
 	cp TOXIC
 	jr nz, .normalPoison ; done if move is not Toxic
-	set BadlyPoisoned, [hl] ; else set Toxic battstatus
+	set BADLY_POISONED, [hl] ; else set Toxic battstatus
 	xor a
 	ld [de], a
 	ld hl, BadlyPoisonedText
@@ -7393,7 +7393,7 @@ ExplodeEffect:
 	inc hl
 	ld [hl], a ; set mon's status to 0
 	ld a, [de]
-	res Seeded, a ; clear mon's leech seed status
+	res SEEDED, a ; clear mon's leech seed status
 	ld [de], a
 	ret
 
@@ -7673,7 +7673,7 @@ UpdateStatDone:
 	jr nz, .asm_3f4f9
  ; if a substitute is up, slide off the substitute and show the mon pic before
  ; playing the minimize animation
-	bit HasSubstituteUp, [hl]
+	bit HAS_SUBSTITUTE_UP, [hl]
 	push af
 	push bc
 	ld hl, HideSubstituteShowMonAnim
@@ -7776,7 +7776,7 @@ StatModifierDownEffect:
 	and a
 	jp nz, MoveMissed
 	ld a, [bc]
-	bit Invulnerable, a ; fly/dig
+	bit INVULNERABLE, a ; fly/dig
 	jp nz, MoveMissed
 	ld a, [de]
 	sub ATTACK_DOWN1_EFFECT
@@ -7992,7 +7992,7 @@ BideEffect:
 	ld de, wEnemyBideAccumulatedDamage
 	ld bc, wEnemyNumAttacksLeft
 .bideEffect
-	set StoringEnergy, [hl] ; mon is now using bide
+	set STORING_ENERGY, [hl] ; mon is now using bide
 	xor a
 	ld [de], a
 	inc de
@@ -8017,7 +8017,7 @@ ThrashPetalDanceEffect:
 	ld hl, wEnemyBattleStatus1
 	ld de, wEnemyNumAttacksLeft
 .thrashPetalDanceEffect
-	set ThrashingAbout, [hl] ; mon is now using thrash/petal dance
+	set THRASHING_ABOUT, [hl] ; mon is now using thrash/petal dance
 	call BattleRandom
 	and $1
 	inc a
@@ -8153,9 +8153,9 @@ TwoToFiveAttacksEffect:
 	ld de, wEnemyNumAttacksLeft
 	ld bc, wEnemyNumHits
 .twoToFiveAttacksEffect
-	bit AttackingMultipleTimes, [hl] ; is mon attacking multiple times?
+	bit ATTACKING_MULTIPLE_TIMES, [hl] ; is mon attacking multiple times?
 	ret nz
-	set AttackingMultipleTimes, [hl] ; mon is now attacking multiple times
+	set ATTACKING_MULTIPLE_TIMES, [hl] ; mon is now attacking multiple times
 	ld hl, wPlayerMoveEffect
 	ld a, [H_WHOSETURN]
 	and a
@@ -8208,7 +8208,7 @@ FlinchSideEffect:
 	call BattleRandom
 	cp b
 	ret nc
-	set Flinched, [hl] ; set mon's status to flinching
+	set FLINCHED, [hl] ; set mon's status to flinching
 	call ClearHyperBeam
 	ret
 
@@ -8226,18 +8226,18 @@ ChargeEffect:
 	ld de, wEnemyMoveEffect
 	ld b, ANIM_AF
 .chargeEffect
-	set ChargingUp, [hl]
+	set CHARGING_UP, [hl]
 	ld a, [de]
 	dec de ; de contains enemy or player MOVENUM
 	cp FLY_EFFECT
 	jr nz, .notFly
-	set Invulnerable, [hl] ; mon is now invulnerable to typical attacks (fly/dig)
+	set INVULNERABLE, [hl] ; mon is now invulnerable to typical attacks (fly/dig)
 	ld b, TELEPORT ; load Teleport's animation
 .notFly
 	ld a, [de]
 	cp DIG
 	jr nz, .notDigOrFly
-	set Invulnerable, [hl] ; mon is now invulnerable to typical attacks (fly/dig)
+	set INVULNERABLE, [hl] ; mon is now invulnerable to typical attacks (fly/dig)
 	ld b, ANIM_C0
 .notDigOrFly
 	xor a
@@ -8306,11 +8306,11 @@ TrappingEffect:
 	ld hl, wEnemyBattleStatus1
 	ld de, wEnemyNumAttacksLeft
 .trappingEffect
-	bit UsingTrappingMove, [hl]
+	bit USING_TRAPPING_MOVE, [hl]
 	ret nz
 	call ClearHyperBeam ; since this effect is called before testing whether the move will hit,
                         ; the target won't need to recharge even if the trapping move missed
-	set UsingTrappingMove, [hl] ; mon is now using a trapping move
+	set USING_TRAPPING_MOVE, [hl] ; mon is now using a trapping move
 	call BattleRandom ; 3/8 chance for 2 and 3 attacks, and 1/8 chance for 4 and 5 attacks
 	and $3
 	cp $2
@@ -8356,9 +8356,9 @@ ConfusionSideEffectSuccess:
 	ld bc, wPlayerConfusedCounter
 	ld a, [wEnemyMoveEffect]
 .confuseTarget
-	bit Confused, [hl] ; is mon confused?
+	bit CONFUSED, [hl] ; is mon confused?
 	jr nz, ConfusionEffectFailed
-	set Confused, [hl] ; mon is now confused
+	set CONFUSED, [hl] ; mon is now confused
 	push af
 	call BattleRandom
 	and $3
@@ -8395,7 +8395,7 @@ HyperBeamEffect:
 	jr z, .hyperBeamEffect
 	ld hl, wEnemyBattleStatus2
 .hyperBeamEffect
-	set NeedsToRecharge, [hl] ; mon now needs to recharge
+	set NEEDS_TO_RECHARGE, [hl] ; mon now needs to recharge
 	ret
 
 ClearHyperBeam:
@@ -8406,7 +8406,7 @@ ClearHyperBeam:
 	jr z, .playerTurn
 	ld hl, wPlayerBattleStatus2
 .playerTurn
-	res NeedsToRecharge, [hl] ; mon no longer needs to recharge
+	res NEEDS_TO_RECHARGE, [hl] ; mon no longer needs to recharge
 	pop hl
 	ret
 
@@ -8417,7 +8417,7 @@ RageEffect:
 	jr z, .player
 	ld hl, wEnemyBattleStatus2
 .player
-	set UsingRage, [hl] ; mon is now in "rage" mode
+	set USING_RAGE, [hl] ; mon is now in "rage" mode
 	ret
 
 MimicEffect:
@@ -8438,7 +8438,7 @@ MimicEffect:
 	ld hl, wEnemyMonMoves
 	ld a, [wEnemyBattleStatus1]
 .enemyTurn
-	bit Invulnerable, a
+	bit INVULNERABLE, a
 	jr nz, .mimicMissed
 .getRandomMove
 	push hl
@@ -8462,7 +8462,7 @@ MimicEffect:
 	jr .playerTurn
 .letPlayerChooseMove
 	ld a, [wEnemyBattleStatus1]
-	bit Invulnerable, a
+	bit INVULNERABLE, a
 	jr nz, .mimicMissed
 	ld a, [wCurrentMenuItem]
 	push af
@@ -8661,7 +8661,7 @@ CheckTargetSubstitute:
 	jr z, .next1
 	ld hl, wPlayerBattleStatus2
 .next1
-	bit HasSubstituteUp, [hl]
+	bit HAS_SUBSTITUTE_UP, [hl]
 	pop hl
 	ret
 

--- a/engine/battle/decrement_pp.asm
+++ b/engine/battle/decrement_pp.asm
@@ -1,13 +1,13 @@
 DecrementPP:
 ; after using a move, decrement pp in battle and (if not transformed?) in party
 	ld a, [de]
-	cp a, STRUGGLE
+	cp STRUGGLE
 	ret z                ; if the pokemon is using "struggle", there's nothing to do
 	                     ; we don't decrement PP for "struggle"
 	ld hl, wPlayerBattleStatus1
 	ld a, [hli]          ; load the wPlayerBattleStatus1 pokemon status flags and increment hl to load the
 	                     ; wPlayerBattleStatus2 status flags later
-	and a, (1 << STORING_ENERGY) | (1 << THRASHING_ABOUT) | (1 << ATTACKING_MULTIPLE_TIMES)
+	and (1 << STORING_ENERGY) | (1 << THRASHING_ABOUT) | (1 << ATTACKING_MULTIPLE_TIMES)
 	ret nz               ; if any of these statuses are true, don't decrement PP
 	bit USING_RAGE, [hl]
 	ret nz               ; don't decrement PP either if Pokemon is using Rage

--- a/engine/battle/decrement_pp.asm
+++ b/engine/battle/decrement_pp.asm
@@ -7,9 +7,9 @@ DecrementPP:
 	ld hl, wPlayerBattleStatus1
 	ld a, [hli]          ; load the wPlayerBattleStatus1 pokemon status flags and increment hl to load the
 	                     ; wPlayerBattleStatus2 status flags later
-	and a, (1 << StoringEnergy) | (1 << ThrashingAbout) | (1 << AttackingMultipleTimes)
+	and a, (1 << STORING_ENERGY) | (1 << THRASHING_ABOUT) | (1 << ATTACKING_MULTIPLE_TIMES)
 	ret nz               ; if any of these statuses are true, don't decrement PP
-	bit UsingRage, [hl]
+	bit USING_RAGE, [hl]
 	ret nz               ; don't decrement PP either if Pokemon is using Rage
 	ld hl, wBattleMonPP  ; PP of first move (in battle)
 
@@ -18,7 +18,7 @@ DecrementPP:
 
 ; decrement PP in the party struct
 	ld a, [wPlayerBattleStatus3]
-	bit Transformed, a
+	bit TRANSFORMED, a
 	ret nz               ; Return if transformed. Pokemon Red stores the "current pokemon's" PP
 	                     ; separately from the "Pokemon in your party's" PP.  This is
 	                     ; duplication -- in all cases *other* than Pokemon with Transform.

--- a/engine/battle/display_effectiveness.asm
+++ b/engine/battle/display_effectiveness.asm
@@ -1,7 +1,7 @@
 DisplayEffectiveness:
 	ld a, [wDamageMultipliers]
-	and a, $7F
-	cp a, $0A
+	and $7F
+	cp $0A
 	ret z
 	ld hl, SuperEffectiveText
 	jr nc, .done

--- a/engine/battle/moveEffects/conversion_effect.asm
+++ b/engine/battle/moveEffects/conversion_effect.asm
@@ -11,7 +11,7 @@ ConversionEffect_:
 	pop de
 	ld a, [wPlayerBattleStatus1]
 .conversionEffect
-	bit Invulnerable, a ; is mon immune to typical attacks (dig/fly)
+	bit INVULNERABLE, a ; is mon immune to typical attacks (dig/fly)
 	jr nz, PrintButItFailedText
 ; copy target's types to user
 	ld a, [hli]

--- a/engine/battle/moveEffects/focus_energy_effect.asm
+++ b/engine/battle/moveEffects/focus_energy_effect.asm
@@ -5,9 +5,9 @@ FocusEnergyEffect_:
 	jr z, .notEnemy
 	ld hl, wEnemyBattleStatus2
 .notEnemy
-	bit GettingPumped, [hl] ; is mon already using focus energy?
+	bit GETTING_PUMPED, [hl] ; is mon already using focus energy?
 	jr nz, .alreadyUsing
-	set GettingPumped, [hl] ; mon is now using focus energy
+	set GETTING_PUMPED, [hl] ; mon is now using focus energy
 	callab PlayCurrentMoveAnimation
 	ld hl, GettingPumpedText
 	jp PrintText

--- a/engine/battle/moveEffects/haze_effect.asm
+++ b/engine/battle/moveEffects/haze_effect.asm
@@ -47,14 +47,14 @@ HazeEffect_:
 	jp PrintText
 
 CureVolatileStatuses:
-	res Confused, [hl]
+	res CONFUSED, [hl]
 	inc hl ; BATTSTATUS2
 	ld a, [hl]
-	; clear UsingXAccuracy, ProtectedByMist, GettingPumped, and Seeded statuses
-	and $ff ^((1 << UsingXAccuracy) | (1 << ProtectedByMist) | (1 << GettingPumped) | (1 << Seeded))
+	; clear USING_X_ACCURACY, PROTECTED_BY_MIST, GETTING_PUMPED, and SEEDED statuses
+	and $ff ^((1 << USING_X_ACCURACY) | (1 << PROTECTED_BY_MIST) | (1 << GETTING_PUMPED) | (1 << SEEDED))
 	ld [hli], a ; BATTSTATUS3
 	ld a, [hl]
-	and %11110000 | (1 << Transformed) ; clear Bad Poison, Reflect and Light Screen statuses
+	and %11110000 | (1 << TRANSFORMED) ; clear Bad Poison, Reflect and Light Screen statuses
 	ld [hl], a
 	ret
 

--- a/engine/battle/moveEffects/leech_seed_effect.asm
+++ b/engine/battle/moveEffects/leech_seed_effect.asm
@@ -19,9 +19,9 @@ LeechSeedEffect_:
 	ld a, [de]
 	cp GRASS
 	jr z, .moveMissed
-	bit Seeded, [hl]
+	bit SEEDED, [hl]
 	jr nz, .moveMissed
-	set Seeded, [hl]
+	set SEEDED, [hl]
 	callab PlayCurrentMoveAnimation
 	ld hl, WasSeededText
 	jp PrintText

--- a/engine/battle/moveEffects/mist_effect.asm
+++ b/engine/battle/moveEffects/mist_effect.asm
@@ -5,9 +5,9 @@ MistEffect_:
 	jr z, .mistEffect
 	ld hl, wEnemyBattleStatus2
 .mistEffect
-	bit ProtectedByMist, [hl] ; is mon protected by mist?
+	bit PROTECTED_BY_MIST, [hl] ; is mon protected by mist?
 	jr nz, .mistAlreadyInUse
-	set ProtectedByMist, [hl] ; mon is now protected by mist
+	set PROTECTED_BY_MIST, [hl] ; mon is now protected by mist
 	callab PlayCurrentMoveAnimation
 	ld hl, ShroudedInMistText
 	jp PrintText

--- a/engine/battle/moveEffects/reflect_light_screen_effect.asm
+++ b/engine/battle/moveEffects/reflect_light_screen_effect.asm
@@ -10,15 +10,15 @@ ReflectLightScreenEffect_:
 	ld a, [de]
 	cp LIGHT_SCREEN_EFFECT
 	jr nz, .reflect
-	bit HasLightScreenUp, [hl] ; is mon already protected by light screen?
+	bit HAS_LIGHT_SCREEN_UP, [hl] ; is mon already protected by light screen?
 	jr nz, .moveFailed
-	set HasLightScreenUp, [hl] ; mon is now protected by light screen
+	set HAS_LIGHT_SCREEN_UP, [hl] ; mon is now protected by light screen
 	ld hl, LightScreenProtectedText
 	jr .playAnim
 .reflect
-	bit HasReflectUp, [hl] ; is mon already protected by reflect?
+	bit HAS_REFLECT_UP, [hl] ; is mon already protected by reflect?
 	jr nz, .moveFailed
-	set HasReflectUp, [hl] ; mon is now protected by reflect
+	set HAS_REFLECT_UP, [hl] ; mon is now protected by reflect
 	ld hl, ReflectGainedArmorText
 .playAnim
 	push hl

--- a/engine/battle/moveEffects/substitute_effect.asm
+++ b/engine/battle/moveEffects/substitute_effect.asm
@@ -12,7 +12,7 @@ SubstituteEffect_:
 	ld bc, wEnemyBattleStatus2
 .notEnemy
 	ld a, [bc]
-	bit HasSubstituteUp, a ; user already has substitute?
+	bit HAS_SUBSTITUTE_UP, a ; user already has substitute?
 	jr nz, .alreadyHasSubstitute
 ; quarter health to remove from user
 ; assumes max HP is 1023 or lower
@@ -43,7 +43,7 @@ SubstituteEffect_:
 	ld [hl], d
 	ld h, b
 	ld l, c
-	set HasSubstituteUp, [hl]
+	set HAS_SUBSTITUTE_UP, [hl]
 	ld a, [wOptions]
 	bit 7, a ; battle animation is enabled?
 	ld hl, PlayCurrentMoveAnimation

--- a/engine/battle/moveEffects/transform_effect.asm
+++ b/engine/battle/moveEffects/transform_effect.asm
@@ -12,7 +12,7 @@ TransformEffect_:
 	ld [wPlayerMoveListIndex], a
 	ld a, [wPlayerBattleStatus1]
 .hitTest
-	bit Invulnerable, a ; is mon invulnerable to typical attacks? (fly/dig)
+	bit INVULNERABLE, a ; is mon invulnerable to typical attacks? (fly/dig)
 	jp nz, .failed
 	push hl
 	push de
@@ -24,7 +24,7 @@ TransformEffect_:
 	ld hl, wEnemyBattleStatus2
 .transformEffect
 ; animation(s) played are different if target has Substitute up
-	bit HasSubstituteUp, [hl]
+	bit HAS_SUBSTITUTE_UP, [hl]
 	push af
 	ld hl, HideSubstituteShowMonAnim
 	ld b, BANK(HideSubstituteShowMonAnim)
@@ -44,7 +44,7 @@ TransformEffect_:
 	call nz, Bankswitch
 	pop bc
 	ld a, [bc]
-	set Transformed, a ; mon is now Transformed
+	set TRANSFORMED, a ; mon is now transformed
 	ld [bc], a
 	pop de
 	pop hl

--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -1,43 +1,43 @@
 ReadTrainer:
 
 ; don't change any moves in a link battle
-	ld a,[wLinkState]
+	ld a, [wLinkState]
 	and a
 	ret nz
 
 ; set [wEnemyPartyCount] to 0, [wEnemyPartyMons] to FF
 ; XXX first is total enemy pokemon?
 ; XXX second is species of first pokemon?
-	ld hl,wEnemyPartyCount
+	ld hl, wEnemyPartyCount
 	xor a
-	ld [hli],a
+	ld [hli], a
 	dec a
-	ld [hl],a
+	ld [hl], a
 
 ; get the pointer to trainer data for this class
-	ld a,[wCurOpponent]
+	ld a, [wCurOpponent]
 	sub $C9 ; convert value from pokemon to trainer
-	add a,a
-	ld hl,TrainerDataPointers
-	ld c,a
-	ld b,0
-	add hl,bc ; hl points to trainer class
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
-	ld a,[wTrainerNo]
-	ld b,a
+	add a
+	ld hl, TrainerDataPointers
+	ld c, a
+	ld b, 0
+	add hl, bc ; hl points to trainer class
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
+	ld a, [wTrainerNo]
+	ld b, a
 ; At this point b contains the trainer number,
 ; and hl points to the trainer class.
 ; Our next task is to iterate through the trainers,
 ; decrementing b each time, until we get to the right one.
 .outer
 	dec b
-	jr z,.IterateTrainer
+	jr z, .IterateTrainer
 .inner
-	ld a,[hli]
+	ld a, [hli]
 	and a
-	jr nz,.inner
+	jr nz, .inner
 	jr .outer
 
 ; if the first byte of trainer data is FF,
@@ -46,17 +46,17 @@ ReadTrainer:
 ; - if [wLoneAttackNo] != 0, one pokemon on the team has a special move
 ; else the first byte is the level of every pokemon on the team
 .IterateTrainer
-	ld a,[hli]
+	ld a, [hli]
 	cp $FF ; is the trainer special?
-	jr z,.SpecialTrainer ; if so, check for special moves
-	ld [wCurEnemyLVL],a
+	jr z, .SpecialTrainer ; if so, check for special moves
+	ld [wCurEnemyLVL], a
 .LoopTrainerData
-	ld a,[hli]
+	ld a, [hli]
 	and a ; have we reached the end of the trainer data?
-	jr z,.FinishUp
-	ld [wcf91],a ; write species somewhere (XXX why?)
-	ld a,ENEMY_PARTY_DATA
-	ld [wMonDataLocation],a
+	jr z, .FinishUp
+	ld [wcf91], a ; write species somewhere (XXX why?)
+	ld a, ENEMY_PARTY_DATA
+	ld [wMonDataLocation], a
 	push hl
 	call AddPartyMon
 	pop hl
@@ -66,101 +66,101 @@ ReadTrainer:
 ; - each pokemon has a specific level
 ;      (as opposed to the whole team being of the same level)
 ; - if [wLoneAttackNo] != 0, one pokemon on the team has a special move
-	ld a,[hli]
+	ld a, [hli]
 	and a ; have we reached the end of the trainer data?
-	jr z,.AddLoneMove
-	ld [wCurEnemyLVL],a
-	ld a,[hli]
-	ld [wcf91],a
-	ld a,ENEMY_PARTY_DATA
-	ld [wMonDataLocation],a
+	jr z, .AddLoneMove
+	ld [wCurEnemyLVL], a
+	ld a, [hli]
+	ld [wcf91], a
+	ld a, ENEMY_PARTY_DATA
+	ld [wMonDataLocation], a
 	push hl
 	call AddPartyMon
 	pop hl
 	jr .SpecialTrainer
 .AddLoneMove
 ; does the trainer have a single monster with a different move
-	ld a,[wLoneAttackNo] ; Brock is 01, Misty is 02, Erika is 04, etc
+	ld a, [wLoneAttackNo] ; Brock is 01, Misty is 02, Erika is 04, etc
 	and a
-	jr z,.AddTeamMove
+	jr z, .AddTeamMove
 	dec a
-	add a,a
-	ld c,a
-	ld b,0
-	ld hl,LoneMoves
-	add hl,bc
-	ld a,[hli]
-	ld d,[hl]
-	ld hl,wEnemyMon1Moves + 2
-	ld bc,wEnemyMon2 - wEnemyMon1
+	add a
+	ld c, a
+	ld b, 0
+	ld hl, LoneMoves
+	add hl, bc
+	ld a, [hli]
+	ld d, [hl]
+	ld hl, wEnemyMon1Moves + 2
+	ld bc, wEnemyMon2 - wEnemyMon1
 	call AddNTimes
-	ld [hl],d
+	ld [hl], d
 	jr .FinishUp
 .AddTeamMove
 ; check if our trainer's team has special moves
 
 ; get trainer class number
-	ld a,[wCurOpponent]
+	ld a, [wCurOpponent]
 	sub 200
-	ld b,a
-	ld hl,TeamMoves
+	ld b, a
+	ld hl, TeamMoves
 
 ; iterate through entries in TeamMoves, checking each for our trainer class
 .IterateTeamMoves
-	ld a,[hli]
+	ld a, [hli]
 	cp b
-	jr z,.GiveTeamMoves ; is there a match?
+	jr z, .GiveTeamMoves ; is there a match?
 	inc hl ; if not, go to the next entry
 	inc a
-	jr nz,.IterateTeamMoves
+	jr nz, .IterateTeamMoves
 
 ; no matches found. is this trainer champion rival?
-	ld a,b
+	ld a, b
 	cp SONY3
-	jr z,.ChampionRival
+	jr z, .ChampionRival
 	jr .FinishUp ; nope
 .GiveTeamMoves
-	ld a,[hl]
-	ld [wEnemyMon5Moves + 2],a
+	ld a, [hl]
+	ld [wEnemyMon5Moves + 2], a
 	jr .FinishUp
 .ChampionRival ; give moves to his team
 
 ; pidgeot
-	ld a,SKY_ATTACK
-	ld [wEnemyMon1Moves + 2],a
+	ld a, SKY_ATTACK
+	ld [wEnemyMon1Moves + 2], a
 
 ; starter
-	ld a,[wRivalStarter]
+	ld a, [wRivalStarter]
 	cp STARTER3
-	ld b,MEGA_DRAIN
-	jr z,.GiveStarterMove
+	ld b, MEGA_DRAIN
+	jr z, .GiveStarterMove
 	cp STARTER1
-	ld b,FIRE_BLAST
-	jr z,.GiveStarterMove
-	ld b,BLIZZARD ; must be squirtle
+	ld b, FIRE_BLAST
+	jr z, .GiveStarterMove
+	ld b, BLIZZARD ; must be squirtle
 .GiveStarterMove
-	ld a,b
-	ld [wEnemyMon6Moves + 2],a
+	ld a, b
+	ld [wEnemyMon6Moves + 2], a
 .FinishUp
 ; clear wAmountMoneyWon addresses
 	xor a
-	ld de,wAmountMoneyWon
-	ld [de],a
+	ld de, wAmountMoneyWon
+	ld [de], a
 	inc de
-	ld [de],a
+	ld [de], a
 	inc de
-	ld [de],a
-	ld a,[wCurEnemyLVL]
-	ld b,a
+	ld [de], a
+	ld a, [wCurEnemyLVL]
+	ld b, a
 .LastLoop
 ; update wAmountMoneyWon addresses (money to win) based on enemy's level
-	ld hl,wTrainerBaseMoney + 1
-	ld c,2 ; wAmountMoneyWon is a 3-byte number
+	ld hl, wTrainerBaseMoney + 1
+	ld c, 2 ; wAmountMoneyWon is a 3-byte number
 	push bc
 	predef AddBCDPredef
 	pop bc
 	inc de
 	inc de
 	dec b
-	jr nz,.LastLoop ; repeat wCurEnemyLVL times
+	jr nz, .LastLoop ; repeat wCurEnemyLVL times
 	ret

--- a/engine/battle/save_trainer_name.asm
+++ b/engine/battle/save_trainer_name.asm
@@ -1,21 +1,21 @@
 SaveTrainerName:
-	ld hl,TrainerNamePointers
-	ld a,[wTrainerClass]
+	ld hl, TrainerNamePointers
+	ld a, [wTrainerClass]
 	dec a
-	ld c,a
-	ld b,0
-	add hl,bc
-	add hl,bc
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
-	ld de,wcd6d
+	ld c, a
+	ld b, 0
+	add hl, bc
+	add hl, bc
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
+	ld de, wcd6d
 .CopyCharacter
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	cp "@"
-	jr nz,.CopyCharacter
+	jr nz, .CopyCharacter
 	ret
 
 TrainerNamePointers:

--- a/engine/battle/trainer_ai.asm
+++ b/engine/battle/trainer_ai.asm
@@ -263,10 +263,10 @@ ReadMove:
 	push de
 	push bc
 	dec a
-	ld hl,Moves
-	ld bc,MoveEnd - Moves
+	ld hl, Moves
+	ld bc, MoveEnd - Moves
 	call AddNTimes
-	ld de,wEnemyMoveNum
+	ld de, wEnemyMoveNum
 	call CopyData
 	pop bc
 	pop de
@@ -338,33 +338,33 @@ INCLUDE "data/trainer_parties.asm"
 
 TrainerAI:
 	and a
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	dec a
 	ret z ; if not a trainer, we're done here
-	ld a,[wLinkState]
+	ld a, [wLinkState]
 	cp LINK_STATE_BATTLING
 	ret z
-	ld a,[wTrainerClass] ; what trainer class is this?
+	ld a, [wTrainerClass] ; what trainer class is this?
 	dec a
-	ld c,a
-	ld b,0
-	ld hl,TrainerAIPointers
-	add hl,bc
-	add hl,bc
-	add hl,bc
-	ld a,[wAICount]
+	ld c, a
+	ld b, 0
+	ld hl, TrainerAIPointers
+	add hl, bc
+	add hl, bc
+	add hl, bc
+	ld a, [wAICount]
 	and a
 	ret z ; if no AI uses left, we're done here
 	inc hl
 	inc a
-	jr nz,.getpointer
+	jr nz, .getpointer
 	dec hl
-	ld a,[hli]
-	ld [wAICount],a
+	ld a, [hli]
+	ld [wAICount], a
 .getpointer
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 	call Random
 	jp hl
 
@@ -442,17 +442,17 @@ CooltrainerMAI:
 
 CooltrainerFAI:
 	cp $40
-	ld a,$A
+	ld a, $A
 	call AICheckIfHPBelowFraction
-	jp c,AIUseHyperPotion
-	ld a,5
+	jp c, AIUseHyperPotion
+	ld a, 5
 	call AICheckIfHPBelowFraction
 	ret nc
 	jp AISwitchIfEnoughMons
 
 BrockAI:
 ; if his active monster has a status condition, use a full heal
-	ld a,[wEnemyMonStatus]
+	ld a, [wEnemyMonStatus]
 	and a
 	ret z
 	jp AIUseFullHeal
@@ -470,7 +470,7 @@ LtSurgeAI:
 ErikaAI:
 	cp $80
 	ret nc
-	ld a,$A
+	ld a, $A
 	call AICheckIfHPBelowFraction
 	ret nc
 	jp AIUseSuperPotion
@@ -488,7 +488,7 @@ BlaineAI:
 SabrinaAI:
 	cp $40
 	ret nc
-	ld a,$A
+	ld a, $A
 	call AICheckIfHPBelowFraction
 	ret nc
 	jp AIUseHyperPotion
@@ -496,7 +496,7 @@ SabrinaAI:
 Sony2AI:
 	cp $20
 	ret nc
-	ld a,5
+	ld a, 5
 	call AICheckIfHPBelowFraction
 	ret nc
 	jp AIUsePotion
@@ -504,7 +504,7 @@ Sony2AI:
 Sony3AI:
 	cp $20
 	ret nc
-	ld a,5
+	ld a, 5
 	call AICheckIfHPBelowFraction
 	ret nc
 	jp AIUseFullRestore
@@ -512,7 +512,7 @@ Sony3AI:
 LoreleiAI:
 	cp $80
 	ret nc
-	ld a,5
+	ld a, 5
 	call AICheckIfHPBelowFraction
 	ret nc
 	jp AIUseSuperPotion
@@ -524,10 +524,10 @@ BrunoAI:
 
 AgathaAI:
 	cp $14
-	jp c,AISwitchIfEnoughMons
+	jp c, AISwitchIfEnoughMons
 	cp $80
 	ret nc
-	ld a,4
+	ld a, 4
 	call AICheckIfHPBelowFraction
 	ret nc
 	jp AIUseSuperPotion
@@ -535,7 +535,7 @@ AgathaAI:
 LanceAI:
 	cp $80
 	ret nc
-	ld a,5
+	ld a, 5
 	call AICheckIfHPBelowFraction
 	ret nc
 	jp AIUseHyperPotion
@@ -547,133 +547,133 @@ GenericAI:
 ; end of individual trainer AI routines
 
 DecrementAICount:
-	ld hl,wAICount
+	ld hl, wAICount
 	dec [hl]
 	scf
 	ret
 
 AIPlayRestoringSFX:
-	ld a,SFX_HEAL_AILMENT
+	ld a, SFX_HEAL_AILMENT
 	jp PlaySoundWaitForCurrent
 
 AIUseFullRestore:
 	call AICureStatus
-	ld a,FULL_RESTORE
-	ld [wAIItem],a
-	ld de,wHPBarOldHP
-	ld hl,wEnemyMonHP + 1
-	ld a,[hld]
-	ld [de],a
+	ld a, FULL_RESTORE
+	ld [wAIItem], a
+	ld de, wHPBarOldHP
+	ld hl, wEnemyMonHP + 1
+	ld a, [hld]
+	ld [de], a
 	inc de
-	ld a,[hl]
-	ld [de],a
+	ld a, [hl]
+	ld [de], a
 	inc de
-	ld hl,wEnemyMonMaxHP + 1
-	ld a,[hld]
-	ld [de],a
+	ld hl, wEnemyMonMaxHP + 1
+	ld a, [hld]
+	ld [de], a
 	inc de
-	ld [wHPBarMaxHP],a
-	ld [wEnemyMonHP + 1],a
-	ld a,[hl]
-	ld [de],a
-	ld [wHPBarMaxHP+1],a
-	ld [wEnemyMonHP],a
+	ld [wHPBarMaxHP], a
+	ld [wEnemyMonHP + 1], a
+	ld a, [hl]
+	ld [de], a
+	ld [wHPBarMaxHP+1], a
+	ld [wEnemyMonHP], a
 	jr AIPrintItemUseAndUpdateHPBar
 
 AIUsePotion:
 ; enemy trainer heals his monster with a potion
-	ld a,POTION
-	ld b,20
+	ld a, POTION
+	ld b, 20
 	jr AIRecoverHP
 
 AIUseSuperPotion:
 ; enemy trainer heals his monster with a super potion
-	ld a,SUPER_POTION
-	ld b,50
+	ld a, SUPER_POTION
+	ld b, 50
 	jr AIRecoverHP
 
 AIUseHyperPotion:
 ; enemy trainer heals his monster with a hyper potion
-	ld a,HYPER_POTION
-	ld b,200
+	ld a, HYPER_POTION
+	ld b, 200
 	; fallthrough
 
 AIRecoverHP:
 ; heal b HP and print "trainer used $(a) on pokemon!"
-	ld [wAIItem],a
-	ld hl,wEnemyMonHP + 1
-	ld a,[hl]
-	ld [wHPBarOldHP],a
+	ld [wAIItem], a
+	ld hl, wEnemyMonHP + 1
+	ld a, [hl]
+	ld [wHPBarOldHP], a
 	add b
-	ld [hld],a
-	ld [wHPBarNewHP],a
-	ld a,[hl]
-	ld [wHPBarOldHP+1],a
-	ld [wHPBarNewHP+1],a
-	jr nc,.next
+	ld [hld], a
+	ld [wHPBarNewHP], a
+	ld a, [hl]
+	ld [wHPBarOldHP+1], a
+	ld [wHPBarNewHP+1], a
+	jr nc, .next
 	inc a
-	ld [hl],a
-	ld [wHPBarNewHP+1],a
+	ld [hl], a
+	ld [wHPBarNewHP+1], a
 .next
 	inc hl
-	ld a,[hld]
-	ld b,a
-	ld de,wEnemyMonMaxHP + 1
-	ld a,[de]
+	ld a, [hld]
+	ld b, a
+	ld de, wEnemyMonMaxHP + 1
+	ld a, [de]
 	dec de
-	ld [wHPBarMaxHP],a
+	ld [wHPBarMaxHP], a
 	sub b
-	ld a,[hli]
-	ld b,a
-	ld a,[de]
-	ld [wHPBarMaxHP+1],a
+	ld a, [hli]
+	ld b, a
+	ld a, [de]
+	ld [wHPBarMaxHP+1], a
 	sbc b
-	jr nc,AIPrintItemUseAndUpdateHPBar
+	jr nc, AIPrintItemUseAndUpdateHPBar
 	inc de
-	ld a,[de]
+	ld a, [de]
 	dec de
-	ld [hld],a
-	ld [wHPBarNewHP],a
-	ld a,[de]
-	ld [hl],a
-	ld [wHPBarNewHP+1],a
+	ld [hld], a
+	ld [wHPBarNewHP], a
+	ld a, [de]
+	ld [hl], a
+	ld [wHPBarNewHP+1], a
 	; fallthrough
 
 AIPrintItemUseAndUpdateHPBar:
 	call AIPrintItemUse_
 	coord hl, 2, 2
 	xor a
-	ld [wHPBarType],a
+	ld [wHPBarType], a
 	predef UpdateHPBar2
 	jp DecrementAICount
 
 AISwitchIfEnoughMons:
 ; enemy trainer switches if there are 3 or more unfainted mons in party
-	ld a,[wEnemyPartyCount]
-	ld c,a
-	ld hl,wEnemyMon1HP
+	ld a, [wEnemyPartyCount]
+	ld c, a
+	ld hl, wEnemyMon1HP
 
-	ld d,0 ; keep count of unfainted monsters
+	ld d, 0 ; keep count of unfainted monsters
 
 	; count how many monsters haven't fainted yet
 .loop
-	ld a,[hli]
-	ld b,a
-	ld a,[hld]
+	ld a, [hli]
+	ld b, a
+	ld a, [hld]
 	or b
-	jr z,.Fainted ; has monster fainted?
+	jr z, .Fainted ; has monster fainted?
 	inc d
 .Fainted
 	push bc
 	ld bc, wEnemyMon2 - wEnemyMon1
-	add hl,bc
+	add hl, bc
 	pop bc
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 
-	ld a,d ; how many available monsters are there?
+	ld a, d ; how many available monsters are there?
 	cp 2 ; don't bother if only 1 or 2
-	jp nc,SwitchEnemyMon
+	jp nc, SwitchEnemyMon
 	and a
 	ret
 
@@ -681,14 +681,14 @@ SwitchEnemyMon:
 
 ; prepare to withdraw the active monster: copy hp, number, and status to roster
 
-	ld a,[wEnemyMonPartyPos]
-	ld hl,wEnemyMon1HP
-	ld bc,wEnemyMon2 - wEnemyMon1
+	ld a, [wEnemyMonPartyPos]
+	ld hl, wEnemyMon1HP
+	ld bc, wEnemyMon2 - wEnemyMon1
 	call AddNTimes
-	ld d,h
-	ld e,l
-	ld hl,wEnemyMonHP
-	ld bc,4
+	ld d, h
+	ld e, l
+	ld hl, wEnemyMonHP
+	ld bc, 4
 	call CopyData
 
 	ld hl, AIBattleWithdrawText
@@ -696,13 +696,13 @@ SwitchEnemyMon:
 
 	; This wFirstMonsNotOutYet variable is abused to prevent the player from
 	; switching in a new mon in response to this switch.
-	ld a,1
-	ld [wFirstMonsNotOutYet],a
+	ld a, 1
+	ld [wFirstMonsNotOutYet], a
 	callab EnemySendOut
 	xor a
-	ld [wFirstMonsNotOutYet],a
+	ld [wFirstMonsNotOutYet], a
 
-	ld a,[wLinkState]
+	ld a, [wLinkState]
 	cp LINK_STATE_BATTLING
 	ret z
 	scf
@@ -715,120 +715,120 @@ AIBattleWithdrawText:
 AIUseFullHeal:
 	call AIPlayRestoringSFX
 	call AICureStatus
-	ld a,FULL_HEAL
+	ld a, FULL_HEAL
 	jp AIPrintItemUse
 
 AICureStatus:
 ; cures the status of enemy's active pokemon
-	ld a,[wEnemyMonPartyPos]
-	ld hl,wEnemyMon1Status
-	ld bc,wEnemyMon2 - wEnemyMon1
+	ld a, [wEnemyMonPartyPos]
+	ld hl, wEnemyMon1Status
+	ld bc, wEnemyMon2 - wEnemyMon1
 	call AddNTimes
 	xor a
-	ld [hl],a ; clear status in enemy team roster
-	ld [wEnemyMonStatus],a ; clear status of active enemy
-	ld hl,wEnemyBattleStatus3
-	res 0,[hl]
+	ld [hl], a ; clear status in enemy team roster
+	ld [wEnemyMonStatus], a ; clear status of active enemy
+	ld hl, wEnemyBattleStatus3
+	res 0, [hl]
 	ret
 
 AIUseXAccuracy: ; unused
 	call AIPlayRestoringSFX
-	ld hl,wEnemyBattleStatus2
-	set 0,[hl]
-	ld a,X_ACCURACY
+	ld hl, wEnemyBattleStatus2
+	set 0, [hl]
+	ld a, X_ACCURACY
 	jp AIPrintItemUse
 
 AIUseGuardSpec:
 	call AIPlayRestoringSFX
-	ld hl,wEnemyBattleStatus2
-	set 1,[hl]
-	ld a,GUARD_SPEC
+	ld hl, wEnemyBattleStatus2
+	set 1, [hl]
+	ld a, GUARD_SPEC
 	jp AIPrintItemUse
 
 AIUseDireHit: ; unused
 	call AIPlayRestoringSFX
-	ld hl,wEnemyBattleStatus2
-	set 2,[hl]
-	ld a,DIRE_HIT
+	ld hl, wEnemyBattleStatus2
+	set 2, [hl]
+	ld a, DIRE_HIT
 	jp AIPrintItemUse
 
 AICheckIfHPBelowFraction:
 ; return carry if enemy trainer's current HP is below 1 / a of the maximum
-	ld [H_DIVISOR],a
-	ld hl,wEnemyMonMaxHP
-	ld a,[hli]
-	ld [H_DIVIDEND],a
-	ld a,[hl]
-	ld [H_DIVIDEND + 1],a
-	ld b,2
+	ld [H_DIVISOR], a
+	ld hl, wEnemyMonMaxHP
+	ld a, [hli]
+	ld [H_DIVIDEND], a
+	ld a, [hl]
+	ld [H_DIVIDEND + 1], a
+	ld b, 2
 	call Divide
-	ld a,[H_QUOTIENT + 3]
-	ld c,a
-	ld a,[H_QUOTIENT + 2]
-	ld b,a
-	ld hl,wEnemyMonHP + 1
-	ld a,[hld]
-	ld e,a
-	ld a,[hl]
-	ld d,a
-	ld a,d
+	ld a, [H_QUOTIENT + 3]
+	ld c, a
+	ld a, [H_QUOTIENT + 2]
+	ld b, a
+	ld hl, wEnemyMonHP + 1
+	ld a, [hld]
+	ld e, a
+	ld a, [hl]
+	ld d, a
+	ld a, d
 	sub b
 	ret nz
-	ld a,e
+	ld a, e
 	sub c
 	ret
 
 AIUseXAttack:
-	ld b,$A
-	ld a,X_ATTACK
+	ld b, $A
+	ld a, X_ATTACK
 	jr AIIncreaseStat
 
 AIUseXDefend:
-	ld b,$B
-	ld a,X_DEFEND
+	ld b, $B
+	ld a, X_DEFEND
 	jr AIIncreaseStat
 
 AIUseXSpeed:
-	ld b,$C
-	ld a,X_SPEED
+	ld b, $C
+	ld a, X_SPEED
 	jr AIIncreaseStat
 
 AIUseXSpecial:
-	ld b,$D
-	ld a,X_SPECIAL
+	ld b, $D
+	ld a, X_SPECIAL
 	; fallthrough
 
 AIIncreaseStat:
-	ld [wAIItem],a
+	ld [wAIItem], a
 	push bc
 	call AIPrintItemUse_
 	pop bc
-	ld hl,wEnemyMoveEffect
-	ld a,[hld]
+	ld hl, wEnemyMoveEffect
+	ld a, [hld]
 	push af
-	ld a,[hl]
+	ld a, [hl]
 	push af
 	push hl
-	ld a,ANIM_AF
-	ld [hli],a
-	ld [hl],b
+	ld a, ANIM_AF
+	ld [hli], a
+	ld [hl], b
 	callab StatModifierUpEffect
 	pop hl
 	pop af
-	ld [hli],a
+	ld [hli], a
 	pop af
-	ld [hl],a
+	ld [hl], a
 	jp DecrementAICount
 
 AIPrintItemUse:
-	ld [wAIItem],a
+	ld [wAIItem], a
 	call AIPrintItemUse_
 	jp DecrementAICount
 
 AIPrintItemUse_:
 ; print "x used [wAIItem] on z!"
-	ld a,[wAIItem]
-	ld [wd11e],a
+	ld a, [wAIItem]
+	ld [wd11e], a
 	call GetItemName
 	ld hl, AIBattleUseItemText
 	jp PrintText

--- a/engine/display_text_id_init.asm
+++ b/engine/display_text_id_init.asm
@@ -1,78 +1,78 @@
 ; function that performs initialization for DisplayTextID
 DisplayTextIDInit:
 	xor a
-	ld [wListMenuID],a
-	ld a,[wAutoTextBoxDrawingControl]
-	bit 0,a
-	jr nz,.skipDrawingTextBoxBorder
-	ld a,[hSpriteIndexOrTextID] ; text ID (or sprite ID)
+	ld [wListMenuID], a
+	ld a, [wAutoTextBoxDrawingControl]
+	bit 0, a
+	jr nz, .skipDrawingTextBoxBorder
+	ld a, [hSpriteIndexOrTextID] ; text ID (or sprite ID)
 	and a
-	jr nz,.notStartMenu
+	jr nz, .notStartMenu
 ; if text ID is 0 (i.e. the start menu)
 ; Note that the start menu text border is also drawn in the function directly
 ; below this, so this seems unnecessary.
 	CheckEvent EVENT_GOT_POKEDEX
 ; start menu with pokedex
 	coord hl, 10, 0
-	ld b,$0e
-	ld c,$08
-	jr nz,.drawTextBoxBorder
+	ld b, $0e
+	ld c, $08
+	jr nz, .drawTextBoxBorder
 ; start menu without pokedex
 	coord hl, 10, 0
-	ld b,$0c
-	ld c,$08
+	ld b, $0c
+	ld c, $08
 	jr .drawTextBoxBorder
 ; if text ID is not 0 (i.e. not the start menu) then do a standard dialogue text box
 .notStartMenu
 	coord hl, 0, 12
-	ld b,$04
-	ld c,$12
+	ld b, $04
+	ld c, $12
 .drawTextBoxBorder
 	call TextBoxBorder
 .skipDrawingTextBoxBorder
-	ld hl,wFontLoaded
-	set 0,[hl]
-	ld hl,wFlags_0xcd60
-	bit 4,[hl]
-	res 4,[hl]
-	jr nz,.skipMovingSprites
+	ld hl, wFontLoaded
+	set 0, [hl]
+	ld hl, wFlags_0xcd60
+	bit 4, [hl]
+	res 4, [hl]
+	jr nz, .skipMovingSprites
 	call UpdateSprites
 .skipMovingSprites
 ; loop to copy C1X9 (direction the sprite is facing) to C2X9 for each sprite
 ; this is done because when you talk to an NPC, they turn to look your way
 ; the original direction they were facing must be restored after the dialogue is over
-	ld hl,wSpriteStateData1 + $19
-	ld c,$0f
-	ld de,$0010
+	ld hl, wSpriteStateData1 + $19
+	ld c, $0f
+	ld de, $0010
 .spriteFacingDirectionCopyLoop
-	ld a,[hl]
+	ld a, [hl]
 	inc h
-	ld [hl],a
+	ld [hl], a
 	dec h
-	add hl,de
+	add hl, de
 	dec c
-	jr nz,.spriteFacingDirectionCopyLoop
+	jr nz, .spriteFacingDirectionCopyLoop
 ; loop to force all the sprites in the middle of animation to stand still
 ; (so that they don't like they're frozen mid-step during the dialogue)
-	ld hl,wSpriteStateData1 + 2
-	ld de,$0010
-	ld c,e
+	ld hl, wSpriteStateData1 + 2
+	ld de, $0010
+	ld c, e
 .spriteStandStillLoop
-	ld a,[hl]
-	cp a,$ff ; is the sprite visible?
-	jr z,.nextSprite
+	ld a, [hl]
+	cp $ff ; is the sprite visible?
+	jr z, .nextSprite
 ; if it is visible
-	and a,$fc
-	ld [hl],a
+	and $fc
+	ld [hl], a
 .nextSprite
-	add hl,de
+	add hl, de
 	dec c
-	jr nz,.spriteStandStillLoop
-	ld b,$9c ; window background address
+	jr nz, .spriteStandStillLoop
+	ld b, $9c ; window background address
 	call CopyScreenTileBufferToVRAM ; transfer background in WRAM to VRAM
 	xor a
-	ld [hWY],a ; put the window on the screen
+	ld [hWY], a ; put the window on the screen
 	call LoadFontTilePatterns
-	ld a,$01
-	ld [H_AUTOBGTRANSFERENABLED],a ; enable continuous WRAM to VRAM transfer each V-blank
+	ld a, $01
+	ld [H_AUTOBGTRANSFERENABLED], a ; enable continuous WRAM to VRAM transfer each V-blank
 	ret

--- a/engine/hall_of_fame.asm
+++ b/engine/hall_of_fame.asm
@@ -6,7 +6,7 @@ AnimateHallOfFame:
 	call LoadFontTilePatterns
 	call LoadTextBoxTilePatterns
 	call DisableLCD
-	ld hl,vBGMap0
+	ld hl, vBGMap0
 	ld bc, $800
 	ld a, " "
 	call FillMemory

--- a/engine/in_game_trades.asm
+++ b/engine/in_game_trades.asm
@@ -1,85 +1,85 @@
 DoInGameTradeDialogue:
 ; trigger the trade offer/action specified by wWhichTrade
 	call SaveScreenTilesToBuffer2
-	ld hl,TradeMons
-	ld a,[wWhichTrade]
-	ld b,a
+	ld hl, TradeMons
+	ld a, [wWhichTrade]
+	ld b, a
 	swap a
 	sub b
 	sub b
-	ld c,a
-	ld b,0
-	add hl,bc
-	ld a,[hli]
-	ld [wInGameTradeGiveMonSpecies],a
-	ld a,[hli]
-	ld [wInGameTradeReceiveMonSpecies],a
-	ld a,[hli]
+	ld c, a
+	ld b, 0
+	add hl, bc
+	ld a, [hli]
+	ld [wInGameTradeGiveMonSpecies], a
+	ld a, [hli]
+	ld [wInGameTradeReceiveMonSpecies], a
+	ld a, [hli]
 	push af
-	ld de,wInGameTradeMonNick
+	ld de, wInGameTradeMonNick
 	ld bc, NAME_LENGTH
 	call CopyData
 	pop af
-	ld l,a
-	ld h,0
-	ld de,InGameTradeTextPointers
-	add hl,hl
-	add hl,de
-	ld a,[hli]
-	ld [wInGameTradeTextPointerTablePointer],a
-	ld a,[hl]
-	ld [wInGameTradeTextPointerTablePointer + 1],a
-	ld a,[wInGameTradeGiveMonSpecies]
-	ld de,wInGameTradeGiveMonName
+	ld l, a
+	ld h, 0
+	ld de, InGameTradeTextPointers
+	add hl, hl
+	add hl, de
+	ld a, [hli]
+	ld [wInGameTradeTextPointerTablePointer], a
+	ld a, [hl]
+	ld [wInGameTradeTextPointerTablePointer + 1], a
+	ld a, [wInGameTradeGiveMonSpecies]
+	ld de, wInGameTradeGiveMonName
 	call InGameTrade_GetMonName
-	ld a,[wInGameTradeReceiveMonSpecies]
-	ld de,wInGameTradeReceiveMonName
+	ld a, [wInGameTradeReceiveMonSpecies]
+	ld de, wInGameTradeReceiveMonName
 	call InGameTrade_GetMonName
-	ld hl,wCompletedInGameTradeFlags
-	ld a,[wWhichTrade]
-	ld c,a
-	ld b,FLAG_TEST
+	ld hl, wCompletedInGameTradeFlags
+	ld a, [wWhichTrade]
+	ld c, a
+	ld b, FLAG_TEST
 	predef FlagActionPredef
-	ld a,c
+	ld a, c
 	and a
-	ld a,$4
-	ld [wInGameTradeTextPointerTableIndex],a
-	jr nz,.printText
+	ld a, $4
+	ld [wInGameTradeTextPointerTableIndex], a
+	jr nz, .printText
 ; if the trade hasn't been done yet
 	xor a
-	ld [wInGameTradeTextPointerTableIndex],a
+	ld [wInGameTradeTextPointerTableIndex], a
 	call .printText
-	ld a,$1
-	ld [wInGameTradeTextPointerTableIndex],a
+	ld a, $1
+	ld [wInGameTradeTextPointerTableIndex], a
 	call YesNoChoice
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	and a
-	jr nz,.printText
+	jr nz, .printText
 	call InGameTrade_DoTrade
-	jr c,.printText
+	jr c, .printText
 	ld hl, TradedForText
 	call PrintText
 .printText
-	ld hl,wInGameTradeTextPointerTableIndex
-	ld a,[hld] ; wInGameTradeTextPointerTableIndex
-	ld e,a
-	ld d,0
-	ld a,[hld] ; wInGameTradeTextPointerTablePointer + 1
-	ld l,[hl] ; wInGameTradeTextPointerTablePointer
-	ld h,a
-	add hl,de
-	add hl,de
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld hl, wInGameTradeTextPointerTableIndex
+	ld a, [hld] ; wInGameTradeTextPointerTableIndex
+	ld e, a
+	ld d, 0
+	ld a, [hld] ; wInGameTradeTextPointerTablePointer + 1
+	ld l, [hl] ; wInGameTradeTextPointerTablePointer
+	ld h, a
+	add hl, de
+	add hl, de
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 	jp PrintText
 
 ; copies name of species a to hl
 InGameTrade_GetMonName:
 	push de
-	ld [wd11e],a
+	ld [wd11e], a
 	call GetMonName
-	ld hl,wcd6d
+	ld hl, wcd6d
 	pop de
 	ld bc, NAME_LENGTH
 	jp CopyData
@@ -88,53 +88,53 @@ INCLUDE "data/trades.asm"
 
 InGameTrade_DoTrade:
 	xor a ; NORMAL_PARTY_MENU
-	ld [wPartyMenuTypeOrMessageID],a
+	ld [wPartyMenuTypeOrMessageID], a
 	dec a
-	ld [wUpdateSpritesEnabled],a
+	ld [wUpdateSpritesEnabled], a
 	call DisplayPartyMenu
 	push af
 	call InGameTrade_RestoreScreen
 	pop af
-	ld a,$1
-	jp c,.tradeFailed ; jump if the player didn't select a pokemon
-	ld a,[wInGameTradeGiveMonSpecies]
-	ld b,a
-	ld a,[wcf91]
+	ld a, $1
+	jp c, .tradeFailed ; jump if the player didn't select a pokemon
+	ld a, [wInGameTradeGiveMonSpecies]
+	ld b, a
+	ld a, [wcf91]
 	cp b
-	ld a,$2
-	jr nz,.tradeFailed ; jump if the selected mon's species is not the required one
-	ld a,[wWhichPokemon]
-	ld hl,wPartyMon1Level
+	ld a, $2
+	jr nz, .tradeFailed ; jump if the selected mon's species is not the required one
+	ld a, [wWhichPokemon]
+	ld hl, wPartyMon1Level
 	ld bc, wPartyMon2 - wPartyMon1
 	call AddNTimes
-	ld a,[hl]
-	ld [wCurEnemyLVL],a
-	ld hl,wCompletedInGameTradeFlags
-	ld a,[wWhichTrade]
-	ld c,a
-	ld b,FLAG_SET
+	ld a, [hl]
+	ld [wCurEnemyLVL], a
+	ld hl, wCompletedInGameTradeFlags
+	ld a, [wWhichTrade]
+	ld c, a
+	ld b, FLAG_SET
 	predef FlagActionPredef
 	ld hl, ConnectCableText
 	call PrintText
-	ld a,[wWhichPokemon]
+	ld a, [wWhichPokemon]
 	push af
-	ld a,[wCurEnemyLVL]
+	ld a, [wCurEnemyLVL]
 	push af
 	call LoadHpBarAndStatusTilePatterns
 	call InGameTrade_PrepareTradeData
 	predef InternalClockTradeAnim
 	pop af
-	ld [wCurEnemyLVL],a
+	ld [wCurEnemyLVL], a
 	pop af
-	ld [wWhichPokemon],a
-	ld a,[wInGameTradeReceiveMonSpecies]
-	ld [wcf91],a
+	ld [wWhichPokemon], a
+	ld a, [wInGameTradeReceiveMonSpecies]
+	ld [wcf91], a
 	xor a
-	ld [wMonDataLocation],a ; not used
-	ld [wRemoveMonFromBox],a
+	ld [wMonDataLocation], a ; not used
+	ld [wRemoveMonFromBox], a
 	call RemovePokemon
-	ld a,$80 ; prevent the player from naming the mon
-	ld [wMonDataLocation],a
+	ld a, $80 ; prevent the player from naming the mon
+	ld [wMonDataLocation], a
 	call AddPartyMon
 	call InGameTrade_CopyDataToReceivedMon
 	callab EvolveTradeMon
@@ -142,12 +142,12 @@ InGameTrade_DoTrade:
 	call InGameTrade_RestoreScreen
 	callba RedrawMapView
 	and a
-	ld a,$3
+	ld a, $3
 	jr .tradeSucceeded
 .tradeFailed
 	scf
 .tradeSucceeded
-	ld [wInGameTradeTextPointerTableIndex],a
+	ld [wInGameTradeTextPointerTableIndex], a
 	ret
 
 InGameTrade_RestoreScreen:

--- a/engine/items/inventory.asm
+++ b/engine/items/inventory.asm
@@ -5,81 +5,81 @@
 ; [wItemQuantity] = item quantity
 ; sets carry flag if successful, unsets carry flag if unsuccessful
 AddItemToInventory_:
-	ld a,[wItemQuantity] ; a = item quantity
+	ld a, [wItemQuantity] ; a = item quantity
 	push af
 	push bc
 	push de
 	push hl
 	push hl
-	ld d,PC_ITEM_CAPACITY ; how many items the PC can hold
-	ld a,wNumBagItems & $FF
+	ld d, PC_ITEM_CAPACITY ; how many items the PC can hold
+	ld a, wNumBagItems & $FF
 	cp l
-	jr nz,.checkIfInventoryFull
-	ld a,wNumBagItems >> 8
+	jr nz, .checkIfInventoryFull
+	ld a, wNumBagItems >> 8
 	cp h
-	jr nz,.checkIfInventoryFull
+	jr nz, .checkIfInventoryFull
 ; if the destination is the bag
-	ld d,BAG_ITEM_CAPACITY ; how many items the bag can hold
+	ld d, BAG_ITEM_CAPACITY ; how many items the bag can hold
 .checkIfInventoryFull
-	ld a,[hl]
+	ld a, [hl]
 	sub d
-	ld d,a
-	ld a,[hli]
+	ld d, a
+	ld a, [hli]
 	and a
-	jr z,.addNewItem
+	jr z, .addNewItem
 .loop
-	ld a,[hli]
-	ld b,a ; b = ID of current item in table
-	ld a,[wcf91] ; a = ID of item being added
+	ld a, [hli]
+	ld b, a ; b = ID of current item in table
+	ld a, [wcf91] ; a = ID of item being added
 	cp b ; does the current item in the table match the item being added?
-	jp z,.increaseItemQuantity ; if so, increase the item's quantity
+	jp z, .increaseItemQuantity ; if so, increase the item's quantity
 	inc hl
-	ld a,[hl]
-	cp a,$ff ; is it the end of the table?
-	jr nz,.loop
+	ld a, [hl]
+	cp $ff ; is it the end of the table?
+	jr nz, .loop
 .addNewItem ; add an item not yet in the inventory
 	pop hl
-	ld a,d
+	ld a, d
 	and a ; is there room for a new item slot?
-	jr z,.done
+	jr z, .done
 ; if there is room
 	inc [hl] ; increment the number of items in the inventory
-	ld a,[hl] ; the number of items will be the index of the new item
+	ld a, [hl] ; the number of items will be the index of the new item
 	add a
 	dec a
-	ld c,a
-	ld b,0
-	add hl,bc ; hl = address to store the item
-	ld a,[wcf91]
-	ld [hli],a ; store item ID
-	ld a,[wItemQuantity]
-	ld [hli],a ; store item quantity
-	ld [hl],$ff ; store terminator
+	ld c, a
+	ld b, 0
+	add hl, bc ; hl = address to store the item
+	ld a, [wcf91]
+	ld [hli], a ; store item ID
+	ld a, [wItemQuantity]
+	ld [hli], a ; store item quantity
+	ld [hl], $ff ; store terminator
 	jp .success
 .increaseItemQuantity ; increase the quantity of an item already in the inventory
-	ld a,[wItemQuantity]
-	ld b,a ; b = quantity to add
-	ld a,[hl] ; a = existing item quantity
+	ld a, [wItemQuantity]
+	ld b, a ; b = quantity to add
+	ld a, [hl] ; a = existing item quantity
 	add b ; a = new item quantity
-	cp a,100
-	jp c,.storeNewQuantity ; if the new quantity is less than 100, store it
+	cp 100
+	jp c, .storeNewQuantity ; if the new quantity is less than 100, store it
 ; if the new quantity is greater than or equal to 100,
 ; try to max out the current slot and add the rest in a new slot
-	sub a,99
-	ld [wItemQuantity],a ; a = amount left over (to put in the new slot)
-	ld a,d
+	sub 99
+	ld [wItemQuantity], a ; a = amount left over (to put in the new slot)
+	ld a, d
 	and a ; is there room for a new item slot?
-	jr z,.increaseItemQuantityFailed
+	jr z, .increaseItemQuantityFailed
 ; if so, store 99 in the current slot and store the rest in a new slot
-	ld a,99
-	ld [hli],a
+	ld a, 99
+	ld [hli], a
 	jp .loop
 .increaseItemQuantityFailed
 	pop hl
 	and a
 	jr .done
 .storeNewQuantity
-	ld [hl],a
+	ld [hl], a
 	pop hl
 .success
 	scf
@@ -88,8 +88,8 @@ AddItemToInventory_:
 	pop de
 	pop bc
 	pop bc
-	ld a,b
-	ld [wItemQuantity],a ; restore the initial value from when the function was called
+	ld a, b
+	ld [wItemQuantity], a ; restore the initial value from when the function was called
 	ret
 
 ; function to remove an item (in varying quantities) from the player's bag or PC box
@@ -100,49 +100,49 @@ AddItemToInventory_:
 RemoveItemFromInventory_:
 	push hl
 	inc hl
-	ld a,[wWhichPokemon] ; index (within the inventory) of the item being removed
+	ld a, [wWhichPokemon] ; index (within the inventory) of the item being removed
 	sla a
 	add l
-	ld l,a
-	jr nc,.noCarry
+	ld l, a
+	jr nc, .noCarry
 	inc h
 .noCarry
 	inc hl
-	ld a,[wItemQuantity] ; quantity being removed
-	ld e,a
-	ld a,[hl] ; a = current quantity
+	ld a, [wItemQuantity] ; quantity being removed
+	ld e, a
+	ld a, [hl] ; a = current quantity
 	sub e
-	ld [hld],a ; store new quantity
-	ld [wMaxItemQuantity],a
+	ld [hld], a ; store new quantity
+	ld [wMaxItemQuantity], a
 	and a
-	jr nz,.skipMovingUpSlots
+	jr nz, .skipMovingUpSlots
 ; if the remaining quantity is 0,
 ; remove the emptied item slot and move up all the following item slots
 .moveSlotsUp
-	ld e,l
-	ld d,h
+	ld e, l
+	ld d, h
 	inc de
 	inc de ; de = address of the slot following the emptied one
 .loop ; loop to move up the following slots
-	ld a,[de]
+	ld a, [de]
 	inc de
-	ld [hli],a
-	cp a,$ff
-	jr nz,.loop
+	ld [hli], a
+	cp $ff
+	jr nz, .loop
 ; update menu info
 	xor a
-	ld [wListScrollOffset],a
-	ld [wCurrentMenuItem],a
-	ld [wBagSavedMenuItem],a
-	ld [wSavedListScrollOffset],a
+	ld [wListScrollOffset], a
+	ld [wCurrentMenuItem], a
+	ld [wBagSavedMenuItem], a
+	ld [wSavedListScrollOffset], a
 	pop hl
-	ld a,[hl] ; a = number of items in inventory
+	ld a, [hl] ; a = number of items in inventory
 	dec a ; decrement the number of items
-	ld [hl],a ; store new number of items
-	ld [wListCount],a
-	cp a,2
-	jr c,.done
-	ld [wMaxMenuItem],a
+	ld [hl], a ; store new number of items
+	ld [wListCount], a
+	cp 2
+	jr c, .done
+	ld [wMaxMenuItem], a
 	jr .done
 .skipMovingUpSlots
 	pop hl

--- a/engine/items/items.asm
+++ b/engine/items/items.asm
@@ -1,18 +1,18 @@
 UseItem_:
-	ld a,1
-	ld [wActionResultOrTookBattleTurn],a ; initialise to success value
-	ld a,[wcf91] ;contains item_ID
-	cp a,HM_01
-	jp nc,ItemUseTMHM
-	ld hl,ItemUsePtrTable
+	ld a, 1
+	ld [wActionResultOrTookBattleTurn], a ; initialise to success value
+	ld a, [wcf91] ;contains item_ID
+	cp HM_01
+	jp nc, ItemUseTMHM
+	ld hl, ItemUsePtrTable
 	dec a
 	add a
-	ld c,a
-	ld b,0
-	add hl,bc
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld c, a
+	ld b, 0
+	add hl, bc
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 	jp hl
 
 ItemUsePtrTable:
@@ -103,75 +103,75 @@ ItemUsePtrTable:
 ItemUseBall:
 
 ; Balls can't be used out of battle.
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp z,ItemUseNotTime
+	jp z, ItemUseNotTime
 
 ; Balls can't catch trainers' Pokémon.
 	dec a
-	jp nz,ThrowBallAtTrainerMon
+	jp nz, ThrowBallAtTrainerMon
 
 ; If this is for the old man battle, skip checking if the party & box are full.
-	ld a,[wBattleType]
+	ld a, [wBattleType]
 	dec a
-	jr z,.canUseBall
+	jr z, .canUseBall
 
-	ld a,[wPartyCount] ; is party full?
-	cp a,PARTY_LENGTH
-	jr nz,.canUseBall
-	ld a,[wNumInBox] ; is box full?
-	cp a,MONS_PER_BOX
-	jp z,BoxFullCannotThrowBall
+	ld a, [wPartyCount] ; is party full?
+	cp PARTY_LENGTH
+	jr nz, .canUseBall
+	ld a, [wNumInBox] ; is box full?
+	cp MONS_PER_BOX
+	jp z, BoxFullCannotThrowBall
 
 .canUseBall
 	xor a
-	ld [wCapturedMonSpecies],a
+	ld [wCapturedMonSpecies], a
 
-	ld a,[wBattleType]
-	cp a,BATTLE_TYPE_SAFARI
-	jr nz,.skipSafariZoneCode
+	ld a, [wBattleType]
+	cp BATTLE_TYPE_SAFARI
+	jr nz, .skipSafariZoneCode
 
 .safariZone
-	ld hl,wNumSafariBalls
+	ld hl, wNumSafariBalls
 	dec [hl] ; remove a Safari Ball
 
 .skipSafariZoneCode
 	call RunDefaultPaletteCommand
 
-	ld a,$43 ; successful capture value
-	ld [wPokeBallAnimData],a
+	ld a, $43 ; successful capture value
+	ld [wPokeBallAnimData], a
 
 	call LoadScreenTilesFromBuffer1
-	ld hl,ItemUseText00
+	ld hl, ItemUseText00
 	call PrintText
 
 ; If the player is fighting an unidentified ghost, set the value that indicates
 ; the Pokémon can't be caught and skip the capture calculations.
 	callab IsGhostBattle
-	ld b,$10 ; can't be caught value
-	jp z,.setAnimData
+	ld b, $10 ; can't be caught value
+	jp z, .setAnimData
 
-	ld a,[wBattleType]
+	ld a, [wBattleType]
 	dec a
-	jr nz,.notOldManBattle
+	jr nz, .notOldManBattle
 
 .oldManBattle
-	ld hl,wGrassRate
-	ld de,wPlayerName
-	ld bc,NAME_LENGTH
+	ld hl, wGrassRate
+	ld de, wPlayerName
+	ld bc, NAME_LENGTH
 	call CopyData ; save the player's name in the Wild Monster data (part of the Cinnabar Island Missingno. glitch)
 	jp .captured
 
 .notOldManBattle
 ; If the player is fighting the ghost Marowak, set the value that indicates the
 ; Pokémon can't be caught and skip the capture calculations.
-	ld a,[wCurMap]
-	cp a,POKEMONTOWER_6
-	jr nz,.loop
-	ld a,[wEnemyMonSpecies2]
-	cp a,MAROWAK
-	ld b,$10 ; can't be caught value
-	jp z,.setAnimData
+	ld a, [wCurMap]
+	cp POKEMONTOWER_6
+	jr nz, .loop
+	ld a, [wEnemyMonSpecies2]
+	cp MAROWAK
+	ld b, $10 ; can't be caught value
+	jp z, .setAnimData
 
 ; Get the first random number. Let it be called Rand1.
 ; Rand1 must be within a certain range according the kind of ball being thrown.
@@ -183,34 +183,34 @@ ItemUseBall:
 
 .loop
 	call Random
-	ld b,a
+	ld b, a
 
 ; Get the item ID.
-	ld hl,wcf91
-	ld a,[hl]
+	ld hl, wcf91
+	ld a, [hl]
 
 ; The Master Ball always succeeds.
-	cp a,MASTER_BALL
-	jp z,.captured
+	cp MASTER_BALL
+	jp z, .captured
 
 ; Anything will do for the basic Poké Ball.
-	cp a,POKE_BALL
-	jr z,.checkForAilments
+	cp POKE_BALL
+	jr z, .checkForAilments
 
 ; If it's a Great/Ultra/Safari Ball and Rand1 is greater than 200, try again.
-	ld a,200
+	ld a, 200
 	cp b
-	jr c,.loop
+	jr c, .loop
 
 ; Less than or equal to 200 is good enough for a Great Ball.
-	ld a,[hl]
-	cp a,GREAT_BALL
-	jr z,.checkForAilments
+	ld a, [hl]
+	cp GREAT_BALL
+	jr z, .checkForAilments
 
 ; If it's an Ultra/Safari Ball and Rand1 is greater than 150, try again.
-	ld a,150
+	ld a, 150
 	cp b
-	jr c,.loop
+	jr c, .loop
 
 .checkForAilments
 ; Pokémon can be caught more easily with a status ailment.
@@ -221,174 +221,174 @@ ItemUseBall:
 ; Burn/Paralysis/Poison: Status = 12
 ; Freeze/Sleep:          Status = 25
 ; If Status is greater than Rand1, the Pokémon will be caught for sure.
-	ld a,[wEnemyMonStatus]
+	ld a, [wEnemyMonStatus]
 	and a
-	jr z,.skipAilmentValueSubtraction ; no ailments
-	and a, 1 << FRZ | SLP
-	ld c,12
-	jr z,.notFrozenOrAsleep
-	ld c,25
+	jr z, .skipAilmentValueSubtraction ; no ailments
+	and 1 << FRZ | SLP
+	ld c, 12
+	jr z, .notFrozenOrAsleep
+	ld c, 25
 .notFrozenOrAsleep
-	ld a,b
+	ld a, b
 	sub c
-	jp c,.captured
-	ld b,a
+	jp c, .captured
+	ld b, a
 
 .skipAilmentValueSubtraction
 	push bc ; save (Rand1 - Status)
 
 ; Calculate MaxHP * 255.
 	xor a
-	ld [H_MULTIPLICAND],a
-	ld hl,wEnemyMonMaxHP
-	ld a,[hli]
-	ld [H_MULTIPLICAND + 1],a
-	ld a,[hl]
-	ld [H_MULTIPLICAND + 2],a
-	ld a,255
-	ld [H_MULTIPLIER],a
+	ld [H_MULTIPLICAND], a
+	ld hl, wEnemyMonMaxHP
+	ld a, [hli]
+	ld [H_MULTIPLICAND + 1], a
+	ld a, [hl]
+	ld [H_MULTIPLICAND + 2], a
+	ld a, 255
+	ld [H_MULTIPLIER], a
 	call Multiply
 
 ; Determine BallFactor. It's 8 for Great Balls and 12 for the others.
-	ld a,[wcf91]
-	cp a,GREAT_BALL
-	ld a,12
-	jr nz,.skip1
-	ld a,8
+	ld a, [wcf91]
+	cp GREAT_BALL
+	ld a, 12
+	jr nz, .skip1
+	ld a, 8
 
 .skip1
 ; Note that the results of all division operations are floored.
 
 ; Calculate (MaxHP * 255) / BallFactor.
-	ld [H_DIVISOR],a
-	ld b,4 ; number of bytes in dividend
+	ld [H_DIVISOR], a
+	ld b, 4 ; number of bytes in dividend
 	call Divide
 
 ; Divide the enemy's current HP by 4. HP is not supposed to exceed 999 so
 ; the result should fit in a. If the division results in a quotient of 0,
 ; change it to 1.
-	ld hl,wEnemyMonHP
-	ld a,[hli]
-	ld b,a
-	ld a,[hl]
+	ld hl, wEnemyMonHP
+	ld a, [hli]
+	ld b, a
+	ld a, [hl]
 	srl b
 	rr a
 	srl b
 	rr a
 	and a
-	jr nz,.skip2
+	jr nz, .skip2
 	inc a
 
 .skip2
 ; Let W = ((MaxHP * 255) / BallFactor) / max(HP / 4, 1). Calculate W.
-	ld [H_DIVISOR],a
-	ld b,4
+	ld [H_DIVISOR], a
+	ld b, 4
 	call Divide
 
 ; If W > 255, store 255 in [H_QUOTIENT + 3].
 ; Let X = min(W, 255) = [H_QUOTIENT + 3].
-	ld a,[H_QUOTIENT + 2]
+	ld a, [H_QUOTIENT + 2]
 	and a
-	jr z,.skip3
-	ld a,255
-	ld [H_QUOTIENT + 3],a
+	jr z, .skip3
+	ld a, 255
+	ld [H_QUOTIENT + 3], a
 
 .skip3
 	pop bc ; b = Rand1 - Status
 
 ; If Rand1 - Status > CatchRate, the ball fails to capture the Pokémon.
-	ld a,[wEnemyMonCatchRate]
+	ld a, [wEnemyMonCatchRate]
 	cp b
-	jr c,.failedToCapture
+	jr c, .failedToCapture
 
 ; If W > 255, the ball captures the Pokémon.
-	ld a,[H_QUOTIENT + 2]
+	ld a, [H_QUOTIENT + 2]
 	and a
-	jr nz,.captured
+	jr nz, .captured
 
 	call Random ; Let this random number be called Rand2.
 
 ; If Rand2 > X, the ball fails to capture the Pokémon.
-	ld b,a
-	ld a,[H_QUOTIENT + 3]
+	ld b, a
+	ld a, [H_QUOTIENT + 3]
 	cp b
-	jr c,.failedToCapture
+	jr c, .failedToCapture
 
 .captured
 	jr .skipShakeCalculations
 
 .failedToCapture
-	ld a,[H_QUOTIENT + 3]
-	ld [wPokeBallCaptureCalcTemp],a ; Save X.
+	ld a, [H_QUOTIENT + 3]
+	ld [wPokeBallCaptureCalcTemp], a ; Save X.
 
 ; Calculate CatchRate * 100.
 	xor a
-	ld [H_MULTIPLICAND],a
-	ld [H_MULTIPLICAND + 1],a
-	ld a,[wEnemyMonCatchRate]
-	ld [H_MULTIPLICAND + 2],a
-	ld a,100
-	ld [H_MULTIPLIER],a
+	ld [H_MULTIPLICAND], a
+	ld [H_MULTIPLICAND + 1], a
+	ld a, [wEnemyMonCatchRate]
+	ld [H_MULTIPLICAND + 2], a
+	ld a, 100
+	ld [H_MULTIPLIER], a
 	call Multiply
 
 ; Determine BallFactor2.
 ; Poké Ball:         BallFactor2 = 255
 ; Great Ball:        BallFactor2 = 200
 ; Ultra/Safari Ball: BallFactor2 = 150
-	ld a,[wcf91]
-	ld b,255
-	cp a,POKE_BALL
-	jr z,.skip4
-	ld b,200
-	cp a,GREAT_BALL
-	jr z,.skip4
-	ld b,150
-	cp a,ULTRA_BALL
-	jr z,.skip4
+	ld a, [wcf91]
+	ld b, 255
+	cp POKE_BALL
+	jr z, .skip4
+	ld b, 200
+	cp GREAT_BALL
+	jr z, .skip4
+	ld b, 150
+	cp ULTRA_BALL
+	jr z, .skip4
 
 .skip4
 ; Let Y = (CatchRate * 100) / BallFactor2. Calculate Y.
-	ld a,b
-	ld [H_DIVISOR],a
-	ld b,4
+	ld a, b
+	ld [H_DIVISOR], a
+	ld b, 4
 	call Divide
 
 ; If Y > 255, there are 3 shakes.
 ; Note that this shouldn't be possible.
 ; The maximum value of Y is (255 * 100) / 150 = 170.
-	ld a,[H_QUOTIENT + 2]
+	ld a, [H_QUOTIENT + 2]
 	and a
-	ld b,$63 ; 3 shakes
-	jr nz,.setAnimData
+	ld b, $63 ; 3 shakes
+	jr nz, .setAnimData
 
 ; Calculate X * Y.
-	ld a,[wPokeBallCaptureCalcTemp]
-	ld [H_MULTIPLIER],a
+	ld a, [wPokeBallCaptureCalcTemp]
+	ld [H_MULTIPLIER], a
 	call Multiply
 
 ; Calculate (X * Y) / 255.
-	ld a,255
-	ld [H_DIVISOR],a
-	ld b,4
+	ld a, 255
+	ld [H_DIVISOR], a
+	ld b, 4
 	call Divide
 
 ; Determine Status2.
 ; no status ailment:     Status2 = 0
 ; Burn/Paralysis/Poison: Status2 = 5
 ; Freeze/Sleep:          Status2 = 10
-	ld a,[wEnemyMonStatus]
+	ld a, [wEnemyMonStatus]
 	and a
-	jr z,.skip5
-	and a, 1 << FRZ | SLP
-	ld b,5
-	jr z,.addAilmentValue
-	ld b,10
+	jr z, .skip5
+	and 1 << FRZ | SLP
+	ld b, 5
+	jr z, .addAilmentValue
+	ld b, 10
 
 .addAilmentValue
 ; If the Pokémon has a status ailment, add Status2.
-	ld a,[H_QUOTIENT + 3]
+	ld a, [H_QUOTIENT + 3]
 	add b
-	ld [H_QUOTIENT + 3],a
+	ld [H_QUOTIENT + 3], a
 
 .skip5
 ; Finally determine the number of shakes.
@@ -398,71 +398,71 @@ ItemUseBall:
 ; 10 ≤ Z < 30: 1 shake
 ; 30 ≤ Z < 70: 2 shakes
 ; 70 ≤ Z:      3 shakes
-	ld a,[H_QUOTIENT + 3]
-	cp a,10
-	ld b,$20
-	jr c,.setAnimData
-	cp a,30
-	ld b,$61
-	jr c,.setAnimData
-	cp a,70
-	ld b,$62
-	jr c,.setAnimData
-	ld b,$63
+	ld a, [H_QUOTIENT + 3]
+	cp 10
+	ld b, $20
+	jr c, .setAnimData
+	cp 30
+	ld b, $61
+	jr c, .setAnimData
+	cp 70
+	ld b, $62
+	jr c, .setAnimData
+	ld b, $63
 
 .setAnimData
-	ld a,b
-	ld [wPokeBallAnimData],a
+	ld a, b
+	ld [wPokeBallAnimData], a
 
 .skipShakeCalculations
-	ld c,20
+	ld c, 20
 	call DelayFrames
 
 ; Do the animation.
-	ld a,TOSS_ANIM
-	ld [wAnimationID],a
+	ld a, TOSS_ANIM
+	ld [wAnimationID], a
 	xor a
-	ld [H_WHOSETURN],a
-	ld [wAnimationType],a
-	ld [wDamageMultipliers],a
-	ld a,[wWhichPokemon]
+	ld [H_WHOSETURN], a
+	ld [wAnimationType], a
+	ld [wDamageMultipliers], a
+	ld a, [wWhichPokemon]
 	push af
-	ld a,[wcf91]
+	ld a, [wcf91]
 	push af
 	predef MoveAnimation
 	pop af
-	ld [wcf91],a
+	ld [wcf91], a
 	pop af
-	ld [wWhichPokemon],a
+	ld [wWhichPokemon], a
 
 ; Determine the message to display from the animation.
-	ld a,[wPokeBallAnimData]
-	cp a,$10
-	ld hl,ItemUseBallText00
-	jp z,.printMessage
-	cp a,$20
-	ld hl,ItemUseBallText01
-	jp z,.printMessage
-	cp a,$61
-	ld hl,ItemUseBallText02
-	jp z,.printMessage
-	cp a,$62
-	ld hl,ItemUseBallText03
-	jp z,.printMessage
-	cp a,$63
-	ld hl,ItemUseBallText04
-	jp z,.printMessage
+	ld a, [wPokeBallAnimData]
+	cp $10
+	ld hl, ItemUseBallText00
+	jp z, .printMessage
+	cp $20
+	ld hl, ItemUseBallText01
+	jp z, .printMessage
+	cp $61
+	ld hl, ItemUseBallText02
+	jp z, .printMessage
+	cp $62
+	ld hl, ItemUseBallText03
+	jp z, .printMessage
+	cp $63
+	ld hl, ItemUseBallText04
+	jp z, .printMessage
 
 ; Save current HP.
-	ld hl,wEnemyMonHP
-	ld a,[hli]
+	ld hl, wEnemyMonHP
+	ld a, [hli]
 	push af
-	ld a,[hli]
+	ld a, [hli]
 	push af
 
 ; Save status ailment.
 	inc hl
-	ld a,[hl]
+	ld a, [hl]
 	push af
 
 	push hl
@@ -470,86 +470,86 @@ ItemUseBall:
 ; If the Pokémon is transformed, the Pokémon is assumed to be a Ditto.
 ; This is a bug because a wild Pokémon could have used Transform via
 ; Mirror Move even though the only wild Pokémon that knows Transform is Ditto.
-	ld hl,wEnemyBattleStatus3
-	bit TRANSFORMED,[hl]
-	jr z,.notTransformed
-	ld a,DITTO
-	ld [wEnemyMonSpecies2],a
+	ld hl, wEnemyBattleStatus3
+	bit TRANSFORMED, [hl]
+	jr z, .notTransformed
+	ld a, DITTO
+	ld [wEnemyMonSpecies2], a
 	jr .skip6
 
 .notTransformed
 ; If the Pokémon is not transformed, set the transformed bit and copy the
 ; DVs to wTransformedEnemyMonOriginalDVs so that LoadEnemyMonData won't generate
 ; new DVs.
-	set TRANSFORMED,[hl]
-	ld hl,wTransformedEnemyMonOriginalDVs
-	ld a,[wEnemyMonDVs]
-	ld [hli],a
-	ld a,[wEnemyMonDVs + 1]
-	ld [hl],a
+	set TRANSFORMED, [hl]
+	ld hl, wTransformedEnemyMonOriginalDVs
+	ld a, [wEnemyMonDVs]
+	ld [hli], a
+	ld a, [wEnemyMonDVs + 1]
+	ld [hl], a
 
 .skip6
-	ld a,[wcf91]
+	ld a, [wcf91]
 	push af
-	ld a,[wEnemyMonSpecies2]
-	ld [wcf91],a
-	ld a,[wEnemyMonLevel]
-	ld [wCurEnemyLVL],a
+	ld a, [wEnemyMonSpecies2]
+	ld [wcf91], a
+	ld a, [wEnemyMonLevel]
+	ld [wCurEnemyLVL], a
 	callab LoadEnemyMonData
 	pop af
-	ld [wcf91],a
+	ld [wcf91], a
 	pop hl
 	pop af
-	ld [hld],a
+	ld [hld], a
 	dec hl
 	pop af
-	ld [hld],a
+	ld [hld], a
 	pop af
-	ld [hl],a
-	ld a,[wEnemyMonSpecies]
-	ld [wCapturedMonSpecies],a
-	ld [wcf91],a
-	ld [wd11e],a
-	ld a,[wBattleType]
+	ld [hl], a
+	ld a, [wEnemyMonSpecies]
+	ld [wCapturedMonSpecies], a
+	ld [wcf91], a
+	ld [wd11e], a
+	ld a, [wBattleType]
 	dec a ; is this the old man battle?
-	jr z,.oldManCaughtMon ; if so, don't give the player the caught Pokémon
+	jr z, .oldManCaughtMon ; if so, don't give the player the caught Pokémon
 
-	ld hl,ItemUseBallText05
+	ld hl, ItemUseBallText05
 	call PrintText
 
 ; Add the caught Pokémon to the Pokédex.
 	predef IndexToPokedex
-	ld a,[wd11e]
+	ld a, [wd11e]
 	dec a
-	ld c,a
-	ld b,FLAG_TEST
-	ld hl,wPokedexOwned
+	ld c, a
+	ld b, FLAG_TEST
+	ld hl, wPokedexOwned
 	predef FlagActionPredef
-	ld a,c
+	ld a, c
 	push af
-	ld a,[wd11e]
+	ld a, [wd11e]
 	dec a
-	ld c,a
-	ld b,FLAG_SET
+	ld c, a
+	ld b, FLAG_SET
 	predef FlagActionPredef
 	pop af
 
 	and a ; was the Pokémon already in the Pokédex?
-	jr nz,.skipShowingPokedexData ; if so, don't show the Pokédex data
+	jr nz, .skipShowingPokedexData ; if so, don't show the Pokédex data
 
-	ld hl,ItemUseBallText06
+	ld hl, ItemUseBallText06
 	call PrintText
 	call ClearSprites
-	ld a,[wEnemyMonSpecies]
-	ld [wd11e],a
+	ld a, [wEnemyMonSpecies]
+	ld [wd11e], a
 	predef ShowPokedexData
 
 .skipShowingPokedexData
-	ld a,[wPartyCount]
-	cp a,PARTY_LENGTH ; is party full?
-	jr z,.sendToBox
+	ld a, [wPartyCount]
+	cp PARTY_LENGTH ; is party full?
+	jr z, .sendToBox
 	xor a ; PLAYER_PARTY_DATA
-	ld [wMonDataLocation],a
+	ld [wMonDataLocation], a
 	call ClearSprites
 	call AddPartyMon
 	jr .done
@@ -557,30 +557,30 @@ ItemUseBall:
 .sendToBox
 	call ClearSprites
 	call SendNewMonToBox
-	ld hl,ItemUseBallText07
+	ld hl, ItemUseBallText07
 	CheckEvent EVENT_MET_BILL
-	jr nz,.printTransferredToPCText
-	ld hl,ItemUseBallText08
+	jr nz, .printTransferredToPCText
+	ld hl, ItemUseBallText08
 .printTransferredToPCText
 	call PrintText
 	jr .done
 
 .oldManCaughtMon
-	ld hl,ItemUseBallText05
+	ld hl, ItemUseBallText05
 
 .printMessage
 	call PrintText
 	call ClearSprites
 
 .done
-	ld a,[wBattleType]
+	ld a, [wBattleType]
 	and a ; is this the old man battle?
 	ret nz ; if so, don't remove a ball from the bag
 
 ; Remove a ball from the bag.
-	ld hl,wNumBagItems
+	ld hl, wNumBagItems
 	inc a
-	ld [wItemQuantity],a
+	ld [wItemQuantity], a
 	jp RemoveItemFromInventory
 
 ItemUseBallText00:
@@ -629,119 +629,119 @@ ItemUseBallText06:
 	db "@"
 
 ItemUseTownMap:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp nz,ItemUseNotTime
+	jp nz, ItemUseNotTime
 	jpba DisplayTownMap
 
 ItemUseBicycle:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp nz,ItemUseNotTime
-	ld a,[wWalkBikeSurfState]
-	ld [wWalkBikeSurfStateCopy],a
-	cp a,2 ; is the player surfing?
-	jp z,ItemUseNotTime
+	jp nz, ItemUseNotTime
+	ld a, [wWalkBikeSurfState]
+	ld [wWalkBikeSurfStateCopy], a
+	cp 2 ; is the player surfing?
+	jp z, ItemUseNotTime
 	dec a ; is player already bicycling?
-	jr nz,.tryToGetOnBike
+	jr nz, .tryToGetOnBike
 .getOffBike
 	call ItemUseReloadOverworldData
 	xor a
-	ld [wWalkBikeSurfState],a ; change player state to walking
+	ld [wWalkBikeSurfState], a ; change player state to walking
 	call PlayDefaultMusic ; play walking music
-	ld hl,GotOffBicycleText
+	ld hl, GotOffBicycleText
 	jr .printText
 .tryToGetOnBike
 	call IsBikeRidingAllowed
-	jp nc,NoCyclingAllowedHere
+	jp nc, NoCyclingAllowedHere
 	call ItemUseReloadOverworldData
 	xor a ; no keys pressed
-	ld [hJoyHeld],a ; current joypad state
+	ld [hJoyHeld], a ; current joypad state
 	inc a
-	ld [wWalkBikeSurfState],a ; change player state to bicycling
-	ld hl,GotOnBicycleText
+	ld [wWalkBikeSurfState], a ; change player state to bicycling
+	ld hl, GotOnBicycleText
 	call PlayDefaultMusic ; play bike riding music
 .printText
 	jp PrintText
 
 ; used for Surf out-of-battle effect
 ItemUseSurfboard:
-	ld a,[wWalkBikeSurfState]
-	ld [wWalkBikeSurfStateCopy],a
-	cp a,2 ; is the player already surfing?
-	jr z,.tryToStopSurfing
+	ld a, [wWalkBikeSurfState]
+	ld [wWalkBikeSurfStateCopy], a
+	cp 2 ; is the player already surfing?
+	jr z, .tryToStopSurfing
 .tryToSurf
 	call IsNextTileShoreOrWater
-	jp c,SurfingAttemptFailed
-	ld hl,TilePairCollisionsWater
+	jp c, SurfingAttemptFailed
+	ld hl, TilePairCollisionsWater
 	call CheckForTilePairCollisions
-	jp c,SurfingAttemptFailed
+	jp c, SurfingAttemptFailed
 .surf
 	call .makePlayerMoveForward
-	ld hl,wd730
-	set 7,[hl]
-	ld a,2
-	ld [wWalkBikeSurfState],a ; change player state to surfing
+	ld hl, wd730
+	set 7, [hl]
+	ld a, 2
+	ld [wWalkBikeSurfState], a ; change player state to surfing
 	call PlayDefaultMusic ; play surfing music
-	ld hl,SurfingGotOnText
+	ld hl, SurfingGotOnText
 	jp PrintText
 .tryToStopSurfing
 	xor a
-	ld [hSpriteIndexOrTextID],a
-	ld d,16 ; talking range in pixels (normal range)
+	ld [hSpriteIndexOrTextID], a
+	ld d, 16 ; talking range in pixels (normal range)
 	call IsSpriteInFrontOfPlayer2
-	res 7,[hl]
-	ld a,[hSpriteIndexOrTextID]
+	res 7, [hl]
+	ld a, [hSpriteIndexOrTextID]
 	and a ; is there a sprite in the way?
-	jr nz,.cannotStopSurfing
-	ld hl,TilePairCollisionsWater
+	jr nz, .cannotStopSurfing
+	ld hl, TilePairCollisionsWater
 	call CheckForTilePairCollisions
-	jr c,.cannotStopSurfing
-	ld hl,wTilesetCollisionPtr ; pointer to list of passable tiles
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a ; hl now points to passable tiles
-	ld a,[wTileInFrontOfPlayer] ; tile in front of the player
-	ld b,a
+	jr c, .cannotStopSurfing
+	ld hl, wTilesetCollisionPtr ; pointer to list of passable tiles
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a ; hl now points to passable tiles
+	ld a, [wTileInFrontOfPlayer] ; tile in front of the player
+	ld b, a
 .passableTileLoop
-	ld a,[hli]
+	ld a, [hli]
 	cp b
-	jr z,.stopSurfing
-	cp a,$ff
-	jr nz,.passableTileLoop
+	jr z, .stopSurfing
+	cp $ff
+	jr nz, .passableTileLoop
 .cannotStopSurfing
-	ld hl,SurfingNoPlaceToGetOffText
+	ld hl, SurfingNoPlaceToGetOffText
 	jp PrintText
 .stopSurfing
 	call .makePlayerMoveForward
-	ld hl,wd730
-	set 7,[hl]
+	ld hl, wd730
+	set 7, [hl]
 	xor a
-	ld [wWalkBikeSurfState],a ; change player state to walking
+	ld [wWalkBikeSurfState], a ; change player state to walking
 	dec a
-	ld [wJoyIgnore],a
+	ld [wJoyIgnore], a
 	call PlayDefaultMusic ; play walking music
 	jp LoadWalkingPlayerSpriteGraphics
 ; uses a simulated button press to make the player move forward
 .makePlayerMoveForward
-	ld a,[wPlayerDirection] ; direction the player is going
-	bit PLAYER_DIR_BIT_UP,a
-	ld b,D_UP
-	jr nz,.storeSimulatedButtonPress
-	bit PLAYER_DIR_BIT_DOWN,a
-	ld b,D_DOWN
-	jr nz,.storeSimulatedButtonPress
-	bit PLAYER_DIR_BIT_LEFT,a
-	ld b,D_LEFT
-	jr nz,.storeSimulatedButtonPress
-	ld b,D_RIGHT
+	ld a, [wPlayerDirection] ; direction the player is going
+	bit PLAYER_DIR_BIT_UP, a
+	ld b, D_UP
+	jr nz, .storeSimulatedButtonPress
+	bit PLAYER_DIR_BIT_DOWN, a
+	ld b, D_DOWN
+	jr nz, .storeSimulatedButtonPress
+	bit PLAYER_DIR_BIT_LEFT, a
+	ld b, D_LEFT
+	jr nz, .storeSimulatedButtonPress
+	ld b, D_RIGHT
 .storeSimulatedButtonPress
-	ld a,b
-	ld [wSimulatedJoypadStatesEnd],a
+	ld a, b
+	ld [wSimulatedJoypadStatesEnd], a
 	xor a
-	ld [wWastedByteCD39],a
+	ld [wWastedByteCD39], a
 	inc a
-	ld [wSimulatedJoypadStatesIndex],a
+	ld [wSimulatedJoypadStatesIndex], a
 	ret
 
 SurfingGotOnText:
@@ -756,73 +756,73 @@ ItemUsePokedex:
 	predef_jump ShowPokedexMenu
 
 ItemUseEvoStone:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp nz,ItemUseNotTime
-	ld a,[wWhichPokemon]
+	jp nz, ItemUseNotTime
+	ld a, [wWhichPokemon]
 	push af
-	ld a,[wcf91]
-	ld [wEvoStoneItemID],a
+	ld a, [wcf91]
+	ld [wEvoStoneItemID], a
 	push af
-	ld a,EVO_STONE_PARTY_MENU
-	ld [wPartyMenuTypeOrMessageID],a
-	ld a,$ff
-	ld [wUpdateSpritesEnabled],a
+	ld a, EVO_STONE_PARTY_MENU
+	ld [wPartyMenuTypeOrMessageID], a
+	ld a, $ff
+	ld [wUpdateSpritesEnabled], a
 	call DisplayPartyMenu
 	pop bc
-	jr c,.canceledItemUse
-	ld a,b
-	ld [wcf91],a
-	ld a,$01
-	ld [wForceEvolution],a
-	ld a,SFX_HEAL_AILMENT
+	jr c, .canceledItemUse
+	ld a, b
+	ld [wcf91], a
+	ld a, $01
+	ld [wForceEvolution], a
+	ld a, SFX_HEAL_AILMENT
 	call PlaySoundWaitForCurrent
 	call WaitForSoundToFinish
 	callab TryEvolvingMon ; try to evolve pokemon
-	ld a,[wEvolutionOccurred]
+	ld a, [wEvolutionOccurred]
 	and a
-	jr z,.noEffect
+	jr z, .noEffect
 	pop af
-	ld [wWhichPokemon],a
-	ld hl,wNumBagItems
-	ld a,1 ; remove 1 stone
-	ld [wItemQuantity],a
+	ld [wWhichPokemon], a
+	ld hl, wNumBagItems
+	ld a, 1 ; remove 1 stone
+	ld [wItemQuantity], a
 	jp RemoveItemFromInventory
 .noEffect
 	call ItemUseNoEffect
 .canceledItemUse
 	xor a
-	ld [wActionResultOrTookBattleTurn],a ; item not used
+	ld [wActionResultOrTookBattleTurn], a ; item not used
 	pop af
 	ret
 
 ItemUseVitamin:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp nz,ItemUseNotTime
+	jp nz, ItemUseNotTime
 
 ItemUseMedicine:
-	ld a,[wPartyCount]
+	ld a, [wPartyCount]
 	and a
-	jp z,.emptyParty
-	ld a,[wWhichPokemon]
+	jp z, .emptyParty
+	ld a, [wWhichPokemon]
 	push af
-	ld a,[wcf91]
+	ld a, [wcf91]
 	push af
-	ld a,USE_ITEM_PARTY_MENU
-	ld [wPartyMenuTypeOrMessageID],a
-	ld a,$ff
-	ld [wUpdateSpritesEnabled],a
-	ld a,[wPseudoItemID]
+	ld a, USE_ITEM_PARTY_MENU
+	ld [wPartyMenuTypeOrMessageID], a
+	ld a, $ff
+	ld [wUpdateSpritesEnabled], a
+	ld a, [wPseudoItemID]
 	and a ; using Softboiled?
-	jr z,.notUsingSoftboiled
+	jr z, .notUsingSoftboiled
 ; if using softboiled
 	call GoBackToPartyMenu
 	jr .getPartyMonDataAddress
 .emptyParty
-	ld hl,.emptyPartyText
+	ld hl, .emptyPartyText
 	xor a
-	ld [wActionResultOrTookBattleTurn],a ; item use failed
+	ld [wActionResultOrTookBattleTurn], a ; item use failed
 	jp PrintText
 .emptyPartyText
 	text "You don't have"
@@ -831,121 +831,121 @@ ItemUseMedicine:
 .notUsingSoftboiled
 	call DisplayPartyMenu
 .getPartyMonDataAddress
-	jp c,.canceledItemUse
-	ld hl,wPartyMons
-	ld bc,wPartyMon2 - wPartyMon1
-	ld a,[wWhichPokemon]
+	jp c, .canceledItemUse
+	ld hl, wPartyMons
+	ld bc, wPartyMon2 - wPartyMon1
+	ld a, [wWhichPokemon]
 	call AddNTimes
-	ld a,[wWhichPokemon]
-	ld [wUsedItemOnWhichPokemon],a
-	ld d,a
-	ld a,[wcf91]
-	ld e,a
-	ld [wd0b5],a
+	ld a, [wWhichPokemon]
+	ld [wUsedItemOnWhichPokemon], a
+	ld d, a
+	ld a, [wcf91]
+	ld e, a
+	ld [wd0b5], a
 	pop af
-	ld [wcf91],a
+	ld [wcf91], a
 	pop af
-	ld [wWhichPokemon],a
-	ld a,[wPseudoItemID]
+	ld [wWhichPokemon], a
+	ld a, [wPseudoItemID]
 	and a ; using Softboiled?
-	jr z,.checkItemType
+	jr z, .checkItemType
 ; if using softboiled
-	ld a,[wWhichPokemon]
+	ld a, [wWhichPokemon]
 	cp d ; is the pokemon trying to use softboiled on itself?
-	jr z,ItemUseMedicine ; if so, force another choice
+	jr z, ItemUseMedicine ; if so, force another choice
 .checkItemType
-	ld a,[wcf91]
-	cp a,REVIVE
-	jr nc,.healHP ; if it's a Revive or Max Revive
-	cp a,FULL_HEAL
-	jr z,.cureStatusAilment ; if it's a Full Heal
-	cp a,HP_UP
-	jp nc,.useVitamin ; if it's a vitamin or Rare Candy
-	cp a,FULL_RESTORE
-	jr nc,.healHP ; if it's a Full Restore or one of the potions
+	ld a, [wcf91]
+	cp REVIVE
+	jr nc, .healHP ; if it's a Revive or Max Revive
+	cp FULL_HEAL
+	jr z, .cureStatusAilment ; if it's a Full Heal
+	cp HP_UP
+	jp nc, .useVitamin ; if it's a vitamin or Rare Candy
+	cp FULL_RESTORE
+	jr nc, .healHP ; if it's a Full Restore or one of the potions
 ; fall through if it's one of the status-specific healing items
 .cureStatusAilment
-	ld bc,wPartyMon1Status - wPartyMon1
-	add hl,bc ; hl now points to status
-	ld a,[wcf91]
+	ld bc, wPartyMon1Status - wPartyMon1
+	add hl, bc ; hl now points to status
+	ld a, [wcf91]
 	lb bc, ANTIDOTE_MSG, 1 << PSN
-	cp a,ANTIDOTE
-	jr z,.checkMonStatus
+	cp ANTIDOTE
+	jr z, .checkMonStatus
 	lb bc, BURN_HEAL_MSG, 1 << BRN
-	cp a,BURN_HEAL
-	jr z,.checkMonStatus
+	cp BURN_HEAL
+	jr z, .checkMonStatus
 	lb bc, ICE_HEAL_MSG, 1 << FRZ
-	cp a,ICE_HEAL
-	jr z,.checkMonStatus
+	cp ICE_HEAL
+	jr z, .checkMonStatus
 	lb bc, AWAKENING_MSG, SLP
-	cp a,AWAKENING
-	jr z,.checkMonStatus
+	cp AWAKENING
+	jr z, .checkMonStatus
 	lb bc, PARALYZ_HEAL_MSG, 1 << PAR
-	cp a,PARLYZ_HEAL
-	jr z,.checkMonStatus
+	cp PARLYZ_HEAL
+	jr z, .checkMonStatus
 	lb bc, FULL_HEAL_MSG, $ff ; Full Heal
 .checkMonStatus
-	ld a,[hl] ; pokemon's status
+	ld a, [hl] ; pokemon's status
 	and c ; does the pokemon have a status ailment the item can cure?
-	jp z,.healingItemNoEffect
+	jp z, .healingItemNoEffect
 ; if the pokemon has a status the item can heal
 	xor a
-	ld [hl],a ; remove the status ailment in the party data
-	ld a,b
-	ld [wPartyMenuTypeOrMessageID],a ; the message to display for the item used
-	ld a,[wPlayerMonNumber]
+	ld [hl], a ; remove the status ailment in the party data
+	ld a, b
+	ld [wPartyMenuTypeOrMessageID], a ; the message to display for the item used
+	ld a, [wPlayerMonNumber]
 	cp d ; is pokemon the item was used on active in battle?
-	jp nz,.doneHealing
+	jp nz, .doneHealing
 ; if it is active in battle
 	xor a
-	ld [wBattleMonStatus],a ; remove the status ailment in the in-battle pokemon data
+	ld [wBattleMonStatus], a ; remove the status ailment in the in-battle pokemon data
 	push hl
-	ld hl,wPlayerBattleStatus3
-	res BADLY_POISONED,[hl] ; heal Toxic status
+	ld hl, wPlayerBattleStatus3
+	res BADLY_POISONED, [hl] ; heal Toxic status
 	pop hl
-	ld bc,wPartyMon1Stats - wPartyMon1Status
-	add hl,bc ; hl now points to party stats
-	ld de,wBattleMonStats
-	ld bc,NUM_STATS * 2
+	ld bc, wPartyMon1Stats - wPartyMon1Status
+	add hl, bc ; hl now points to party stats
+	ld de, wBattleMonStats
+	ld bc, NUM_STATS * 2
 	call CopyData ; copy party stats to in-battle stat data
 	predef DoubleOrHalveSelectedStats
 	jp .doneHealing
 .healHP
 	inc hl ; hl = address of current HP
-	ld a,[hli]
-	ld b,a
-	ld [wHPBarOldHP+1],a
-	ld a,[hl]
-	ld c,a
-	ld [wHPBarOldHP],a ; current HP stored at wHPBarOldHP (2 bytes, big-endian)
+	ld a, [hli]
+	ld b, a
+	ld [wHPBarOldHP+1], a
+	ld a, [hl]
+	ld c, a
+	ld [wHPBarOldHP], a ; current HP stored at wHPBarOldHP (2 bytes, big-endian)
 	or b
-	jr nz,.notFainted
+	jr nz, .notFainted
 .fainted
-	ld a,[wcf91]
-	cp a,REVIVE
-	jr z,.updateInBattleFaintedData
-	cp a,MAX_REVIVE
-	jr z,.updateInBattleFaintedData
+	ld a, [wcf91]
+	cp REVIVE
+	jr z, .updateInBattleFaintedData
+	cp MAX_REVIVE
+	jr z, .updateInBattleFaintedData
 	jp .healingItemNoEffect
 .updateInBattleFaintedData
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jr z,.compareCurrentHPToMaxHP
+	jr z, .compareCurrentHPToMaxHP
 	push hl
 	push de
 	push bc
-	ld a,[wUsedItemOnWhichPokemon]
-	ld c,a
-	ld hl,wPartyFoughtCurrentEnemyFlags
-	ld b,FLAG_TEST
+	ld a, [wUsedItemOnWhichPokemon]
+	ld c, a
+	ld hl, wPartyFoughtCurrentEnemyFlags
+	ld b, FLAG_TEST
 	predef FlagActionPredef
-	ld a,c
+	ld a, c
 	and a
-	jr z,.next
-	ld a,[wUsedItemOnWhichPokemon]
-	ld c,a
-	ld hl,wPartyGainExpFlags
-	ld b,FLAG_SET
+	jr z, .next
+	ld a, [wUsedItemOnWhichPokemon]
+	ld c, a
+	ld hl, wPartyGainExpFlags
+	ld b, FLAG_SET
 	predef FlagActionPredef
 .next
 	pop bc
@@ -953,467 +953,467 @@ ItemUseMedicine:
 	pop hl
 	jr .compareCurrentHPToMaxHP
 .notFainted
-	ld a,[wcf91]
-	cp a,REVIVE
-	jp z,.healingItemNoEffect
-	cp a,MAX_REVIVE
-	jp z,.healingItemNoEffect
+	ld a, [wcf91]
+	cp REVIVE
+	jp z, .healingItemNoEffect
+	cp MAX_REVIVE
+	jp z, .healingItemNoEffect
 .compareCurrentHPToMaxHP
 	push hl
 	push bc
-	ld bc,wPartyMon1MaxHP - (wPartyMon1HP + 1)
-	add hl,bc ; hl now points to max HP
+	ld bc, wPartyMon1MaxHP - (wPartyMon1HP + 1)
+	add hl, bc ; hl now points to max HP
 	pop bc
-	ld a,[hli]
+	ld a, [hli]
 	cp b
-	jr nz,.skipComparingLSB ; no need to compare the LSB's if the MSB's don't match
-	ld a,[hl]
+	jr nz, .skipComparingLSB ; no need to compare the LSB's if the MSB's don't match
+	ld a, [hl]
 	cp c
 .skipComparingLSB
 	pop hl
-	jr nz,.notFullHP
+	jr nz, .notFullHP
 .fullHP ; if the pokemon's current HP equals its max HP
-	ld a,[wcf91]
-	cp a,FULL_RESTORE
-	jp nz,.healingItemNoEffect
+	ld a, [wcf91]
+	cp FULL_RESTORE
+	jp nz, .healingItemNoEffect
 	inc hl
 	inc hl
-	ld a,[hld] ; status ailment
+	ld a, [hld] ; status ailment
 	and a ; does the pokemon have a status ailment?
-	jp z,.healingItemNoEffect
-	ld a,FULL_HEAL
-	ld [wcf91],a
+	jp z, .healingItemNoEffect
+	ld a, FULL_HEAL
+	ld [wcf91], a
 	dec hl
 	dec hl
 	dec hl
 	jp .cureStatusAilment
 .notFullHP ; if the pokemon's current HP doesn't equal its max HP
 	xor a
-	ld [wLowHealthAlarm],a ;disable low health alarm
-	ld [wChannelSoundIDs + Ch4],a
+	ld [wLowHealthAlarm], a ;disable low health alarm
+	ld [wChannelSoundIDs + Ch4], a
 	push hl
 	push de
-	ld bc,wPartyMon1MaxHP - (wPartyMon1HP + 1)
-	add hl,bc ; hl now points to max HP
-	ld a,[hli]
-	ld [wHPBarMaxHP+1],a
-	ld a,[hl]
-	ld [wHPBarMaxHP],a ; max HP stored at wHPBarMaxHP (2 bytes, big-endian)
-	ld a,[wPseudoItemID]
+	ld bc, wPartyMon1MaxHP - (wPartyMon1HP + 1)
+	add hl, bc ; hl now points to max HP
+	ld a, [hli]
+	ld [wHPBarMaxHP+1], a
+	ld a, [hl]
+	ld [wHPBarMaxHP], a ; max HP stored at wHPBarMaxHP (2 bytes, big-endian)
+	ld a, [wPseudoItemID]
 	and a ; using Softboiled?
-	jp z,.notUsingSoftboiled2
+	jp z, .notUsingSoftboiled2
 ; if using softboiled
-	ld hl,wHPBarMaxHP
-	ld a,[hli]
+	ld hl, wHPBarMaxHP
+	ld a, [hli]
 	push af
-	ld a,[hli]
+	ld a, [hli]
 	push af
-	ld a,[hli]
+	ld a, [hli]
 	push af
-	ld a,[hl]
+	ld a, [hl]
 	push af
-	ld hl,wPartyMon1MaxHP
-	ld a,[wWhichPokemon]
-	ld bc,wPartyMon2 - wPartyMon1
+	ld hl, wPartyMon1MaxHP
+	ld a, [wWhichPokemon]
+	ld bc, wPartyMon2 - wPartyMon1
 	call AddNTimes
-	ld a,[hli]
-	ld [wHPBarMaxHP + 1],a
-	ld [H_DIVIDEND],a
-	ld a,[hl]
-	ld [wHPBarMaxHP],a
-	ld [H_DIVIDEND + 1],a
-	ld a,5
-	ld [H_DIVISOR],a
-	ld b,2 ; number of bytes
+	ld a, [hli]
+	ld [wHPBarMaxHP + 1], a
+	ld [H_DIVIDEND], a
+	ld a, [hl]
+	ld [wHPBarMaxHP], a
+	ld [H_DIVIDEND + 1], a
+	ld a, 5
+	ld [H_DIVISOR], a
+	ld b, 2 ; number of bytes
 	call Divide ; get 1/5 of max HP of pokemon that used Softboiled
-	ld bc,(wPartyMon1HP + 1) - (wPartyMon1MaxHP + 1)
-	add hl,bc ; hl now points to LSB of current HP of pokemon that used Softboiled
+	ld bc, (wPartyMon1HP + 1) - (wPartyMon1MaxHP + 1)
+	add hl, bc ; hl now points to LSB of current HP of pokemon that used Softboiled
 ; subtract 1/5 of max HP from current HP of pokemon that used Softboiled
-	ld a,[H_QUOTIENT + 3]
+	ld a, [H_QUOTIENT + 3]
 	push af
-	ld b,a
-	ld a,[hl]
-	ld [wHPBarOldHP],a
+	ld b, a
+	ld a, [hl]
+	ld [wHPBarOldHP], a
 	sub b
-	ld [hld],a
-	ld [wHPBarNewHP],a
-	ld a,[H_QUOTIENT + 2]
-	ld b,a
-	ld a,[hl]
-	ld [wHPBarOldHP+1],a
+	ld [hld], a
+	ld [wHPBarNewHP], a
+	ld a, [H_QUOTIENT + 2]
+	ld b, a
+	ld a, [hl]
+	ld [wHPBarOldHP+1], a
 	sbc b
-	ld [hl],a
-	ld [wHPBarNewHP+1],a
+	ld [hl], a
+	ld [wHPBarNewHP+1], a
 	coord hl, 4, 1
-	ld a,[wWhichPokemon]
-	ld bc,2 * SCREEN_WIDTH
+	ld a, [wWhichPokemon]
+	ld bc, 2 * SCREEN_WIDTH
 	call AddNTimes ; calculate coordinates of HP bar of pokemon that used Softboiled
-	ld a,SFX_HEAL_HP
+	ld a, SFX_HEAL_HP
 	call PlaySoundWaitForCurrent
-	ld a,[hFlags_0xFFF6]
-	set 0,a
-	ld [hFlags_0xFFF6],a
-	ld a,$02
-	ld [wHPBarType],a
+	ld a, [hFlags_0xFFF6]
+	set 0, a
+	ld [hFlags_0xFFF6], a
+	ld a, $02
+	ld [wHPBarType], a
 	predef UpdateHPBar2 ; animate HP bar decrease of pokemon that used Softboiled
-	ld a,[hFlags_0xFFF6]
-	res 0,a
-	ld [hFlags_0xFFF6],a
+	ld a, [hFlags_0xFFF6]
+	res 0, a
+	ld [hFlags_0xFFF6], a
 	pop af
-	ld b,a ; store heal amount (1/5 of max HP)
-	ld hl,wHPBarOldHP + 1
+	ld b, a ; store heal amount (1/5 of max HP)
+	ld hl, wHPBarOldHP + 1
 	pop af
-	ld [hld],a
+	ld [hld], a
 	pop af
-	ld [hld],a
+	ld [hld], a
 	pop af
-	ld [hld],a
+	ld [hld], a
 	pop af
-	ld [hl],a
+	ld [hl], a
 	jr .addHealAmount
 .notUsingSoftboiled2
-	ld a,[wcf91]
-	cp a,SODA_POP
-	ld b,60 ; Soda Pop heal amount
-	jr z,.addHealAmount
-	ld b,80 ; Lemonade heal amount
-	jr nc,.addHealAmount
-	cp a,FRESH_WATER
-	ld b,50 ; Fresh Water heal amount
-	jr z,.addHealAmount
-	cp a,SUPER_POTION
-	ld b,200 ; Hyper Potion heal amount
-	jr c,.addHealAmount
-	ld b,50 ; Super Potion heal amount
-	jr z,.addHealAmount
-	ld b,20 ; Potion heal amount
+	ld a, [wcf91]
+	cp SODA_POP
+	ld b, 60 ; Soda Pop heal amount
+	jr z, .addHealAmount
+	ld b, 80 ; Lemonade heal amount
+	jr nc, .addHealAmount
+	cp FRESH_WATER
+	ld b, 50 ; Fresh Water heal amount
+	jr z, .addHealAmount
+	cp SUPER_POTION
+	ld b, 200 ; Hyper Potion heal amount
+	jr c, .addHealAmount
+	ld b, 50 ; Super Potion heal amount
+	jr z, .addHealAmount
+	ld b, 20 ; Potion heal amount
 .addHealAmount
 	pop de
 	pop hl
-	ld a,[hl]
+	ld a, [hl]
 	add b
-	ld [hld],a
-	ld [wHPBarNewHP],a
-	ld a,[hl]
-	ld [wHPBarNewHP+1],a
-	jr nc,.noCarry
+	ld [hld], a
+	ld [wHPBarNewHP], a
+	ld a, [hl]
+	ld [wHPBarNewHP+1], a
+	jr nc, .noCarry
 	inc [hl]
-	ld a,[hl]
-	ld [wHPBarNewHP + 1],a
+	ld a, [hl]
+	ld [wHPBarNewHP + 1], a
 .noCarry
 	push de
 	inc hl
-	ld d,h
-	ld e,l ; de now points to current HP
-	ld hl,(wPartyMon1MaxHP + 1) - (wPartyMon1HP + 1)
-	add hl,de ; hl now points to max HP
-	ld a,[wcf91]
-	cp a,REVIVE
-	jr z,.setCurrentHPToHalfMaxHP
-	ld a,[hld]
-	ld b,a
-	ld a,[de]
+	ld d, h
+	ld e, l ; de now points to current HP
+	ld hl, (wPartyMon1MaxHP + 1) - (wPartyMon1HP + 1)
+	add hl, de ; hl now points to max HP
+	ld a, [wcf91]
+	cp REVIVE
+	jr z, .setCurrentHPToHalfMaxHP
+	ld a, [hld]
+	ld b, a
+	ld a, [de]
 	sub b
 	dec de
-	ld b,[hl]
-	ld a,[de]
+	ld b, [hl]
+	ld a, [de]
 	sbc b
-	jr nc,.setCurrentHPToMaxHp ; if current HP exceeds max HP after healing
-	ld a,[wcf91]
-	cp a,HYPER_POTION
-	jr c,.setCurrentHPToMaxHp ; if using a Full Restore or Max Potion
-	cp a,MAX_REVIVE
-	jr z,.setCurrentHPToMaxHp ; if using a Max Revive
+	jr nc, .setCurrentHPToMaxHp ; if current HP exceeds max HP after healing
+	ld a, [wcf91]
+	cp HYPER_POTION
+	jr c, .setCurrentHPToMaxHp ; if using a Full Restore or Max Potion
+	cp MAX_REVIVE
+	jr z, .setCurrentHPToMaxHp ; if using a Max Revive
 	jr .updateInBattleData
 .setCurrentHPToHalfMaxHP
 	dec hl
 	dec de
-	ld a,[hli]
+	ld a, [hli]
 	srl a
-	ld [de],a
-	ld [wHPBarNewHP+1],a
-	ld a,[hl]
+	ld [de], a
+	ld [wHPBarNewHP+1], a
+	ld a, [hl]
 	rr a
 	inc de
-	ld [de],a
-	ld [wHPBarNewHP],a
+	ld [de], a
+	ld [wHPBarNewHP], a
 	dec de
 	jr .doneHealingPartyHP
 .setCurrentHPToMaxHp
-	ld a,[hli]
-	ld [de],a
-	ld [wHPBarNewHP+1],a
+	ld a, [hli]
+	ld [de], a
+	ld [wHPBarNewHP+1], a
 	inc de
-	ld a,[hl]
-	ld [de],a
-	ld [wHPBarNewHP],a
+	ld a, [hl]
+	ld [de], a
+	ld [wHPBarNewHP], a
 	dec de
 .doneHealingPartyHP ; done updating the pokemon's current HP in the party data structure
-	ld a,[wcf91]
-	cp a,FULL_RESTORE
-	jr nz,.updateInBattleData
-	ld bc,wPartyMon1Status - (wPartyMon1MaxHP + 1)
-	add hl,bc
+	ld a, [wcf91]
+	cp FULL_RESTORE
+	jr nz, .updateInBattleData
+	ld bc, wPartyMon1Status - (wPartyMon1MaxHP + 1)
+	add hl, bc
 	xor a
-	ld [hl],a ; remove the status ailment in the party data
+	ld [hl], a ; remove the status ailment in the party data
 .updateInBattleData
-	ld h,d
-	ld l,e
+	ld h, d
+	ld l, e
 	pop de
-	ld a,[wPlayerMonNumber]
+	ld a, [wPlayerMonNumber]
 	cp d ; is pokemon the item was used on active in battle?
-	jr nz,.calculateHPBarCoords
+	jr nz, .calculateHPBarCoords
 ; copy party HP to in-battle HP
-	ld a,[hli]
-	ld [wBattleMonHP],a
-	ld a,[hld]
-	ld [wBattleMonHP + 1],a
-	ld a,[wcf91]
-	cp a,FULL_RESTORE
-	jr nz,.calculateHPBarCoords
+	ld a, [hli]
+	ld [wBattleMonHP], a
+	ld a, [hld]
+	ld [wBattleMonHP + 1], a
+	ld a, [wcf91]
+	cp FULL_RESTORE
+	jr nz, .calculateHPBarCoords
 	xor a
-	ld [wBattleMonStatus],a ; remove the status ailment in the in-battle pokemon data
+	ld [wBattleMonStatus], a ; remove the status ailment in the in-battle pokemon data
 .calculateHPBarCoords
-	ld hl,wOAMBuffer + $90
-	ld bc,2 * SCREEN_WIDTH
+	ld hl, wOAMBuffer + $90
+	ld bc, 2 * SCREEN_WIDTH
 	inc d
 .calculateHPBarCoordsLoop
-	add hl,bc
+	add hl, bc
 	dec d
-	jr nz,.calculateHPBarCoordsLoop
+	jr nz, .calculateHPBarCoordsLoop
 	jr .doneHealing
 .healingItemNoEffect
 	call ItemUseNoEffect
 	jp .done
 .doneHealing
-	ld a,[wPseudoItemID]
+	ld a, [wPseudoItemID]
 	and a ; using Softboiled?
-	jr nz,.skipRemovingItem ; no item to remove if using Softboiled
+	jr nz, .skipRemovingItem ; no item to remove if using Softboiled
 	push hl
 	call RemoveUsedItem
 	pop hl
 .skipRemovingItem
-	ld a,[wcf91]
-	cp a,FULL_RESTORE
-	jr c,.playStatusAilmentCuringSound
-	cp a,FULL_HEAL
-	jr z,.playStatusAilmentCuringSound
-	ld a,SFX_HEAL_HP
+	ld a, [wcf91]
+	cp FULL_RESTORE
+	jr c, .playStatusAilmentCuringSound
+	cp FULL_HEAL
+	jr z, .playStatusAilmentCuringSound
+	ld a, SFX_HEAL_HP
 	call PlaySoundWaitForCurrent
-	ld a,[hFlags_0xFFF6]
-	set 0,a
-	ld [hFlags_0xFFF6],a
-	ld a,$02
-	ld [wHPBarType],a
+	ld a, [hFlags_0xFFF6]
+	set 0, a
+	ld [hFlags_0xFFF6], a
+	ld a, $02
+	ld [wHPBarType], a
 	predef UpdateHPBar2 ; animate the HP bar lengthening
-	ld a,[hFlags_0xFFF6]
-	res 0,a
-	ld [hFlags_0xFFF6],a
-	ld a,REVIVE_MSG
-	ld [wPartyMenuTypeOrMessageID],a
-	ld a,[wcf91]
-	cp a,REVIVE
-	jr z,.showHealingItemMessage
-	cp a,MAX_REVIVE
-	jr z,.showHealingItemMessage
-	ld a,POTION_MSG
-	ld [wPartyMenuTypeOrMessageID],a
+	ld a, [hFlags_0xFFF6]
+	res 0, a
+	ld [hFlags_0xFFF6], a
+	ld a, REVIVE_MSG
+	ld [wPartyMenuTypeOrMessageID], a
+	ld a, [wcf91]
+	cp REVIVE
+	jr z, .showHealingItemMessage
+	cp MAX_REVIVE
+	jr z, .showHealingItemMessage
+	ld a, POTION_MSG
+	ld [wPartyMenuTypeOrMessageID], a
 	jr .showHealingItemMessage
 .playStatusAilmentCuringSound
-	ld a,SFX_HEAL_AILMENT
+	ld a, SFX_HEAL_AILMENT
 	call PlaySoundWaitForCurrent
 .showHealingItemMessage
 	xor a
-	ld [H_AUTOBGTRANSFERENABLED],a
+	ld [H_AUTOBGTRANSFERENABLED], a
 	call ClearScreen
 	dec a
-	ld [wUpdateSpritesEnabled],a
+	ld [wUpdateSpritesEnabled], a
 	call RedrawPartyMenu ; redraws the party menu and displays the message
-	ld a,1
-	ld [H_AUTOBGTRANSFERENABLED],a
-	ld c,50
+	ld a, 1
+	ld [H_AUTOBGTRANSFERENABLED], a
+	ld c, 50
 	call DelayFrames
 	call WaitForTextScrollButtonPress
 	jr .done
 .canceledItemUse
 	xor a
-	ld [wActionResultOrTookBattleTurn],a ; item use failed
+	ld [wActionResultOrTookBattleTurn], a ; item use failed
 	pop af
 	pop af
 .done
-	ld a,[wPseudoItemID]
+	ld a, [wPseudoItemID]
 	and a ; using Softboiled?
 	ret nz ; if so, return
 	call GBPalWhiteOut
-	call z,RunDefaultPaletteCommand
-	ld a,[wIsInBattle]
+	call z, RunDefaultPaletteCommand
+	ld a, [wIsInBattle]
 	and a
 	ret nz
 	jp ReloadMapData
 .useVitamin
 	push hl
-	ld a,[hl]
-	ld [wd0b5],a
-	ld [wd11e],a
-	ld bc,wPartyMon1Level - wPartyMon1
-	add hl,bc ; hl now points to level
-	ld a,[hl] ; a = level
-	ld [wCurEnemyLVL],a ; store level
+	ld a, [hl]
+	ld [wd0b5], a
+	ld [wd11e], a
+	ld bc, wPartyMon1Level - wPartyMon1
+	add hl, bc ; hl now points to level
+	ld a, [hl] ; a = level
+	ld [wCurEnemyLVL], a ; store level
 	call GetMonHeader
 	push de
-	ld a,d
-	ld hl,wPartyMonNicks
+	ld a, d
+	ld hl, wPartyMonNicks
 	call GetPartyMonName
 	pop de
 	pop hl
-	ld a,[wcf91]
-	cp a,RARE_CANDY
-	jp z,.useRareCandy
+	ld a, [wcf91]
+	cp RARE_CANDY
+	jp z, .useRareCandy
 	push hl
-	sub a,HP_UP
+	sub HP_UP
 	add a
-	ld bc,wPartyMon1HPExp - wPartyMon1
-	add hl,bc
+	ld bc, wPartyMon1HPExp - wPartyMon1
+	add hl, bc
 	add l
-	ld l,a
-	jr nc,.noCarry2
+	ld l, a
+	jr nc, .noCarry2
 	inc h
 .noCarry2
-	ld a,10
-	ld b,a
-	ld a,[hl] ; a = MSB of stat experience of the appropriate stat
-	cp a,100 ; is there already at least 25600 (256 * 100) stat experience?
-	jr nc,.vitaminNoEffect ; if so, vitamins can't add any more
+	ld a, 10
+	ld b, a
+	ld a, [hl] ; a = MSB of stat experience of the appropriate stat
+	cp 100 ; is there already at least 25600 (256 * 100) stat experience?
+	jr nc, .vitaminNoEffect ; if so, vitamins can't add any more
 	add b ; add 2560 (256 * 10) stat experience
-	jr nc,.noCarry3 ; a carry should be impossible here, so this will always jump
-	ld a,255
+	jr nc, .noCarry3 ; a carry should be impossible here, so this will always jump
+	ld a, 255
 .noCarry3
-	ld [hl],a
+	ld [hl], a
 	pop hl
 	call .recalculateStats
-	ld hl,VitaminText
-	ld a,[wcf91]
-	sub a,HP_UP - 1
-	ld c,a
+	ld hl, VitaminText
+	ld a, [wcf91]
+	sub HP_UP - 1
+	ld c, a
 .statNameLoop ; loop to get the address of the name of the stat the vitamin increases
 	dec c
-	jr z,.gotStatName
+	jr z, .gotStatName
 .statNameInnerLoop
-	ld a,[hli]
-	ld b,a
-	ld a,$50
+	ld a, [hli]
+	ld b, a
+	ld a, $50
 	cp b
-	jr nz,.statNameInnerLoop
+	jr nz, .statNameInnerLoop
 	jr .statNameLoop
 .gotStatName
-	ld de,wcf4b
-	ld bc,10
+	ld de, wcf4b
+	ld bc, 10
 	call CopyData ; copy the stat's name to wcf4b
-	ld a,SFX_HEAL_AILMENT
+	ld a, SFX_HEAL_AILMENT
 	call PlaySound
-	ld hl,VitaminStatRoseText
+	ld hl, VitaminStatRoseText
 	call PrintText
 	jp RemoveUsedItem
 .vitaminNoEffect
 	pop hl
-	ld hl,VitaminNoEffectText
+	ld hl, VitaminNoEffectText
 	call PrintText
 	jp GBPalWhiteOut
 .recalculateStats
-	ld bc,wPartyMon1Stats - wPartyMon1
-	add hl,bc
-	ld d,h
-	ld e,l ; de now points to stats
-	ld bc,(wPartyMon1Exp + 2) - wPartyMon1Stats
-	add hl,bc ; hl now points to LSB of experience
-	ld b,1
+	ld bc, wPartyMon1Stats - wPartyMon1
+	add hl, bc
+	ld d, h
+	ld e, l ; de now points to stats
+	ld bc, (wPartyMon1Exp + 2) - wPartyMon1Stats
+	add hl, bc ; hl now points to LSB of experience
+	ld b, 1
 	jp CalcStats ; recalculate stats
 .useRareCandy
 	push hl
-	ld bc,wPartyMon1Level - wPartyMon1
-	add hl,bc ; hl now points to level
-	ld a,[hl] ; a = level
-	cp a, MAX_LEVEL
-	jr z,.vitaminNoEffect ; can't raise level above 100
+	ld bc, wPartyMon1Level - wPartyMon1
+	add hl, bc ; hl now points to level
+	ld a, [hl] ; a = level
+	cp MAX_LEVEL
+	jr z, .vitaminNoEffect ; can't raise level above 100
 	inc a
-	ld [hl],a ; store incremented level
-	ld [wCurEnemyLVL],a
+	ld [hl], a ; store incremented level
+	ld [wCurEnemyLVL], a
 	push hl
 	push de
-	ld d,a
+	ld d, a
 	callab CalcExperience ; calculate experience for next level and store it at $ff96
 	pop de
 	pop hl
-	ld bc,wPartyMon1Exp - wPartyMon1Level
-	add hl,bc ; hl now points to MSB of experience
+	ld bc, wPartyMon1Exp - wPartyMon1Level
+	add hl, bc ; hl now points to MSB of experience
 ; update experience to minimum for new level
-	ld a,[hExperience]
-	ld [hli],a
-	ld a,[hExperience + 1]
-	ld [hli],a
-	ld a,[hExperience + 2]
-	ld [hl],a
+	ld a, [hExperience]
+	ld [hli], a
+	ld a, [hExperience + 1]
+	ld [hli], a
+	ld a, [hExperience + 2]
+	ld [hl], a
 	pop hl
-	ld a,[wWhichPokemon]
+	ld a, [wWhichPokemon]
 	push af
-	ld a,[wcf91]
+	ld a, [wcf91]
 	push af
 	push de
 	push hl
-	ld bc,wPartyMon1MaxHP - wPartyMon1
-	add hl,bc ; hl now points to MSB of max HP
-	ld a,[hli]
-	ld b,a
-	ld c,[hl]
+	ld bc, wPartyMon1MaxHP - wPartyMon1
+	add hl, bc ; hl now points to MSB of max HP
+	ld a, [hli]
+	ld b, a
+	ld c, [hl]
 	pop hl
 	push bc
 	push hl
 	call .recalculateStats
 	pop hl
-	ld bc,(wPartyMon1MaxHP + 1) - wPartyMon1
-	add hl,bc ; hl now points to LSB of max HP
+	ld bc, (wPartyMon1MaxHP + 1) - wPartyMon1
+	add hl, bc ; hl now points to LSB of max HP
 	pop bc
-	ld a,[hld]
+	ld a, [hld]
 	sub c
-	ld c,a
-	ld a,[hl]
+	ld c, a
+	ld a, [hl]
 	sbc b
-	ld b,a ; bc = the amount of max HP gained from leveling up
+	ld b, a ; bc = the amount of max HP gained from leveling up
 ; add the amount gained to the current HP
-	ld de,(wPartyMon1HP + 1) - wPartyMon1MaxHP
-	add hl,de ; hl now points to LSB of current HP
-	ld a,[hl]
+	ld de, (wPartyMon1HP + 1) - wPartyMon1MaxHP
+	add hl, de ; hl now points to LSB of current HP
+	ld a, [hl]
 	add c
-	ld [hld],a
-	ld a,[hl]
+	ld [hld], a
+	ld a, [hl]
 	adc b
-	ld [hl],a
-	ld a,RARE_CANDY_MSG
-	ld [wPartyMenuTypeOrMessageID],a
+	ld [hl], a
+	ld a, RARE_CANDY_MSG
+	ld [wPartyMenuTypeOrMessageID], a
 	call RedrawPartyMenu
 	pop de
-	ld a,d
-	ld [wWhichPokemon],a
-	ld a,e
-	ld [wd11e],a
+	ld a, d
+	ld [wWhichPokemon], a
+	ld a, e
+	ld [wd11e], a
 	xor a ; PLAYER_PARTY_DATA
-	ld [wMonDataLocation],a
+	ld [wMonDataLocation], a
 	call LoadMonData
-	ld d,$01
+	ld d, $01
 	callab PrintStatsBox ; display new stats text box
 	call WaitForTextScrollButtonPress ; wait for button press
 	xor a ; PLAYER_PARTY_DATA
-	ld [wMonDataLocation],a
+	ld [wMonDataLocation], a
 	predef LearnMoveFromLevelUp ; learn level up move, if any
 	xor a
-	ld [wForceEvolution],a
+	ld [wForceEvolution], a
 	callab TryEvolvingMon ; evolve pokemon, if appropriate
-	ld a,$01
-	ld [wUpdateSpritesEnabled],a
+	ld a, $01
+	ld [wUpdateSpritesEnabled], a
 	pop af
-	ld [wcf91],a
+	ld [wcf91], a
 	pop af
-	ld [wWhichPokemon],a
+	ld [wWhichPokemon], a
 	jp RemoveUsedItem
 
 VitaminStatRoseText:
@@ -1432,50 +1432,50 @@ VitaminText:
 	db "SPECIAL@"
 
 ItemUseBait:
-	ld hl,ThrewBaitText
+	ld hl, ThrewBaitText
 	call PrintText
-	ld hl,wEnemyMonCatchRate ; catch rate
+	ld hl, wEnemyMonCatchRate ; catch rate
 	srl [hl] ; halve catch rate
-	ld a,BAIT_ANIM
-	ld hl,wSafariBaitFactor ; bait factor
-	ld de,wSafariEscapeFactor ; escape factor
+	ld a, BAIT_ANIM
+	ld hl, wSafariBaitFactor ; bait factor
+	ld de, wSafariEscapeFactor ; escape factor
 	jr BaitRockCommon
 
 ItemUseRock:
-	ld hl,ThrewRockText
+	ld hl, ThrewRockText
 	call PrintText
-	ld hl,wEnemyMonCatchRate ; catch rate
-	ld a,[hl]
+	ld hl, wEnemyMonCatchRate ; catch rate
+	ld a, [hl]
 	add a ; double catch rate
-	jr nc,.noCarry
-	ld a,$ff
+	jr nc, .noCarry
+	ld a, $ff
 .noCarry
-	ld [hl],a
-	ld a,ROCK_ANIM
-	ld hl,wSafariEscapeFactor ; escape factor
-	ld de,wSafariBaitFactor ; bait factor
+	ld [hl], a
+	ld a, ROCK_ANIM
+	ld hl, wSafariEscapeFactor ; escape factor
+	ld de, wSafariBaitFactor ; bait factor
 
 BaitRockCommon:
-	ld [wAnimationID],a
+	ld [wAnimationID], a
 	xor a
-	ld [wAnimationType],a
-	ld [H_WHOSETURN],a
-	ld [de],a ; zero escape factor (for bait), zero bait factor (for rock)
+	ld [wAnimationType], a
+	ld [H_WHOSETURN], a
+	ld [de], a ; zero escape factor (for bait), zero bait factor (for rock)
 .randomLoop ; loop until a random number less than 5 is generated
 	call Random
-	and a,7
-	cp a,5
-	jr nc,.randomLoop
+	and 7
+	cp 5
+	jr nc, .randomLoop
 	inc a ; increment the random number, giving a range from 1 to 5 inclusive
-	ld b,a
-	ld a,[hl]
+	ld b, a
+	ld a, [hl]
 	add b ; increase bait factor (for bait), increase escape factor (for rock)
-	jr nc,.noCarry
-	ld a,$ff
+	jr nc, .noCarry
+	ld a, $ff
 .noCarry
-	ld [hl],a
+	ld [hl], a
 	predef MoveAnimation ; do animation
-	ld c,70
+	ld c, 70
 	jp DelayFrames
 
 ThrewBaitText:
@@ -1488,38 +1488,38 @@ ThrewRockText:
 
 ; also used for Dig out-of-battle effect
 ItemUseEscapeRope:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jr nz,.notUsable
-	ld a,[wCurMap]
-	cp a,AGATHAS_ROOM
-	jr z,.notUsable
-	ld a,[wCurMapTileset]
-	ld b,a
-	ld hl,EscapeRopeTilesets
+	jr nz, .notUsable
+	ld a, [wCurMap]
+	cp AGATHAS_ROOM
+	jr z, .notUsable
+	ld a, [wCurMapTileset]
+	ld b, a
+	ld hl, EscapeRopeTilesets
 .loop
-	ld a,[hli]
-	cp a,$ff
-	jr z,.notUsable
+	ld a, [hli]
+	cp $ff
+	jr z, .notUsable
 	cp b
-	jr nz,.loop
-	ld hl,wd732
-	set 3,[hl]
-	set 6,[hl]
-	ld hl,wd72e
-	res 4,[hl]
+	jr nz, .loop
+	ld hl, wd732
+	set 3, [hl]
+	set 6, [hl]
+	ld hl, wd72e
+	res 4, [hl]
 	ResetEvent EVENT_IN_SAFARI_ZONE
 	xor a
-	ld [wNumSafariBalls],a
-	ld [wSafariZoneEntranceCurScript],a
+	ld [wNumSafariBalls], a
+	ld [wSafariZoneEntranceCurScript], a
 	inc a
-	ld [wEscapedFromBattle],a
-	ld [wActionResultOrTookBattleTurn],a ; item used
-	ld a,[wPseudoItemID]
+	ld [wEscapedFromBattle], a
+	ld [wActionResultOrTookBattleTurn], a ; item used
+	ld a, [wPseudoItemID]
 	and a ; using Dig?
 	ret nz ; if so, return
 	call ItemUseReloadOverworldData
-	ld c,30
+	ld c, 30
 	call DelayFrames
 	jp RemoveUsedItem
 .notUsable
@@ -1530,62 +1530,62 @@ EscapeRopeTilesets:
 	db $ff ; terminator
 
 ItemUseRepel:
-	ld b,100
+	ld b, 100
 
 ItemUseRepelCommon:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp nz,ItemUseNotTime
-	ld a,b
-	ld [wRepelRemainingSteps],a
+	jp nz, ItemUseNotTime
+	ld a, b
+	ld [wRepelRemainingSteps], a
 	jp PrintItemUseTextAndRemoveItem
 
 ; handles X Accuracy item
 ItemUseXAccuracy:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp z,ItemUseNotTime
-	ld hl,wPlayerBattleStatus2
-	set USING_X_ACCURACY,[hl] ; X Accuracy bit
+	jp z, ItemUseNotTime
+	ld hl, wPlayerBattleStatus2
+	set USING_X_ACCURACY, [hl] ; X Accuracy bit
 	jp PrintItemUseTextAndRemoveItem
 
 ; This function is bugged and never works. It always jumps to ItemUseNotTime.
 ; The Card Key is handled in a different way.
 ItemUseCardKey:
 	xor a
-	ld [wUnusedD71F],a
+	ld [wUnusedD71F], a
 	call GetTileAndCoordsInFrontOfPlayer
-	ld a,[GetTileAndCoordsInFrontOfPlayer]
-	cp a,$18
-	jr nz,.next0
-	ld hl,CardKeyTable1
+	ld a, [GetTileAndCoordsInFrontOfPlayer]
+	cp $18
+	jr nz, .next0
+	ld hl, CardKeyTable1
 	jr .next1
 .next0
-	cp a,$24
-	jr nz,.next2
-	ld hl,CardKeyTable2
+	cp $24
+	jr nz, .next2
+	ld hl, CardKeyTable2
 	jr .next1
 .next2
-	cp a,$5e
-	jp nz,ItemUseNotTime
-	ld hl,CardKeyTable3
+	cp $5e
+	jp nz, ItemUseNotTime
+	ld hl, CardKeyTable3
 .next1
-	ld a,[wCurMap]
-	ld b,a
+	ld a, [wCurMap]
+	ld b, a
 .loop
-	ld a,[hli]
-	cp a,$ff
-	jp z,ItemUseNotTime
+	ld a, [hli]
+	cp $ff
+	jp z, ItemUseNotTime
 	cp b
-	jr nz,.nextEntry1
-	ld a,[hli]
+	jr nz, .nextEntry1
+	ld a, [hli]
 	cp d
-	jr nz,.nextEntry2
-	ld a,[hli]
+	jr nz, .nextEntry2
+	ld a, [hli]
 	cp e
-	jr nz,.nextEntry3
-	ld a,[hl]
-	ld [wUnusedD71F],a
+	jr nz, .nextEntry3
+	ld a, [hl]
+	ld [wUnusedD71F], a
 	jr .done
 .nextEntry1
 	inc hl
@@ -1595,10 +1595,10 @@ ItemUseCardKey:
 	inc hl
 	jr .loop
 .done
-	ld hl,ItemUseText00
+	ld hl, ItemUseText00
 	call PrintText
-	ld hl,wd728
-	set 7,[hl]
+	ld hl, wd728
+	set 7, [hl]
 	ret
 
 ; These tables are probably supposed to be door locations in Silph Co.,
@@ -1643,145 +1643,145 @@ CardKeyTable3:
 	db $ff
 
 ItemUsePokedoll:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	dec a
-	jp nz,ItemUseNotTime
-	ld a,$01
-	ld [wEscapedFromBattle],a
+	jp nz, ItemUseNotTime
+	ld a, $01
+	ld [wEscapedFromBattle], a
 	jp PrintItemUseTextAndRemoveItem
 
 ItemUseGuardSpec:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp z,ItemUseNotTime
-	ld hl,wPlayerBattleStatus2
-	set PROTECTED_BY_MIST,[hl] ; Mist bit
+	jp z, ItemUseNotTime
+	ld hl, wPlayerBattleStatus2
+	set PROTECTED_BY_MIST, [hl] ; Mist bit
 	jp PrintItemUseTextAndRemoveItem
 
 ItemUseSuperRepel:
-	ld b,200
+	ld b, 200
 	jp ItemUseRepelCommon
 
 ItemUseMaxRepel:
-	ld b,250
+	ld b, 250
 	jp ItemUseRepelCommon
 
 ItemUseDireHit:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp z,ItemUseNotTime
-	ld hl,wPlayerBattleStatus2
-	set GETTING_PUMPED,[hl] ; Focus Energy bit
+	jp z, ItemUseNotTime
+	ld hl, wPlayerBattleStatus2
+	set GETTING_PUMPED, [hl] ; Focus Energy bit
 	jp PrintItemUseTextAndRemoveItem
 
 ItemUseXStat:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jr nz,.inBattle
+	jr nz, .inBattle
 	call ItemUseNotTime
-	ld a,2
-	ld [wActionResultOrTookBattleTurn],a ; item not used
+	ld a, 2
+	ld [wActionResultOrTookBattleTurn], a ; item not used
 	ret
 .inBattle
-	ld hl,wPlayerMoveNum
-	ld a,[hli]
+	ld hl, wPlayerMoveNum
+	ld a, [hli]
 	push af ; save [wPlayerMoveNum]
-	ld a,[hl]
+	ld a, [hl]
 	push af ; save [wPlayerMoveEffect]
 	push hl
-	ld a,[wcf91]
-	sub a,X_ATTACK - ATTACK_UP1_EFFECT
-	ld [hl],a ; store player move effect
+	ld a, [wcf91]
+	sub X_ATTACK - ATTACK_UP1_EFFECT
+	ld [hl], a ; store player move effect
 	call PrintItemUseTextAndRemoveItem
-	ld a,XSTATITEM_ANIM ; X stat item animation ID
-	ld [wPlayerMoveNum],a
+	ld a, XSTATITEM_ANIM ; X stat item animation ID
+	ld [wPlayerMoveNum], a
 	call LoadScreenTilesFromBuffer1 ; restore saved screen
 	call Delay3
 	xor a
-	ld [H_WHOSETURN],a ; set turn to player's turn
+	ld [H_WHOSETURN], a ; set turn to player's turn
 	callba StatModifierUpEffect ; do stat increase move
 	pop hl
 	pop af
-	ld [hld],a ; restore [wPlayerMoveEffect]
+	ld [hld], a ; restore [wPlayerMoveEffect]
 	pop af
-	ld [hl],a ; restore [wPlayerMoveNum]
+	ld [hl], a ; restore [wPlayerMoveNum]
 	ret
 
 ItemUsePokeflute:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jr nz,.inBattle
+	jr nz, .inBattle
 ; if not in battle
 	call ItemUseReloadOverworldData
-	ld a,[wCurMap]
-	cp a,ROUTE_12
-	jr nz,.notRoute12
+	ld a, [wCurMap]
+	cp ROUTE_12
+	jr nz, .notRoute12
 	CheckEvent EVENT_BEAT_ROUTE12_SNORLAX
-	jr nz,.noSnorlaxToWakeUp
+	jr nz, .noSnorlaxToWakeUp
 ; if the player hasn't beaten Route 12 Snorlax
-	ld hl,Route12SnorlaxFluteCoords
+	ld hl, Route12SnorlaxFluteCoords
 	call ArePlayerCoordsInArray
-	jr nc,.noSnorlaxToWakeUp
-	ld hl,PlayedFluteHadEffectText
+	jr nc, .noSnorlaxToWakeUp
+	ld hl, PlayedFluteHadEffectText
 	call PrintText
 	SetEvent EVENT_FIGHT_ROUTE12_SNORLAX
 	ret
 .notRoute12
-	cp a,ROUTE_16
-	jr nz,.noSnorlaxToWakeUp
+	cp ROUTE_16
+	jr nz, .noSnorlaxToWakeUp
 	CheckEvent EVENT_BEAT_ROUTE16_SNORLAX
-	jr nz,.noSnorlaxToWakeUp
+	jr nz, .noSnorlaxToWakeUp
 ; if the player hasn't beaten Route 16 Snorlax
-	ld hl,Route16SnorlaxFluteCoords
+	ld hl, Route16SnorlaxFluteCoords
 	call ArePlayerCoordsInArray
-	jr nc,.noSnorlaxToWakeUp
-	ld hl,PlayedFluteHadEffectText
+	jr nc, .noSnorlaxToWakeUp
+	ld hl, PlayedFluteHadEffectText
 	call PrintText
 	SetEvent EVENT_FIGHT_ROUTE16_SNORLAX
 	ret
 .noSnorlaxToWakeUp
-	ld hl,PlayedFluteNoEffectText
+	ld hl, PlayedFluteNoEffectText
 	jp PrintText
 .inBattle
 	xor a
-	ld [wWereAnyMonsAsleep],a
-	ld b,~SLP & $ff
-	ld hl,wPartyMon1Status
+	ld [wWereAnyMonsAsleep], a
+	ld b, ~SLP & $ff
+	ld hl, wPartyMon1Status
 	call WakeUpEntireParty
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	dec a ; is it a trainer battle?
-	jr z,.skipWakingUpEnemyParty
+	jr z, .skipWakingUpEnemyParty
 ; if it's a trainer battle
-	ld hl,wEnemyMon1Status
+	ld hl, wEnemyMon1Status
 	call WakeUpEntireParty
 .skipWakingUpEnemyParty
-	ld hl,wBattleMonStatus
-	ld a,[hl]
+	ld hl, wBattleMonStatus
+	ld a, [hl]
 	and b ; remove Sleep status
-	ld [hl],a
-	ld hl,wEnemyMonStatus
-	ld a,[hl]
+	ld [hl], a
+	ld hl, wEnemyMonStatus
+	ld a, [hl]
 	and b ; remove Sleep status
-	ld [hl],a
+	ld [hl], a
 	call LoadScreenTilesFromBuffer2 ; restore saved screen
-	ld a,[wWereAnyMonsAsleep]
+	ld a, [wWereAnyMonsAsleep]
 	and a ; were any pokemon asleep before playing the flute?
-	ld hl,PlayedFluteNoEffectText
-	jp z,PrintText ; if no pokemon were asleep
+	ld hl, PlayedFluteNoEffectText
+	jp z, PrintText ; if no pokemon were asleep
 ; if some pokemon were asleep
-	ld hl,PlayedFluteHadEffectText
+	ld hl, PlayedFluteHadEffectText
 	call PrintText
-	ld a,[wLowHealthAlarm]
-	and a,$80
-	jr nz,.skipMusic
+	ld a, [wLowHealthAlarm]
+	and $80
+	jr nz, .skipMusic
 	call WaitForSoundToFinish ; wait for sound to end
 	callba Music_PokeFluteInBattle ; play in-battle pokeflute music
 .musicWaitLoop ; wait for music to finish playing
-	ld a,[wChannelSoundIDs + Ch6]
+	ld a, [wChannelSoundIDs + Ch6]
 	and a ; music off?
-	jr nz,.musicWaitLoop
+	jr nz, .musicWaitLoop
 .skipMusic
-	ld hl,FluteWokeUpText
+	ld hl, FluteWokeUpText
 	jp PrintText
 
 ; wakes up all party pokemon
@@ -1792,22 +1792,22 @@ ItemUsePokeflute:
 ; OUTPUT:
 ; [wWereAnyMonsAsleep]: set to 1 if any pokemon were asleep
 WakeUpEntireParty:
-	ld de,44
-	ld c,6
+	ld de, 44
+	ld c, 6
 .loop
-	ld a,[hl]
+	ld a, [hl]
 	push af
-	and a,SLP ; is pokemon asleep?
-	jr z,.notAsleep
-	ld a,1
-	ld [wWereAnyMonsAsleep],a ; indicate that a pokemon had to be woken up
+	and SLP ; is pokemon asleep?
+	jr z, .notAsleep
+	ld a, 1
+	ld [wWereAnyMonsAsleep], a ; indicate that a pokemon had to be woken up
 .notAsleep
 	pop af
 	and b ; remove Sleep status
-	ld [hl],a
-	add hl,de
+	ld [hl], a
+	add hl, de
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 ; Format:
@@ -1840,28 +1840,28 @@ PlayedFluteHadEffectText:
 	TX_FAR _PlayedFluteHadEffectText
 	TX_BLINK
 	TX_ASM
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jr nz,.done
+	jr nz, .done
 ; play out-of-battle pokeflute music
-	ld a,$ff
+	ld a, $ff
 	call PlaySound ; turn off music
 	ld a, SFX_POKEFLUTE
 	ld c, BANK(SFX_Pokeflute)
 	call PlayMusic
 .musicWaitLoop ; wait for music to finish playing
-	ld a,[wChannelSoundIDs + Ch2]
-	cp a, SFX_POKEFLUTE
-	jr z,.musicWaitLoop
+	ld a, [wChannelSoundIDs + Ch2]
+	cp SFX_POKEFLUTE
+	jr z, .musicWaitLoop
 	call PlayDefaultMusic ; start playing normal music again
 .done
 	jp TextScriptEnd ; end text
 
 ItemUseCoinCase:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp nz,ItemUseNotTime
-	ld hl,CoinCaseNumCoinsText
+	jp nz, ItemUseNotTime
+	ld hl, CoinCaseNumCoinsText
 	jp PrintText
 
 CoinCaseNumCoinsText:
@@ -1877,7 +1877,7 @@ ItemUseOldRod:
 
 ItemUseGoodRod:
 	call FishingInit
-	jp c,ItemUseNotTime
+	jp c, ItemUseNotTime
 .RandomLoop
 	call Random
 	srl a
@@ -1886,17 +1886,17 @@ ItemUseGoodRod:
 	cp 2
 	jr nc, .RandomLoop
 	; choose which monster appears
-	ld hl,GoodRodMons
-	add a,a
-	ld c,a
-	ld b,0
-	add hl,bc
-	ld b,[hl]
+	ld hl, GoodRodMons
+	add a
+	ld c, a
+	ld b, 0
+	add hl, bc
+	ld b, [hl]
 	inc hl
-	ld c,[hl]
+	ld c, [hl]
 	and a
 .SetBite
-	ld a,0
+	ld a, 0
 	rla
 	xor 1
 	jr RodResponse
@@ -1936,23 +1936,23 @@ RodResponse:
 ; checks if fishing is possible and if so, runs initialization code common to all rods
 ; unsets carry if fishing is possible, sets carry if not
 FishingInit:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jr z,.notInBattle
+	jr z, .notInBattle
 	scf ; can't fish during battle
 	ret
 .notInBattle
 	call IsNextTileShoreOrWater
 	ret c
-	ld a,[wWalkBikeSurfState]
-	cp a,2 ; Surfing?
-	jr z,.surfing
+	ld a, [wWalkBikeSurfState]
+	cp 2 ; Surfing?
+	jr z, .surfing
 	call ItemUseReloadOverworldData
-	ld hl,ItemUseText00
+	ld hl, ItemUseText00
 	call PrintText
-	ld a,SFX_HEAL_AILMENT
+	ld a, SFX_HEAL_AILMENT
 	call PlaySound
-	ld c,80
+	ld c, 80
 	call DelayFrames
 	and a
 	ret
@@ -1964,22 +1964,22 @@ ItemUseOaksParcel:
 	jp ItemUseNotYoursToUse
 
 ItemUseItemfinder:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp nz,ItemUseNotTime
+	jp nz, ItemUseNotTime
 	call ItemUseReloadOverworldData
 	callba HiddenItemNear ; check for hidden items
-	ld hl,ItemfinderFoundNothingText
-	jr nc,.printText ; if no hidden items
-	ld c,4
+	ld hl, ItemfinderFoundNothingText
+	jr nc, .printText ; if no hidden items
+	ld c, 4
 .loop
-	ld a,SFX_HEALING_MACHINE
+	ld a, SFX_HEALING_MACHINE
 	call PlaySoundWaitForCurrent
-	ld a,SFX_PURCHASE
+	ld a, SFX_PURCHASE
 	call PlaySoundWaitForCurrent
 	dec c
-	jr nz,.loop
-	ld hl,ItemfinderFoundItemText
+	jr nz, .loop
+	ld hl, ItemfinderFoundItemText
 .printText
 	jp PrintText
 
@@ -1992,136 +1992,136 @@ ItemfinderFoundNothingText:
 	db "@"
 
 ItemUsePPUp:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp nz,ItemUseNotTime
+	jp nz, ItemUseNotTime
 
 ItemUsePPRestore:
-	ld a,[wWhichPokemon]
+	ld a, [wWhichPokemon]
 	push af
-	ld a,[wcf91]
-	ld [wPPRestoreItem],a
+	ld a, [wcf91]
+	ld [wPPRestoreItem], a
 .chooseMon
 	xor a
-	ld [wUpdateSpritesEnabled],a
-	ld a,USE_ITEM_PARTY_MENU
-	ld [wPartyMenuTypeOrMessageID],a
+	ld [wUpdateSpritesEnabled], a
+	ld a, USE_ITEM_PARTY_MENU
+	ld [wPartyMenuTypeOrMessageID], a
 	call DisplayPartyMenu
-	jr nc,.chooseMove
+	jr nc, .chooseMove
 	jp .itemNotUsed
 .chooseMove
-	ld a,[wPPRestoreItem]
-	cp a,ELIXER
-	jp nc,.useElixir ; if Elixir or Max Elixir
-	ld a,$02
-	ld [wMoveMenuType],a
-	ld hl,RaisePPWhichTechniqueText
-	ld a,[wPPRestoreItem]
-	cp a,ETHER ; is it a PP Up?
-	jr c,.printWhichTechniqueMessage ; if so, print the raise PP message
-	ld hl,RestorePPWhichTechniqueText ; otherwise, print the restore PP message
+	ld a, [wPPRestoreItem]
+	cp ELIXER
+	jp nc, .useElixir ; if Elixir or Max Elixir
+	ld a, $02
+	ld [wMoveMenuType], a
+	ld hl, RaisePPWhichTechniqueText
+	ld a, [wPPRestoreItem]
+	cp ETHER ; is it a PP Up?
+	jr c, .printWhichTechniqueMessage ; if so, print the raise PP message
+	ld hl, RestorePPWhichTechniqueText ; otherwise, print the restore PP message
 .printWhichTechniqueMessage
 	call PrintText
 	xor a
-	ld [wPlayerMoveListIndex],a
+	ld [wPlayerMoveListIndex], a
 	callab MoveSelectionMenu ; move selection menu
-	ld a,0
-	ld [wPlayerMoveListIndex],a
-	jr nz,.chooseMon
-	ld hl,wPartyMon1Moves
+	ld a, 0
+	ld [wPlayerMoveListIndex], a
+	jr nz, .chooseMon
+	ld hl, wPartyMon1Moves
 	ld bc, wPartyMon2 - wPartyMon1
 	call GetSelectedMoveOffset
 	push hl
-	ld a,[hl]
-	ld [wd11e],a
+	ld a, [hl]
+	ld [wd11e], a
 	call GetMoveName
 	call CopyStringToCF4B ; copy name to wcf4b
 	pop hl
-	ld a,[wPPRestoreItem]
-	cp a,ETHER
-	jr nc,.useEther ; if Ether or Max Ether
+	ld a, [wPPRestoreItem]
+	cp ETHER
+	jr nc, .useEther ; if Ether or Max Ether
 .usePPUp
-	ld bc,wPartyMon1PP - wPartyMon1Moves
-	add hl,bc
-	ld a,[hl] ; move PP
-	cp a,3 << 6 ; have 3 PP Ups already been used?
-	jr c,.PPNotMaxedOut
-	ld hl,PPMaxedOutText
+	ld bc, wPartyMon1PP - wPartyMon1Moves
+	add hl, bc
+	ld a, [hl] ; move PP
+	cp 3 << 6 ; have 3 PP Ups already been used?
+	jr c, .PPNotMaxedOut
+	ld hl, PPMaxedOutText
 	call PrintText
 	jr .chooseMove
 .PPNotMaxedOut
-	ld a,[hl]
-	add a,1 << 6 ; increase PP Up count by 1
-	ld [hl],a
-	ld a,1 ; 1 PP Up used
-	ld [wd11e],a
+	ld a, [hl]
+	add 1 << 6 ; increase PP Up count by 1
+	ld [hl], a
+	ld a, 1 ; 1 PP Up used
+	ld [wd11e], a
 	call RestoreBonusPP ; add the bonus PP to current PP
-	ld hl,PPIncreasedText
+	ld hl, PPIncreasedText
 	call PrintText
 .done
 	pop af
-	ld [wWhichPokemon],a
+	ld [wWhichPokemon], a
 	call GBPalWhiteOut
 	call RunDefaultPaletteCommand
 	jp RemoveUsedItem
 .afterRestoringPP ; after using a (Max) Ether/Elixir
-	ld a,[wWhichPokemon]
-	ld b,a
-	ld a,[wPlayerMonNumber]
+	ld a, [wWhichPokemon]
+	ld b, a
+	ld a, [wPlayerMonNumber]
 	cp b ; is the pokemon whose PP was restored active in battle?
-	jr nz,.skipUpdatingInBattleData
-	ld hl,wPartyMon1PP
+	jr nz, .skipUpdatingInBattleData
+	ld hl, wPartyMon1PP
 	ld bc, wPartyMon2 - wPartyMon1
 	call AddNTimes
-	ld de,wBattleMonPP
-	ld bc,4
+	ld de, wBattleMonPP
+	ld bc, 4
 	call CopyData ; copy party data to in-battle data
 .skipUpdatingInBattleData
-	ld a,SFX_HEAL_AILMENT
+	ld a, SFX_HEAL_AILMENT
 	call PlaySound
-	ld hl,PPRestoredText
+	ld hl, PPRestoredText
 	call PrintText
 	jr .done
 .useEther
 	call .restorePP
-	jr nz,.afterRestoringPP
+	jr nz, .afterRestoringPP
 	jp .noEffect
 ; unsets zero flag if PP was restored, sets zero flag if not
 ; however, this is bugged for Max Ethers and Max Elixirs (see below)
 .restorePP
 	xor a ; PLAYER_PARTY_DATA
-	ld [wMonDataLocation],a
+	ld [wMonDataLocation], a
 	call GetMaxPP
-	ld hl,wPartyMon1Moves
+	ld hl, wPartyMon1Moves
 	ld bc, wPartyMon2 - wPartyMon1
 	call GetSelectedMoveOffset
 	ld bc, wPartyMon1PP - wPartyMon1Moves
-	add hl,bc ; hl now points to move's PP
-	ld a,[wMaxPP]
-	ld b,a
-	ld a,[wPPRestoreItem]
-	cp a,MAX_ETHER
-	jr z,.fullyRestorePP
-	ld a,[hl] ; move PP
-	and a,%00111111 ; lower 6 bit bits store current PP
+	add hl, bc ; hl now points to move's PP
+	ld a, [wMaxPP]
+	ld b, a
+	ld a, [wPPRestoreItem]
+	cp MAX_ETHER
+	jr z, .fullyRestorePP
+	ld a, [hl] ; move PP
+	and %00111111 ; lower 6 bit bits store current PP
 	cp b ; does current PP equal max PP?
 	ret z ; if so, return
-	add a,10 ; increase current PP by 10
+	add 10 ; increase current PP by 10
 ; b holds the max PP amount and b will hold the new PP amount.
 ; So, if the new amount meets or exceeds the max amount,
 ; cap the amount to the max amount by leaving b unchanged.
 ; Otherwise, store the new amount in b.
 	cp b ; does the new amount meet or exceed the maximum?
-	jr nc,.storeNewAmount
-	ld b,a
+	jr nc, .storeNewAmount
+	ld b, a
 .storeNewAmount
-	ld a,[hl] ; move PP
-	and a,%11000000 ; PP Up counter bits
+	ld a, [hl] ; move PP
+	and %11000000 ; PP Up counter bits
 	add b
-	ld [hl],a
+	ld [hl], a
 	ret
 .fullyRestorePP
-	ld a,[hl] ; move PP
+	ld a, [hl] ; move PP
 ; Note that this code has a bug. It doesn't mask out the upper two bits, which
 ; are used to count how many PP Ups have been used on the move. So, Max Ethers
 ; and Max Elixirs will not be detected as having no effect on a move with full
@@ -2131,37 +2131,37 @@ ItemUsePPRestore:
 	jr .storeNewAmount
 .useElixir
 ; decrement the item ID so that ELIXER becomes ETHER and MAX_ELIXER becomes MAX_ETHER
-	ld hl,wPPRestoreItem
+	ld hl, wPPRestoreItem
 	dec [hl]
 	dec [hl]
 	xor a
-	ld hl,wCurrentMenuItem
-	ld [hli],a
-	ld [hl],a ; zero the counter for number of moves that had their PP restored
-	ld b,4
+	ld hl, wCurrentMenuItem
+	ld [hli], a
+	ld [hl], a ; zero the counter for number of moves that had their PP restored
+	ld b, 4
 ; loop through each move and restore PP
 .elixirLoop
 	push bc
-	ld hl,wPartyMon1Moves
+	ld hl, wPartyMon1Moves
 	ld bc, wPartyMon2 - wPartyMon1
 	call GetSelectedMoveOffset
-	ld a,[hl]
+	ld a, [hl]
 	and a ; does the current slot have a move?
-	jr z,.nextMove
+	jr z, .nextMove
 	call .restorePP
-	jr z,.nextMove
+	jr z, .nextMove
 ; if some PP was restored
-	ld hl,wTileBehindCursor ; counter for number of moves that had their PP restored
+	ld hl, wTileBehindCursor ; counter for number of moves that had their PP restored
 	inc [hl]
 .nextMove
-	ld hl,wCurrentMenuItem
+	ld hl, wCurrentMenuItem
 	inc [hl]
 	pop bc
 	dec b
-	jr nz,.elixirLoop
-	ld a,[wTileBehindCursor]
+	jr nz, .elixirLoop
+	ld a, [wTileBehindCursor]
 	and a ; did any moves have their PP restored?
-	jp nz,.afterRestoringPP
+	jp nz, .afterRestoringPP
 .noEffect
 	call ItemUseNoEffect
 .itemNotUsed
@@ -2169,7 +2169,7 @@ ItemUsePPRestore:
 	call RunDefaultPaletteCommand
 	pop af
 	xor a
-	ld [wActionResultOrTookBattleTurn],a ; item use failed
+	ld [wActionResultOrTookBattleTurn], a ; item use failed
 	ret
 
 RaisePPWhichTechniqueText:
@@ -2197,63 +2197,63 @@ UnusableItem:
 	jp ItemUseNotTime
 
 ItemUseTMHM:
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp nz,ItemUseNotTime
-	ld a,[wcf91]
-	sub a,TM_01
+	jp nz, ItemUseNotTime
+	ld a, [wcf91]
+	sub TM_01
 	push af
-	jr nc,.skipAdding
-	add a,55 ; if item is an HM, add 55
+	jr nc, .skipAdding
+	add 55 ; if item is an HM, add 55
 .skipAdding
 	inc a
-	ld [wd11e],a
+	ld [wd11e], a
 	predef TMToMove ; get move ID from TM/HM ID
-	ld a,[wd11e]
-	ld [wMoveNum],a
+	ld a, [wd11e]
+	ld [wMoveNum], a
 	call GetMoveName
 	call CopyStringToCF4B ; copy name to wcf4b
 	pop af
-	ld hl,BootedUpTMText
-	jr nc,.printBootedUpMachineText
-	ld hl,BootedUpHMText
+	ld hl, BootedUpTMText
+	jr nc, .printBootedUpMachineText
+	ld hl, BootedUpHMText
 .printBootedUpMachineText
 	call PrintText
-	ld hl,TeachMachineMoveText
+	ld hl, TeachMachineMoveText
 	call PrintText
 	coord hl, 14, 7
 	lb bc, 8, 15
-	ld a,TWO_OPTION_MENU
-	ld [wTextBoxID],a
+	ld a, TWO_OPTION_MENU
+	ld [wTextBoxID], a
 	call DisplayTextBoxID ; yes/no menu
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	and a
-	jr z,.useMachine
-	ld a,2
-	ld [wActionResultOrTookBattleTurn],a ; item not used
+	jr z, .useMachine
+	ld a, 2
+	ld [wActionResultOrTookBattleTurn], a ; item not used
 	ret
 .useMachine
-	ld a,[wWhichPokemon]
+	ld a, [wWhichPokemon]
 	push af
-	ld a,[wcf91]
+	ld a, [wcf91]
 	push af
 .chooseMon
-	ld hl,wcf4b
-	ld de,wTempMoveNameBuffer
-	ld bc,14
+	ld hl, wcf4b
+	ld de, wTempMoveNameBuffer
+	ld bc, 14
 	call CopyData ; save the move name because DisplayPartyMenu will overwrite it
-	ld a,$ff
-	ld [wUpdateSpritesEnabled],a
-	ld a,TMHM_PARTY_MENU
-	ld [wPartyMenuTypeOrMessageID],a
+	ld a, $ff
+	ld [wUpdateSpritesEnabled], a
+	ld a, TMHM_PARTY_MENU
+	ld [wPartyMenuTypeOrMessageID], a
 	call DisplayPartyMenu
 	push af
-	ld hl,wTempMoveNameBuffer
-	ld de,wcf4b
-	ld bc,14
+	ld hl, wTempMoveNameBuffer
+	ld de, wcf4b
+	ld bc, 14
 	call CopyData
 	pop af
-	jr nc,.checkIfAbleToLearnMove
+	jr nc, .checkIfAbleToLearnMove
 ; if the player canceled teaching the move
 	pop af
 	pop af
@@ -2264,31 +2264,31 @@ ItemUseTMHM:
 .checkIfAbleToLearnMove
 	predef CanLearnTM ; check if the pokemon can learn the move
 	push bc
-	ld a,[wWhichPokemon]
-	ld hl,wPartyMonNicks
+	ld a, [wWhichPokemon]
+	ld hl, wPartyMonNicks
 	call GetPartyMonName
 	pop bc
-	ld a,c
+	ld a, c
 	and a ; can the pokemon learn the move?
-	jr nz,.checkIfAlreadyLearnedMove
+	jr nz, .checkIfAlreadyLearnedMove
 ; if the pokemon can't learn the move
-	ld a,SFX_DENIED
+	ld a, SFX_DENIED
 	call PlaySoundWaitForCurrent
-	ld hl,MonCannotLearnMachineMoveText
+	ld hl, MonCannotLearnMachineMoveText
 	call PrintText
 	jr .chooseMon
 .checkIfAlreadyLearnedMove
 	callab CheckIfMoveIsKnown ; check if the pokemon already knows the move
-	jr c,.chooseMon
+	jr c, .chooseMon
 	predef LearnMove ; teach move
 	pop af
-	ld [wcf91],a
+	ld [wcf91], a
 	pop af
-	ld [wWhichPokemon],a
-	ld a,b
+	ld [wWhichPokemon], a
+	ld a, b
 	and a
 	ret z
-	ld a,[wcf91]
+	ld a, [wcf91]
 	call IsItemHM
 	ret c
 	jp RemoveUsedItem
@@ -2310,57 +2310,57 @@ MonCannotLearnMachineMoveText:
 	db "@"
 
 PrintItemUseTextAndRemoveItem:
-	ld hl,ItemUseText00
+	ld hl, ItemUseText00
 	call PrintText
-	ld a,SFX_HEAL_AILMENT
+	ld a, SFX_HEAL_AILMENT
 	call PlaySound
 	call WaitForTextScrollButtonPress ; wait for button press
 
 RemoveUsedItem:
-	ld hl,wNumBagItems
-	ld a,1 ; one item
-	ld [wItemQuantity],a
+	ld hl, wNumBagItems
+	ld a, 1 ; one item
+	ld [wItemQuantity], a
 	jp RemoveItemFromInventory
 
 ItemUseNoEffect:
-	ld hl,ItemUseNoEffectText
+	ld hl, ItemUseNoEffectText
 	jr ItemUseFailed
 
 ItemUseNotTime:
-	ld hl,ItemUseNotTimeText
+	ld hl, ItemUseNotTimeText
 	jr ItemUseFailed
 
 ItemUseNotYoursToUse:
-	ld hl,ItemUseNotYoursToUseText
+	ld hl, ItemUseNotYoursToUseText
 	jr ItemUseFailed
 
 ThrowBallAtTrainerMon:
 	call RunDefaultPaletteCommand
 	call LoadScreenTilesFromBuffer1 ; restore saved screen
 	call Delay3
-	ld a,TOSS_ANIM
-	ld [wAnimationID],a
+	ld a, TOSS_ANIM
+	ld [wAnimationID], a
 	predef MoveAnimation ; do animation
-	ld hl,ThrowBallAtTrainerMonText1
+	ld hl, ThrowBallAtTrainerMonText1
 	call PrintText
-	ld hl,ThrowBallAtTrainerMonText2
+	ld hl, ThrowBallAtTrainerMonText2
 	call PrintText
 	jr RemoveUsedItem
 
 NoCyclingAllowedHere:
-	ld hl,NoCyclingAllowedHereText
+	ld hl, NoCyclingAllowedHereText
 	jr ItemUseFailed
 
 BoxFullCannotThrowBall:
-	ld hl,BoxFullCannotThrowBallText
+	ld hl, BoxFullCannotThrowBallText
 	jr ItemUseFailed
 
 SurfingAttemptFailed:
-	ld hl,NoSurfingHereText
+	ld hl, NoSurfingHereText
 
 ItemUseFailed:
 	xor a
-	ld [wActionResultOrTookBattleTurn],a ; item use failed
+	ld [wActionResultOrTookBattleTurn], a ; item use failed
 	jp PrintText
 
 ItemUseNotTimeText:
@@ -2419,37 +2419,37 @@ GotOffBicycleText:
 ; [wWhichPokemon] = index of pokemon in party
 ; [wCurrentMenuItem] = index of move (when using a PP Up)
 RestoreBonusPP:
-	ld hl,wPartyMon1Moves
+	ld hl, wPartyMon1Moves
 	ld bc, wPartyMon2 - wPartyMon1
-	ld a,[wWhichPokemon]
+	ld a, [wWhichPokemon]
 	call AddNTimes
 	push hl
-	ld de,wNormalMaxPPList - 1
+	ld de, wNormalMaxPPList - 1
 	predef LoadMovePPs ; loads the normal max PP of each of the pokemon's moves to wNormalMaxPPList
 	pop hl
 	ld c, wPartyMon1PP - wPartyMon1Moves
-	ld b,0
-	add hl,bc ; hl now points to move 1 PP
-	ld de,wNormalMaxPPList
-	ld b,0 ; initialize move counter to zero
+	ld b, 0
+	add hl, bc ; hl now points to move 1 PP
+	ld de, wNormalMaxPPList
+	ld b, 0 ; initialize move counter to zero
 ; loop through the pokemon's moves
 .loop
 	inc b
-	ld a,b
-	cp a,5 ; reached the end of the pokemon's moves?
+	ld a, b
+	cp 5 ; reached the end of the pokemon's moves?
 	ret z ; if so, return
-	ld a,[wUsingPPUp]
+	ld a, [wUsingPPUp]
 	dec a ; using a PP Up?
-	jr nz,.skipMenuItemIDCheck
+	jr nz, .skipMenuItemIDCheck
 ; if using a PP Up, check if this is the move it's being used on
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	inc a
 	cp b
-	jr nz,.nextMove
+	jr nz, .nextMove
 .skipMenuItemIDCheck
-	ld a,[hl]
-	and a,%11000000 ; have any PP Ups been used?
-	call nz,AddBonusPP ; if so, add bonus PP
+	ld a, [hl]
+	and %11000000 ; have any PP Ups been used?
+	call nz, AddBonusPP ; if so, add bonus PP
 .nextMove
 	inc hl
 	inc de
@@ -2462,38 +2462,38 @@ RestoreBonusPP:
 ; [hl] = move PP
 AddBonusPP:
 	push bc
-	ld a,[de] ; normal max PP of move
-	ld [H_DIVIDEND + 3],a
+	ld a, [de] ; normal max PP of move
+	ld [H_DIVIDEND + 3], a
 	xor a
-	ld [H_DIVIDEND],a
-	ld [H_DIVIDEND + 1],a
-	ld [H_DIVIDEND + 2],a
-	ld a,5
-	ld [H_DIVISOR],a
-	ld b,4
+	ld [H_DIVIDEND], a
+	ld [H_DIVIDEND + 1], a
+	ld [H_DIVIDEND + 2], a
+	ld a, 5
+	ld [H_DIVISOR], a
+	ld b, 4
 	call Divide
-	ld a,[hl] ; move PP
-	ld b,a
+	ld a, [hl] ; move PP
+	ld b, a
 	swap a
-	and a,%00001111
+	and %00001111
 	srl a
 	srl a
-	ld c,a ; c = number of PP Ups used
+	ld c, a ; c = number of PP Ups used
 .loop
-	ld a,[H_QUOTIENT + 3]
-	cp a,8 ; is the amount greater than or equal to 8?
-	jr c,.addAmount
-	ld a,7 ; cap the amount at 7
+	ld a, [H_QUOTIENT + 3]
+	cp 8 ; is the amount greater than or equal to 8?
+	jr c, .addAmount
+	ld a, 7 ; cap the amount at 7
 .addAmount
 	add b
-	ld b,a
-	ld a,[wUsingPPUp]
+	ld b, a
+	ld a, [wUsingPPUp]
 	dec a ; is the player using a PP Up right now?
-	jr z,.done ; if so, only add the bonus once
+	jr z, .done ; if so, only add the bonus once
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 .done
-	ld [hl],b
+	ld [hl], b
 	pop bc
 	ret
 
@@ -2510,74 +2510,74 @@ AddBonusPP:
 ; OUTPUT:
 ; [wMaxPP] = max PP
 GetMaxPP:
-	ld a,[wMonDataLocation]
+	ld a, [wMonDataLocation]
 	and a
-	ld hl,wPartyMon1Moves
-	ld bc,wPartyMon2 - wPartyMon1
-	jr z,.sourceWithMultipleMon
-	ld hl,wEnemyMon1Moves
+	ld hl, wPartyMon1Moves
+	ld bc, wPartyMon2 - wPartyMon1
+	jr z, .sourceWithMultipleMon
+	ld hl, wEnemyMon1Moves
 	dec a
-	jr z,.sourceWithMultipleMon
-	ld hl,wBoxMon1Moves
-	ld bc,wBoxMon2 - wBoxMon1
+	jr z, .sourceWithMultipleMon
+	ld hl, wBoxMon1Moves
+	ld bc, wBoxMon2 - wBoxMon1
 	dec a
-	jr z,.sourceWithMultipleMon
-	ld hl,wDayCareMonMoves
+	jr z, .sourceWithMultipleMon
+	ld hl, wDayCareMonMoves
 	dec a
-	jr z,.sourceWithOneMon
-	ld hl,wBattleMonMoves ; player's in-battle pokemon
+	jr z, .sourceWithOneMon
+	ld hl, wBattleMonMoves ; player's in-battle pokemon
 .sourceWithOneMon
 	call GetSelectedMoveOffset2
 	jr .next
 .sourceWithMultipleMon
 	call GetSelectedMoveOffset
 .next
-	ld a,[hl]
+	ld a, [hl]
 	dec a
 	push hl
-	ld hl,Moves
-	ld bc,MoveEnd - Moves
+	ld hl, Moves
+	ld bc, MoveEnd - Moves
 	call AddNTimes
-	ld de,wcd6d
-	ld a,BANK(Moves)
+	ld de, wcd6d
+	ld a, BANK(Moves)
 	call FarCopyData
-	ld de,wcd6d + 5 ; PP is byte 5 of move data
-	ld a,[de]
-	ld b,a ; b = normal max PP
+	ld de, wcd6d + 5 ; PP is byte 5 of move data
+	ld a, [de]
+	ld b, a ; b = normal max PP
 	pop hl
 	push bc
-	ld bc,wPartyMon1PP - wPartyMon1Moves ; PP offset if not player's in-battle pokemon data
-	ld a,[wMonDataLocation]
-	cp a,4 ; player's in-battle pokemon?
-	jr nz,.addPPOffset
-	ld bc,wBattleMonPP - wBattleMonMoves ; PP offset if player's in-battle pokemon data
+	ld bc, wPartyMon1PP - wPartyMon1Moves ; PP offset if not player's in-battle pokemon data
+	ld a, [wMonDataLocation]
+	cp 4 ; player's in-battle pokemon?
+	jr nz, .addPPOffset
+	ld bc, wBattleMonPP - wBattleMonMoves ; PP offset if player's in-battle pokemon data
 .addPPOffset
-	add hl,bc
-	ld a,[hl] ; a = current PP
-	and a,%11000000 ; get PP Up count
+	add hl, bc
+	ld a, [hl] ; a = current PP
+	and %11000000 ; get PP Up count
 	pop bc
 	or b ; place normal max PP in 6 lower bits of a
-	ld h,d
-	ld l,e
+	ld h, d
+	ld l, e
 	inc hl ; hl = wcd73
-	ld [hl],a
+	ld [hl], a
 	xor a ; add the bonus for the existing PP Up count
-	ld [wUsingPPUp],a
+	ld [wUsingPPUp], a
 	call AddBonusPP ; add bonus PP from PP Ups
-	ld a,[hl]
-	and a,%00111111 ; mask out the PP Up count
-	ld [wMaxPP],a ; store max PP
+	ld a, [hl]
+	and %00111111 ; mask out the PP Up count
+	ld [wMaxPP], a ; store max PP
 	ret
 
 GetSelectedMoveOffset:
-	ld a,[wWhichPokemon]
+	ld a, [wWhichPokemon]
 	call AddNTimes
 
 GetSelectedMoveOffset2:
-	ld a,[wCurrentMenuItem]
-	ld c,a
-	ld b,0
-	add hl,bc
+	ld a, [wCurrentMenuItem]
+	ld c, a
+	ld b, 0
+	add hl, bc
 	ret
 
 ; confirms the item toss and then tosses the item
@@ -2590,49 +2590,49 @@ GetSelectedMoveOffset2:
 ; clears carry flag if the item is tossed, sets carry flag if not
 TossItem_:
 	push hl
-	ld a,[wcf91]
+	ld a, [wcf91]
 	call IsItemHM
 	pop hl
-	jr c,.tooImportantToToss
+	jr c, .tooImportantToToss
 	push hl
 	call IsKeyItem_
-	ld a,[wIsKeyItem]
+	ld a, [wIsKeyItem]
 	pop hl
 	and a
-	jr nz,.tooImportantToToss
+	jr nz, .tooImportantToToss
 	push hl
-	ld a,[wcf91]
-	ld [wd11e],a
+	ld a, [wcf91]
+	ld [wd11e], a
 	call GetItemName
 	call CopyStringToCF4B ; copy name to wcf4b
-	ld hl,IsItOKToTossItemText
+	ld hl, IsItOKToTossItemText
 	call PrintText
 	coord hl, 14, 7
 	lb bc, 8, 15
-	ld a,TWO_OPTION_MENU
-	ld [wTextBoxID],a
+	ld a, TWO_OPTION_MENU
+	ld [wTextBoxID], a
 	call DisplayTextBoxID ; yes/no menu
-	ld a,[wMenuExitMethod]
-	cp a,CHOSE_SECOND_ITEM
+	ld a, [wMenuExitMethod]
+	cp CHOSE_SECOND_ITEM
 	pop hl
 	scf
 	ret z ; return if the player chose No
 ; if the player chose Yes
 	push hl
-	ld a,[wWhichPokemon]
+	ld a, [wWhichPokemon]
 	call RemoveItemFromInventory
-	ld a,[wcf91]
-	ld [wd11e],a
+	ld a, [wcf91]
+	ld [wd11e], a
 	call GetItemName
 	call CopyStringToCF4B ; copy name to wcf4b
-	ld hl,ThrewAwayItemText
+	ld hl, ThrewAwayItemText
 	call PrintText
 	pop hl
 	and a
 	ret
 .tooImportantToToss
 	push hl
-	ld hl,TooImportantToTossText
+	ld hl, TooImportantToTossText
 	call PrintText
 	pop hl
 	scf
@@ -2658,32 +2658,32 @@ TooImportantToTossText:
 ; 00: item is not key item
 ; 01: item is key item
 IsKeyItem_:
-	ld a,$01
-	ld [wIsKeyItem],a
-	ld a,[wcf91]
-	cp a,HM_01 ; is the item an HM or TM?
-	jr nc,.checkIfItemIsHM
+	ld a, $01
+	ld [wIsKeyItem], a
+	ld a, [wcf91]
+	cp HM_01 ; is the item an HM or TM?
+	jr nc, .checkIfItemIsHM
 ; if the item is not an HM or TM
 	push af
-	ld hl,KeyItemBitfield
-	ld de,wBuffer
-	ld bc,15 ; only 11 bytes are actually used
+	ld hl, KeyItemBitfield
+	ld de, wBuffer
+	ld bc, 15 ; only 11 bytes are actually used
 	call CopyData
 	pop af
 	dec a
-	ld c,a
-	ld hl,wBuffer
-	ld b,FLAG_TEST
+	ld c, a
+	ld hl, wBuffer
+	ld b, FLAG_TEST
 	predef FlagActionPredef
-	ld a,c
+	ld a, c
 	and a
 	ret nz
 .checkIfItemIsHM
-	ld a,[wcf91]
+	ld a, [wcf91]
 	call IsItemHM
 	ret c
 	xor a
-	ld [wIsKeyItem],a
+	ld [wIsKeyItem], a
 	ret
 
 INCLUDE "data/key_items.asm"
@@ -2860,7 +2860,7 @@ SendNewMonToBox:
 IsNextTileShoreOrWater:
 	ld a, [wCurMapTileset]
 	ld hl, WaterTilesets
-	ld de,1
+	ld de, 1
 	call IsInArray
 	jr nc, .notShoreOrWater
 	ld a, [wCurMapTileset]

--- a/engine/items/items.asm
+++ b/engine/items/items.asm
@@ -471,7 +471,7 @@ ItemUseBall:
 ; This is a bug because a wild Pokémon could have used Transform via
 ; Mirror Move even though the only wild Pokémon that knows Transform is Ditto.
 	ld hl,wEnemyBattleStatus3
-	bit Transformed,[hl]
+	bit TRANSFORMED,[hl]
 	jr z,.notTransformed
 	ld a,DITTO
 	ld [wEnemyMonSpecies2],a
@@ -481,7 +481,7 @@ ItemUseBall:
 ; If the Pokémon is not transformed, set the transformed bit and copy the
 ; DVs to wTransformedEnemyMonOriginalDVs so that LoadEnemyMonData won't generate
 ; new DVs.
-	set Transformed,[hl]
+	set TRANSFORMED,[hl]
 	ld hl,wTransformedEnemyMonOriginalDVs
 	ld a,[wEnemyMonDVs]
 	ld [hli],a
@@ -901,7 +901,7 @@ ItemUseMedicine:
 	ld [wBattleMonStatus],a ; remove the status ailment in the in-battle pokemon data
 	push hl
 	ld hl,wPlayerBattleStatus3
-	res BadlyPoisoned,[hl] ; heal Toxic status
+	res BADLY_POISONED,[hl] ; heal Toxic status
 	pop hl
 	ld bc,wPartyMon1Stats - wPartyMon1Status
 	add hl,bc ; hl now points to party stats
@@ -1546,7 +1546,7 @@ ItemUseXAccuracy:
 	and a
 	jp z,ItemUseNotTime
 	ld hl,wPlayerBattleStatus2
-	set UsingXAccuracy,[hl] ; X Accuracy bit
+	set USING_X_ACCURACY,[hl] ; X Accuracy bit
 	jp PrintItemUseTextAndRemoveItem
 
 ; This function is bugged and never works. It always jumps to ItemUseNotTime.
@@ -1655,7 +1655,7 @@ ItemUseGuardSpec:
 	and a
 	jp z,ItemUseNotTime
 	ld hl,wPlayerBattleStatus2
-	set ProtectedByMist,[hl] ; Mist bit
+	set PROTECTED_BY_MIST,[hl] ; Mist bit
 	jp PrintItemUseTextAndRemoveItem
 
 ItemUseSuperRepel:
@@ -1671,7 +1671,7 @@ ItemUseDireHit:
 	and a
 	jp z,ItemUseNotTime
 	ld hl,wPlayerBattleStatus2
-	set GettingPumped,[hl] ; Focus Energy bit
+	set GETTING_PUMPED,[hl] ; Focus Energy bit
 	jp PrintItemUseTextAndRemoveItem
 
 ItemUseXStat:

--- a/engine/load_pokedex_tiles.asm
+++ b/engine/load_pokedex_tiles.asm
@@ -1,11 +1,11 @@
 ; Loads tile patterns for tiles used in the pokedex.
 LoadPokedexTilePatterns:
 	call LoadHpBarAndStatusTilePatterns
-	ld de,PokedexTileGraphics
-	ld hl,vChars2 + $600
+	ld de, PokedexTileGraphics
+	ld hl, vChars2 + $600
 	lb bc, BANK(PokedexTileGraphics), (PokedexTileGraphicsEnd - PokedexTileGraphics) / $10
 	call CopyVideoData
-	ld de,PokeballTileGraphics
-	ld hl,vChars2 + $720
+	ld de, PokeballTileGraphics
+	ld hl, vChars2 + $720
 	lb bc, BANK(PokeballTileGraphics), $01
 	jp CopyVideoData ; load pokeball tile for marking caught mons

--- a/engine/menu/draw_start_menu.asm
+++ b/engine/menu/draw_start_menu.asm
@@ -3,60 +3,60 @@ DrawStartMenu:
 	CheckEvent EVENT_GOT_POKEDEX
 ; menu with pokedex
 	coord hl, 10, 0
-	ld b,$0e
-	ld c,$08
-	jr nz,.drawTextBoxBorder
+	ld b, $0e
+	ld c, $08
+	jr nz, .drawTextBoxBorder
 ; shorter menu if the player doesn't have the pokedex
 	coord hl, 10, 0
-	ld b,$0c
-	ld c,$08
+	ld b, $0c
+	ld c, $08
 .drawTextBoxBorder
 	call TextBoxBorder
-	ld a,D_DOWN | D_UP | START | B_BUTTON | A_BUTTON
-	ld [wMenuWatchedKeys],a
-	ld a,$02
-	ld [wTopMenuItemY],a ; Y position of first menu choice
-	ld a,$0b
-	ld [wTopMenuItemX],a ; X position of first menu choice
-	ld a,[wBattleAndStartSavedMenuItem] ; remembered menu selection from last time
-	ld [wCurrentMenuItem],a
-	ld [wLastMenuItem],a
+	ld a, D_DOWN | D_UP | START | B_BUTTON | A_BUTTON
+	ld [wMenuWatchedKeys], a
+	ld a, $02
+	ld [wTopMenuItemY], a ; Y position of first menu choice
+	ld a, $0b
+	ld [wTopMenuItemX], a ; X position of first menu choice
+	ld a, [wBattleAndStartSavedMenuItem] ; remembered menu selection from last time
+	ld [wCurrentMenuItem], a
+	ld [wLastMenuItem], a
 	xor a
-	ld [wMenuWatchMovingOutOfBounds],a
-	ld hl,wd730
-	set 6,[hl] ; no pauses between printing each letter
+	ld [wMenuWatchMovingOutOfBounds], a
+	ld hl, wd730
+	set 6, [hl] ; no pauses between printing each letter
 	coord hl, 12, 2
 	CheckEvent EVENT_GOT_POKEDEX
 ; case for not having pokedex
-	ld a,$06
-	jr z,.storeMenuItemCount
+	ld a, $06
+	jr z, .storeMenuItemCount
 ; case for having pokedex
-	ld de,StartMenuPokedexText
+	ld de, StartMenuPokedexText
 	call PrintStartMenuItem
-	ld a,$07
+	ld a, $07
 .storeMenuItemCount
-	ld [wMaxMenuItem],a ; number of menu items
-	ld de,StartMenuPokemonText
+	ld [wMaxMenuItem], a ; number of menu items
+	ld de, StartMenuPokemonText
 	call PrintStartMenuItem
-	ld de,StartMenuItemText
+	ld de, StartMenuItemText
 	call PrintStartMenuItem
-	ld de,wPlayerName ; player's name
+	ld de, wPlayerName ; player's name
 	call PrintStartMenuItem
-	ld a,[wd72e]
-	bit 6,a ; is the player using the link feature?
+	ld a, [wd72e]
+	bit 6, a ; is the player using the link feature?
 ; case for not using link feature
-	ld de,StartMenuSaveText
-	jr z,.printSaveOrResetText
+	ld de, StartMenuSaveText
+	jr z, .printSaveOrResetText
 ; case for using link feature
-	ld de,StartMenuResetText
+	ld de, StartMenuResetText
 .printSaveOrResetText
 	call PrintStartMenuItem
-	ld de,StartMenuOptionText
+	ld de, StartMenuOptionText
 	call PrintStartMenuItem
-	ld de,StartMenuExitText
+	ld de, StartMenuExitText
 	call PlaceString
-	ld hl,wd730
-	res 6,[hl] ; turn pauses between printing letters back on
+	ld hl, wd730
+	res 6, [hl] ; turn pauses between printing letters back on
 	ret
 
 StartMenuPokedexText:
@@ -84,6 +84,6 @@ PrintStartMenuItem:
 	push hl
 	call PlaceString
 	pop hl
-	ld de,SCREEN_WIDTH * 2
-	add hl,de
+	ld de, SCREEN_WIDTH * 2
+	add hl, de
 	ret

--- a/engine/menu/main_menu.asm
+++ b/engine/menu/main_menu.asm
@@ -2,133 +2,133 @@ MainMenu:
 ; Check save file
 	call InitOptions
 	xor a
-	ld [wOptionsInitialized],a
+	ld [wOptionsInitialized], a
 	inc a
-	ld [wSaveFileStatus],a
+	ld [wSaveFileStatus], a
 	call CheckForPlayerNameInSRAM
-	jr nc,.mainMenuLoop
+	jr nc, .mainMenuLoop
 
 	predef LoadSAV
 
 .mainMenuLoop
-	ld c,20
+	ld c, 20
 	call DelayFrames
 	xor a ; LINK_STATE_NONE
-	ld [wLinkState],a
-	ld hl,wPartyAndBillsPCSavedMenuItem
-	ld [hli],a
-	ld [hli],a
-	ld [hli],a
-	ld [hl],a
-	ld [wDefaultMap],a
-	ld hl,wd72e
-	res 6,[hl]
+	ld [wLinkState], a
+	ld hl, wPartyAndBillsPCSavedMenuItem
+	ld [hli], a
+	ld [hli], a
+	ld [hli], a
+	ld [hl], a
+	ld [wDefaultMap], a
+	ld hl, wd72e
+	res 6, [hl]
 	call ClearScreen
 	call RunDefaultPaletteCommand
 	call LoadTextBoxTilePatterns
 	call LoadFontTilePatterns
-	ld hl,wd730
-	set 6,[hl]
-	ld a,[wSaveFileStatus]
-	cp a,1
-	jr z,.noSaveFile
+	ld hl, wd730
+	set 6, [hl]
+	ld a, [wSaveFileStatus]
+	cp 1
+	jr z, .noSaveFile
 ; there's a save file
 	coord hl, 0, 0
-	ld b,6
-	ld c,13
+	ld b, 6
+	ld c, 13
 	call TextBoxBorder
 	coord hl, 2, 2
-	ld de,ContinueText
+	ld de, ContinueText
 	call PlaceString
 	jr .next2
 .noSaveFile
 	coord hl, 0, 0
-	ld b,4
-	ld c,13
+	ld b, 4
+	ld c, 13
 	call TextBoxBorder
 	coord hl, 2, 2
-	ld de,NewGameText
+	ld de, NewGameText
 	call PlaceString
 .next2
-	ld hl,wd730
-	res 6,[hl]
+	ld hl, wd730
+	res 6, [hl]
 	call UpdateSprites
 	xor a
-	ld [wCurrentMenuItem],a
-	ld [wLastMenuItem],a
-	ld [wMenuJoypadPollCount],a
+	ld [wCurrentMenuItem], a
+	ld [wLastMenuItem], a
+	ld [wMenuJoypadPollCount], a
 	inc a
-	ld [wTopMenuItemX],a
+	ld [wTopMenuItemX], a
 	inc a
-	ld [wTopMenuItemY],a
-	ld a,A_BUTTON | B_BUTTON | START
-	ld [wMenuWatchedKeys],a
-	ld a,[wSaveFileStatus]
-	ld [wMaxMenuItem],a
+	ld [wTopMenuItemY], a
+	ld a, A_BUTTON | B_BUTTON | START
+	ld [wMenuWatchedKeys], a
+	ld a, [wSaveFileStatus]
+	ld [wMaxMenuItem], a
 	call HandleMenuInput
-	bit 1,a ; pressed B?
-	jp nz,DisplayTitleScreen ; if so, go back to the title screen
-	ld c,20
+	bit 1, a ; pressed B?
+	jp nz, DisplayTitleScreen ; if so, go back to the title screen
+	ld c, 20
 	call DelayFrames
-	ld a,[wCurrentMenuItem]
-	ld b,a
-	ld a,[wSaveFileStatus]
-	cp a,2
-	jp z,.skipInc
+	ld a, [wCurrentMenuItem]
+	ld b, a
+	ld a, [wSaveFileStatus]
+	cp 2
+	jp z, .skipInc
 ; If there's no save file, increment the current menu item so that the numbers
 ; are the same whether or not there's a save file.
 	inc b
 .skipInc
-	ld a,b
+	ld a, b
 	and a
-	jr z,.choseContinue
-	cp a,1
-	jp z,StartNewGame
+	jr z, .choseContinue
+	cp 1
+	jp z, StartNewGame
 	call DisplayOptionMenu
-	ld a,1
-	ld [wOptionsInitialized],a
+	ld a, 1
+	ld [wOptionsInitialized], a
 	jp .mainMenuLoop
 .choseContinue
 	call DisplayContinueGameInfo
-	ld hl,wCurrentMapScriptFlags
-	set 5,[hl]
+	ld hl, wCurrentMapScriptFlags
+	set 5, [hl]
 .inputLoop
 	xor a
-	ld [hJoyPressed],a
-	ld [hJoyReleased],a
-	ld [hJoyHeld],a
+	ld [hJoyPressed], a
+	ld [hJoyReleased], a
+	ld [hJoyHeld], a
 	call Joypad
-	ld a,[hJoyHeld]
-	bit 0,a
-	jr nz,.pressedA
-	bit 1,a
-	jp nz,.mainMenuLoop ; pressed B
+	ld a, [hJoyHeld]
+	bit 0, a
+	jr nz, .pressedA
+	bit 1, a
+	jp nz, .mainMenuLoop ; pressed B
 	jr .inputLoop
 .pressedA
 	call GBPalWhiteOutWithDelay3
 	call ClearScreen
-	ld a,PLAYER_DIR_DOWN
-	ld [wPlayerDirection],a
-	ld c,10
+	ld a, PLAYER_DIR_DOWN
+	ld [wPlayerDirection], a
+	ld c, 10
 	call DelayFrames
-	ld a,[wNumHoFTeams]
+	ld a, [wNumHoFTeams]
 	and a
-	jp z,SpecialEnterMap
-	ld a,[wCurMap] ; map ID
-	cp a,HALL_OF_FAME
-	jp nz,SpecialEnterMap
+	jp z, SpecialEnterMap
+	ld a, [wCurMap] ; map ID
+	cp HALL_OF_FAME
+	jp nz, SpecialEnterMap
 	xor a
-	ld [wDestinationMap],a
-	ld hl,wd732
-	set 2,[hl] ; fly warp or dungeon warp
+	ld [wDestinationMap], a
+	ld hl, wd732
+	set 2, [hl] ; fly warp or dungeon warp
 	call SpecialWarpIn
 	jp SpecialEnterMap
 
 InitOptions:
-	ld a,1 ; no delay
-	ld [wLetterPrintingDelayFlags],a
-	ld a,3 ; medium speed
-	ld [wOptions],a
+	ld a, 1 ; no delay
+	ld [wLetterPrintingDelayFlags], a
+	ld a, 3 ; medium speed
+	ld [wOptions], a
 	ret
 
 LinkMenu:
@@ -428,154 +428,154 @@ SaveScreenInfoText:
 
 DisplayOptionMenu:
 	coord hl, 0, 0
-	ld b,3
-	ld c,18
+	ld b, 3
+	ld c, 18
 	call TextBoxBorder
 	coord hl, 0, 5
-	ld b,3
-	ld c,18
+	ld b, 3
+	ld c, 18
 	call TextBoxBorder
 	coord hl, 0, 10
-	ld b,3
-	ld c,18
+	ld b, 3
+	ld c, 18
 	call TextBoxBorder
 	coord hl, 1, 1
-	ld de,TextSpeedOptionText
+	ld de, TextSpeedOptionText
 	call PlaceString
 	coord hl, 1, 6
-	ld de,BattleAnimationOptionText
+	ld de, BattleAnimationOptionText
 	call PlaceString
 	coord hl, 1, 11
-	ld de,BattleStyleOptionText
+	ld de, BattleStyleOptionText
 	call PlaceString
 	coord hl, 2, 16
-	ld de,OptionMenuCancelText
+	ld de, OptionMenuCancelText
 	call PlaceString
 	xor a
-	ld [wCurrentMenuItem],a
-	ld [wLastMenuItem],a
+	ld [wCurrentMenuItem], a
+	ld [wLastMenuItem], a
 	inc a
-	ld [wLetterPrintingDelayFlags],a
-	ld [wUnusedCD40],a
-	ld a,3 ; text speed cursor Y coordinate
-	ld [wTopMenuItemY],a
+	ld [wLetterPrintingDelayFlags], a
+	ld [wUnusedCD40], a
+	ld a, 3 ; text speed cursor Y coordinate
+	ld [wTopMenuItemY], a
 	call SetCursorPositionsFromOptions
-	ld a,[wOptionsTextSpeedCursorX] ; text speed cursor X coordinate
-	ld [wTopMenuItemX],a
-	ld a,$01
-	ld [H_AUTOBGTRANSFERENABLED],a ; enable auto background transfer
+	ld a, [wOptionsTextSpeedCursorX] ; text speed cursor X coordinate
+	ld [wTopMenuItemX], a
+	ld a, $01
+	ld [H_AUTOBGTRANSFERENABLED], a ; enable auto background transfer
 	call Delay3
 .loop
 	call PlaceMenuCursor
 	call SetOptionsFromCursorPositions
 .getJoypadStateLoop
 	call JoypadLowSensitivity
-	ld a,[hJoy5]
-	ld b,a
-	and a,A_BUTTON | B_BUTTON | START | D_RIGHT | D_LEFT | D_UP | D_DOWN ; any key besides select pressed?
-	jr z,.getJoypadStateLoop
-	bit 1,b ; B button pressed?
-	jr nz,.exitMenu
-	bit 3,b ; Start button pressed?
-	jr nz,.exitMenu
-	bit 0,b ; A button pressed?
-	jr z,.checkDirectionKeys
-	ld a,[wTopMenuItemY]
-	cp a,16 ; is the cursor on Cancel?
-	jr nz,.loop
+	ld a, [hJoy5]
+	ld b, a
+	and A_BUTTON | B_BUTTON | START | D_RIGHT | D_LEFT | D_UP | D_DOWN ; any key besides select pressed?
+	jr z, .getJoypadStateLoop
+	bit 1, b ; B button pressed?
+	jr nz, .exitMenu
+	bit 3, b ; Start button pressed?
+	jr nz, .exitMenu
+	bit 0, b ; A button pressed?
+	jr z, .checkDirectionKeys
+	ld a, [wTopMenuItemY]
+	cp 16 ; is the cursor on Cancel?
+	jr nz, .loop
 .exitMenu
-	ld a,SFX_PRESS_AB
+	ld a, SFX_PRESS_AB
 	call PlaySound
 	ret
 .eraseOldMenuCursor
-	ld [wTopMenuItemX],a
+	ld [wTopMenuItemX], a
 	call EraseMenuCursor
 	jp .loop
 .checkDirectionKeys
-	ld a,[wTopMenuItemY]
-	bit 7,b ; Down pressed?
-	jr nz,.downPressed
-	bit 6,b ; Up pressed?
-	jr nz,.upPressed
-	cp a,8 ; cursor in Battle Animation section?
-	jr z,.cursorInBattleAnimation
-	cp a,13 ; cursor in Battle Style section?
-	jr z,.cursorInBattleStyle
-	cp a,16 ; cursor on Cancel?
-	jr z,.loop
+	ld a, [wTopMenuItemY]
+	bit 7, b ; Down pressed?
+	jr nz, .downPressed
+	bit 6, b ; Up pressed?
+	jr nz, .upPressed
+	cp 8 ; cursor in Battle Animation section?
+	jr z, .cursorInBattleAnimation
+	cp 13 ; cursor in Battle Style section?
+	jr z, .cursorInBattleStyle
+	cp 16 ; cursor on Cancel?
+	jr z, .loop
 .cursorInTextSpeed
-	bit 5,b ; Left pressed?
-	jp nz,.pressedLeftInTextSpeed
+	bit 5, b ; Left pressed?
+	jp nz, .pressedLeftInTextSpeed
 	jp .pressedRightInTextSpeed
 .downPressed
-	cp a,16
-	ld b,-13
-	ld hl,wOptionsTextSpeedCursorX
-	jr z,.updateMenuVariables
-	ld b,5
-	cp a,3
+	cp 16
+	ld b, -13
+	ld hl, wOptionsTextSpeedCursorX
+	jr z, .updateMenuVariables
+	ld b, 5
+	cp 3
 	inc hl
-	jr z,.updateMenuVariables
-	cp a,8
+	jr z, .updateMenuVariables
+	cp 8
 	inc hl
-	jr z,.updateMenuVariables
-	ld b,3
+	jr z, .updateMenuVariables
+	ld b, 3
 	inc hl
 	jr .updateMenuVariables
 .upPressed
-	cp a,8
-	ld b,-5
-	ld hl,wOptionsTextSpeedCursorX
-	jr z,.updateMenuVariables
-	cp a,13
+	cp 8
+	ld b, -5
+	ld hl, wOptionsTextSpeedCursorX
+	jr z, .updateMenuVariables
+	cp 13
 	inc hl
-	jr z,.updateMenuVariables
-	cp a,16
-	ld b,-3
+	jr z, .updateMenuVariables
+	cp 16
+	ld b, -3
 	inc hl
-	jr z,.updateMenuVariables
-	ld b,13
+	jr z, .updateMenuVariables
+	ld b, 13
 	inc hl
 .updateMenuVariables
 	add b
-	ld [wTopMenuItemY],a
-	ld a,[hl]
-	ld [wTopMenuItemX],a
+	ld [wTopMenuItemY], a
+	ld a, [hl]
+	ld [wTopMenuItemX], a
 	call PlaceUnfilledArrowMenuCursor
 	jp .loop
 .cursorInBattleAnimation
-	ld a,[wOptionsBattleAnimCursorX] ; battle animation cursor X coordinate
-	xor a,$0b ; toggle between 1 and 10
-	ld [wOptionsBattleAnimCursorX],a
+	ld a, [wOptionsBattleAnimCursorX] ; battle animation cursor X coordinate
+	xor $0b ; toggle between 1 and 10
+	ld [wOptionsBattleAnimCursorX], a
 	jp .eraseOldMenuCursor
 .cursorInBattleStyle
-	ld a,[wOptionsBattleStyleCursorX] ; battle style cursor X coordinate
-	xor a,$0b ; toggle between 1 and 10
-	ld [wOptionsBattleStyleCursorX],a
+	ld a, [wOptionsBattleStyleCursorX] ; battle style cursor X coordinate
+	xor $0b ; toggle between 1 and 10
+	ld [wOptionsBattleStyleCursorX], a
 	jp .eraseOldMenuCursor
 .pressedLeftInTextSpeed
-	ld a,[wOptionsTextSpeedCursorX] ; text speed cursor X coordinate
-	cp a,1
-	jr z,.updateTextSpeedXCoord
-	cp a,7
-	jr nz,.fromSlowToMedium
-	sub a,6
+	ld a, [wOptionsTextSpeedCursorX] ; text speed cursor X coordinate
+	cp 1
+	jr z, .updateTextSpeedXCoord
+	cp 7
+	jr nz, .fromSlowToMedium
+	sub 6
 	jr .updateTextSpeedXCoord
 .fromSlowToMedium
-	sub a,7
+	sub 7
 	jr .updateTextSpeedXCoord
 .pressedRightInTextSpeed
-	ld a,[wOptionsTextSpeedCursorX] ; text speed cursor X coordinate
-	cp a,14
-	jr z,.updateTextSpeedXCoord
-	cp a,7
-	jr nz,.fromFastToMedium
-	add a,7
+	ld a, [wOptionsTextSpeedCursorX] ; text speed cursor X coordinate
+	cp 14
+	jr z, .updateTextSpeedXCoord
+	cp 7
+	jr nz, .fromFastToMedium
+	add 7
 	jr .updateTextSpeedXCoord
 .fromFastToMedium
-	add a,6
+	add 6
 .updateTextSpeedXCoord
-	ld [wOptionsTextSpeedCursorX],a ; text speed cursor X coordinate
+	ld [wOptionsTextSpeedCursorX], a ; text speed cursor X coordinate
 	jp .eraseOldMenuCursor
 
 TextSpeedOptionText:
@@ -595,79 +595,79 @@ OptionMenuCancelText:
 
 ; sets the options variable according to the current placement of the menu cursors in the options menu
 SetOptionsFromCursorPositions:
-	ld hl,TextSpeedOptionData
-	ld a,[wOptionsTextSpeedCursorX] ; text speed cursor X coordinate
-	ld c,a
+	ld hl, TextSpeedOptionData
+	ld a, [wOptionsTextSpeedCursorX] ; text speed cursor X coordinate
+	ld c, a
 .loop
-	ld a,[hli]
+	ld a, [hli]
 	cp c
-	jr z,.textSpeedMatchFound
+	jr z, .textSpeedMatchFound
 	inc hl
 	jr .loop
 .textSpeedMatchFound
-	ld a,[hl]
-	ld d,a
-	ld a,[wOptionsBattleAnimCursorX] ; battle animation cursor X coordinate
+	ld a, [hl]
+	ld d, a
+	ld a, [wOptionsBattleAnimCursorX] ; battle animation cursor X coordinate
 	dec a
-	jr z,.battleAnimationOn
+	jr z, .battleAnimationOn
 .battleAnimationOff
-	set 7,d
+	set 7, d
 	jr .checkBattleStyle
 .battleAnimationOn
-	res 7,d
+	res 7, d
 .checkBattleStyle
-	ld a,[wOptionsBattleStyleCursorX] ; battle style cursor X coordinate
+	ld a, [wOptionsBattleStyleCursorX] ; battle style cursor X coordinate
 	dec a
-	jr z,.battleStyleShift
+	jr z, .battleStyleShift
 .battleStyleSet
-	set 6,d
+	set 6, d
 	jr .storeOptions
 .battleStyleShift
-	res 6,d
+	res 6, d
 .storeOptions
-	ld a,d
-	ld [wOptions],a
+	ld a, d
+	ld [wOptions], a
 	ret
 
 ; reads the options variable and places menu cursors in the correct positions within the options menu
 SetCursorPositionsFromOptions:
-	ld hl,TextSpeedOptionData + 1
-	ld a,[wOptions]
-	ld c,a
-	and a,$3f
+	ld hl, TextSpeedOptionData + 1
+	ld a, [wOptions]
+	ld c, a
+	and $3f
 	push bc
-	ld de,2
+	ld de, 2
 	call IsInArray
 	pop bc
 	dec hl
-	ld a,[hl]
-	ld [wOptionsTextSpeedCursorX],a ; text speed cursor X coordinate
+	ld a, [hl]
+	ld [wOptionsTextSpeedCursorX], a ; text speed cursor X coordinate
 	coord hl, 0, 3
 	call .placeUnfilledRightArrow
 	sla c
-	ld a,1 ; On
-	jr nc,.storeBattleAnimationCursorX
-	ld a,10 ; Off
+	ld a, 1 ; On
+	jr nc, .storeBattleAnimationCursorX
+	ld a, 10 ; Off
 .storeBattleAnimationCursorX
-	ld [wOptionsBattleAnimCursorX],a ; battle animation cursor X coordinate
+	ld [wOptionsBattleAnimCursorX], a ; battle animation cursor X coordinate
 	coord hl, 0, 8
 	call .placeUnfilledRightArrow
 	sla c
-	ld a,1
-	jr nc,.storeBattleStyleCursorX
-	ld a,10
+	ld a, 1
+	jr nc, .storeBattleStyleCursorX
+	ld a, 10
 .storeBattleStyleCursorX
-	ld [wOptionsBattleStyleCursorX],a ; battle style cursor X coordinate
+	ld [wOptionsBattleStyleCursorX], a ; battle style cursor X coordinate
 	coord hl, 0, 13
 	call .placeUnfilledRightArrow
 ; cursor in front of Cancel
 	coord hl, 0, 16
-	ld a,1
+	ld a, 1
 .placeUnfilledRightArrow
-	ld e,a
-	ld d,0
-	add hl,de
-	ld [hl],$ec ; unfilled right arrow menu cursor
+	ld e, a
+	ld d, 0
+	add hl, de
+	ld [hl], $ec ; unfilled right arrow menu cursor
 	ret
 
 ; table that indicates how the 3 text speed options affect frame delays

--- a/engine/menu/party_menu.asm
+++ b/engine/menu/party_menu.asm
@@ -19,83 +19,83 @@
 ; f8: leveled up
 DrawPartyMenu_:
 	xor a
-	ld [H_AUTOBGTRANSFERENABLED],a
+	ld [H_AUTOBGTRANSFERENABLED], a
 	call ClearScreen
 	call UpdateSprites
 	callba LoadMonPartySpriteGfxWithLCDDisabled ; load pokemon icon graphics
 
 RedrawPartyMenu_:
-	ld a,[wPartyMenuTypeOrMessageID]
-	cp a,SWAP_MONS_PARTY_MENU
-	jp z,.printMessage
+	ld a, [wPartyMenuTypeOrMessageID]
+	cp SWAP_MONS_PARTY_MENU
+	jp z, .printMessage
 	call ErasePartyMenuCursors
 	callba InitPartyMenuBlkPacket
 	coord hl, 3, 0
-	ld de,wPartySpecies
+	ld de, wPartySpecies
 	xor a
-	ld c,a
-	ld [hPartyMonIndex],a
-	ld [wWhichPartyMenuHPBar],a
+	ld c, a
+	ld [hPartyMonIndex], a
+	ld [wWhichPartyMenuHPBar], a
 .loop
-	ld a,[de]
-	cp a,$FF ; reached the terminator?
-	jp z,.afterDrawingMonEntries
+	ld a, [de]
+	cp $FF ; reached the terminator?
+	jp z, .afterDrawingMonEntries
 	push bc
 	push de
 	push hl
-	ld a,c
+	ld a, c
 	push hl
-	ld hl,wPartyMonNicks
+	ld hl, wPartyMonNicks
 	call GetPartyMonName
 	pop hl
 	call PlaceString ; print the pokemon's name
 	callba WriteMonPartySpriteOAMByPartyIndex ; place the appropriate pokemon icon
-	ld a,[hPartyMonIndex]
-	ld [wWhichPokemon],a
+	ld a, [hPartyMonIndex]
+	ld [wWhichPokemon], a
 	inc a
-	ld [hPartyMonIndex],a
+	ld [hPartyMonIndex], a
 	call LoadMonData
 	pop hl
 	push hl
-	ld a,[wMenuItemToSwap]
+	ld a, [wMenuItemToSwap]
 	and a ; is the player swapping pokemon positions?
-	jr z,.skipUnfilledRightArrow
+	jr z, .skipUnfilledRightArrow
 ; if the player is swapping pokemon positions
 	dec a
-	ld b,a
-	ld a,[wWhichPokemon]
+	ld b, a
+	ld a, [wWhichPokemon]
 	cp b ; is the player swapping the current pokemon in the list?
-	jr nz,.skipUnfilledRightArrow
+	jr nz, .skipUnfilledRightArrow
 ; the player is swapping the current pokemon in the list
 	dec hl
 	dec hl
 	dec hl
-	ld a,"▷" ; unfilled right arrow menu cursor
-	ld [hli],a ; place the cursor
+	ld a, "▷" ; unfilled right arrow menu cursor
+	ld [hli], a ; place the cursor
 	inc hl
 	inc hl
 .skipUnfilledRightArrow
-	ld a,[wPartyMenuTypeOrMessageID] ; menu type
-	cp a,TMHM_PARTY_MENU
-	jr z,.teachMoveMenu
-	cp a,EVO_STONE_PARTY_MENU
-	jr z,.evolutionStoneMenu
+	ld a, [wPartyMenuTypeOrMessageID] ; menu type
+	cp TMHM_PARTY_MENU
+	jr z, .teachMoveMenu
+	cp EVO_STONE_PARTY_MENU
+	jr z, .evolutionStoneMenu
 	push hl
-	ld bc,14 ; 14 columns to the right
-	add hl,bc
-	ld de,wLoadedMonStatus
+	ld bc, 14 ; 14 columns to the right
+	add hl, bc
+	ld de, wLoadedMonStatus
 	call PrintStatusCondition
 	pop hl
 	push hl
-	ld bc,SCREEN_WIDTH + 1 ; down 1 row and right 1 column
-	ld a,[hFlags_0xFFF6]
-	set 0,a
-	ld [hFlags_0xFFF6],a
-	add hl,bc
+	ld bc, SCREEN_WIDTH + 1 ; down 1 row and right 1 column
+	ld a, [hFlags_0xFFF6]
+	set 0, a
+	ld [hFlags_0xFFF6], a
+	add hl, bc
 	predef DrawHP2 ; draw HP bar and prints current / max HP
-	ld a,[hFlags_0xFFF6]
-	res 0,a
-	ld [hFlags_0xFFF6],a
+	ld a, [hFlags_0xFFF6]
+	res 0, a
+	ld [hFlags_0xFFF6], a
 	call SetPartyMenuHPBarColor ; color the HP bar (on SGB)
 	pop hl
 	jr .printLevel
@@ -103,26 +103,26 @@ RedrawPartyMenu_:
 	push hl
 	predef CanLearnTM ; check if the pokemon can learn the move
 	pop hl
-	ld de,.ableToLearnMoveText
-	ld a,c
+	ld de, .ableToLearnMoveText
+	ld a, c
 	and a
-	jr nz,.placeMoveLearnabilityString
-	ld de,.notAbleToLearnMoveText
+	jr nz, .placeMoveLearnabilityString
+	ld de, .notAbleToLearnMoveText
 .placeMoveLearnabilityString
-	ld bc,20 + 9 ; down 1 row and right 9 columns
+	ld bc, 20 + 9 ; down 1 row and right 9 columns
 	push hl
-	add hl,bc
+	add hl, bc
 	call PlaceString
 	pop hl
 .printLevel
-	ld bc,10 ; move 10 columns to the right
-	add hl,bc
+	ld bc, 10 ; move 10 columns to the right
+	add hl, bc
 	call PrintLevel
 	pop hl
 	pop de
 	inc de
-	ld bc,2 * 20
-	add hl,bc
+	ld bc, 2 * 20
+	add hl, bc
 	pop bc
 	inc c
 	jp .loop
@@ -132,54 +132,54 @@ RedrawPartyMenu_:
 	db "NOT ABLE@"
 .evolutionStoneMenu
 	push hl
-	ld hl,EvosMovesPointerTable
-	ld b,0
-	ld a,[wLoadedMonSpecies]
+	ld hl, EvosMovesPointerTable
+	ld b, 0
+	ld a, [wLoadedMonSpecies]
 	dec a
 	add a
 	rl b
-	ld c,a
-	add hl,bc
-	ld de,wcd6d
-	ld a,BANK(EvosMovesPointerTable)
-	ld bc,2
+	ld c, a
+	add hl, bc
+	ld de, wcd6d
+	ld a, BANK(EvosMovesPointerTable)
+	ld bc, 2
 	call FarCopyData
-	ld hl,wcd6d
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
-	ld de,wcd6d
-	ld a,BANK(EvosMovesPointerTable)
-	ld bc,Mon133_EvosEnd - Mon133_EvosMoves
+	ld hl, wcd6d
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
+	ld de, wcd6d
+	ld a, BANK(EvosMovesPointerTable)
+	ld bc, Mon133_EvosEnd - Mon133_EvosMoves
 	call FarCopyData
-	ld hl,wcd6d
-	ld de,.notAbleToEvolveText
+	ld hl, wcd6d
+	ld de, .notAbleToEvolveText
 ; loop through the pokemon's evolution entries
 .checkEvolutionsLoop
-	ld a,[hli]
+	ld a, [hli]
 	and a ; reached terminator?
-	jr z,.placeEvolutionStoneString ; if so, place the "NOT ABLE" string
+	jr z, .placeEvolutionStoneString ; if so, place the "NOT ABLE" string
 	inc hl
 	inc hl
-	cp a,EV_ITEM
-	jr nz,.checkEvolutionsLoop
+	cp EV_ITEM
+	jr nz, .checkEvolutionsLoop
 ; if it's a stone evolution entry
 	dec hl
 	dec hl
-	ld b,[hl]
-	ld a,[wEvoStoneItemID] ; the stone the player used
+	ld b, [hl]
+	ld a, [wEvoStoneItemID] ; the stone the player used
 	inc hl
 	inc hl
 	inc hl
 	cp b ; does the player's stone match this evolution entry's stone?
-	jr nz,.checkEvolutionsLoop
+	jr nz, .checkEvolutionsLoop
 ; if it does match
-	ld de,.ableToEvolveText
+	ld de, .ableToEvolveText
 .placeEvolutionStoneString
-	ld bc,20 + 9 ; down 1 row and right 9 columns
+	ld bc, 20 + 9 ; down 1 row and right 9 columns
 	pop hl
 	push hl
-	add hl,bc
+	add hl, bc
 	call PlaceString
 	pop hl
 	jr .printLevel
@@ -191,44 +191,44 @@ RedrawPartyMenu_:
 	ld b, SET_PAL_PARTY_MENU
 	call RunPaletteCommand
 .printMessage
-	ld hl,wd730
-	ld a,[hl]
+	ld hl, wd730
+	ld a, [hl]
 	push af
 	push hl
-	set 6,[hl] ; turn off letter printing delay
-	ld a,[wPartyMenuTypeOrMessageID] ; message ID
-	cp a,$F0
-	jr nc,.printItemUseMessage
+	set 6, [hl] ; turn off letter printing delay
+	ld a, [wPartyMenuTypeOrMessageID] ; message ID
+	cp $F0
+	jr nc, .printItemUseMessage
 	add a
-	ld hl,PartyMenuMessagePointers
-	ld b,0
-	ld c,a
-	add hl,bc
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld hl, PartyMenuMessagePointers
+	ld b, 0
+	ld c, a
+	add hl, bc
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 	call PrintText
 .done
 	pop hl
 	pop af
-	ld [hl],a
-	ld a,1
-	ld [H_AUTOBGTRANSFERENABLED],a
+	ld [hl], a
+	ld a, 1
+	ld [H_AUTOBGTRANSFERENABLED], a
 	call Delay3
 	jp GBPalNormal
 .printItemUseMessage
-	and a,$0F
-	ld hl,PartyMenuItemUseMessagePointers
+	and $0F
+	ld hl, PartyMenuItemUseMessagePointers
 	add a
-	ld c,a
-	ld b,0
-	add hl,bc
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld c, a
+	ld b, 0
+	add hl, bc
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 	push hl
-	ld a,[wUsedItemOnWhichPokemon]
-	ld hl,wPartyMonNicks
+	ld a, [wUsedItemOnWhichPokemon]
+	ld hl, wPartyMonNicks
 	call GetPartyMonName
 	pop hl
 	call PrintText

--- a/engine/menu/pc.asm
+++ b/engine/menu/pc.asm
@@ -17,34 +17,34 @@ PCMainMenu:
 	bit 1, a              ;if player pressed B
 	jp nz, LogOff
 	ld a, [wMaxMenuItem]
-	cp a, 2
+	cp 2
 	jr nz, .next ;if not 2 menu items (not counting log off) (2 occurs before you get the pokedex)
 	ld a, [wCurrentMenuItem]
 	and a
 	jp z, BillsPC    ;if current menu item id is 0, it's bills pc
-	cp a, 1
+	cp 1
 	jr z, .playersPC ;if current menu item id is 1, it's players pc
 	jp LogOff        ;otherwise, it's 2, and you're logging off
 .next
-	cp a, 3
+	cp 3
 	jr nz, .next2 ;if not 3 menu items (not counting log off) (3 occurs after you get the pokedex, before you beat the pokemon league)
 	ld a, [wCurrentMenuItem]
 	and a
 	jp z, BillsPC    ;if current menu item id is 0, it's bills pc
-	cp a, 1
+	cp 1
 	jr z, .playersPC ;if current menu item id is 1, it's players pc
-	cp a, 2
+	cp 2
 	jp z, OaksPC     ;if current menu item id is 2, it's oaks pc
 	jp LogOff        ;otherwise, it's 3, and you're logging off
 .next2
 	ld a, [wCurrentMenuItem]
 	and a
 	jp z, BillsPC    ;if current menu item id is 0, it's bills pc
-	cp a, 1
+	cp 1
 	jr z, .playersPC ;if current menu item id is 1, it's players pc
-	cp a, 2
+	cp 2
 	jp z, OaksPC     ;if current menu item id is 2, it's oaks pc
-	cp a, 3
+	cp 3
 	jp z, PKMNLeague ;if current menu item id is 3, it's pkmnleague
 	jp LogOff        ;otherwise, it's 4, and you're logging off
 .playersPC

--- a/engine/menu/pokedex.asm
+++ b/engine/menu/pokedex.asm
@@ -2,53 +2,53 @@ ShowPokedexMenu:
 	call GBPalWhiteOut
 	call ClearScreen
 	call UpdateSprites
-	ld a,[wListScrollOffset]
+	ld a, [wListScrollOffset]
 	push af
 	xor a
-	ld [wCurrentMenuItem],a
-	ld [wListScrollOffset],a
-	ld [wLastMenuItem],a
+	ld [wCurrentMenuItem], a
+	ld [wListScrollOffset], a
+	ld [wLastMenuItem], a
 	inc a
-	ld [wd11e],a
-	ld [hJoy7],a
+	ld [wd11e], a
+	ld [hJoy7], a
 .setUpGraphics
 	ld b, SET_PAL_GENERIC
 	call RunPaletteCommand
 	callab LoadPokedexTilePatterns
 .doPokemonListMenu
-	ld hl,wTopMenuItemY
-	ld a,3
-	ld [hli],a ; top menu item Y
+	ld hl, wTopMenuItemY
+	ld a, 3
+	ld [hli], a ; top menu item Y
 	xor a
-	ld [hli],a ; top menu item X
+	ld [hli], a ; top menu item X
 	inc a
-	ld [wMenuWatchMovingOutOfBounds],a
+	ld [wMenuWatchMovingOutOfBounds], a
 	inc hl
 	inc hl
-	ld a,6
-	ld [hli],a ; max menu item ID
-	ld [hl],D_LEFT | D_RIGHT | B_BUTTON | A_BUTTON
+	ld a, 6
+	ld [hli], a ; max menu item ID
+	ld [hl], D_LEFT | D_RIGHT | B_BUTTON | A_BUTTON
 	call HandlePokedexListMenu
-	jr c,.goToSideMenu ; if the player chose a pokemon from the list
+	jr c, .goToSideMenu ; if the player chose a pokemon from the list
 .exitPokedex
 	xor a
-	ld [wMenuWatchMovingOutOfBounds],a
-	ld [wCurrentMenuItem],a
-	ld [wLastMenuItem],a
-	ld [hJoy7],a
-	ld [wWastedByteCD3A],a
-	ld [wOverrideSimulatedJoypadStatesMask],a
+	ld [wMenuWatchMovingOutOfBounds], a
+	ld [wCurrentMenuItem], a
+	ld [wLastMenuItem], a
+	ld [hJoy7], a
+	ld [wWastedByteCD3A], a
+	ld [wOverrideSimulatedJoypadStatesMask], a
 	pop af
-	ld [wListScrollOffset],a
+	ld [wListScrollOffset], a
 	call GBPalWhiteOutWithDelay3
 	call RunDefaultPaletteCommand
 	jp ReloadMapData
 .goToSideMenu
 	call HandlePokedexSideMenu
 	dec b
-	jr z,.exitPokedex ; if the player chose Quit
+	jr z, .exitPokedex ; if the player chose Quit
 	dec b
-	jr z,.doPokemonListMenu ; if pokemon not seen or player pressed B button
+	jr z, .doPokemonListMenu ; if pokemon not seen or player pressed B button
 	jp .setUpGraphics ; if pokemon data or area was shown
 
 ; handles the menu on the lower right in the pokedex screen
@@ -59,68 +59,68 @@ ShowPokedexMenu:
 ; 02: the pokemon has not been seen yet or the player pressed the B button
 HandlePokedexSideMenu:
 	call PlaceUnfilledArrowMenuCursor
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	push af
-	ld b,a
-	ld a,[wLastMenuItem]
+	ld b, a
+	ld a, [wLastMenuItem]
 	push af
-	ld a,[wListScrollOffset]
+	ld a, [wListScrollOffset]
 	push af
 	add b
 	inc a
-	ld [wd11e],a
-	ld a,[wd11e]
+	ld [wd11e], a
+	ld a, [wd11e]
 	push af
-	ld a,[wDexMaxSeenMon]
+	ld a, [wDexMaxSeenMon]
 	push af ; this doesn't need to be preserved
-	ld hl,wPokedexSeen
+	ld hl, wPokedexSeen
 	call IsPokemonBitSet
-	ld b,2
-	jr z,.exitSideMenu
+	ld b, 2
+	jr z, .exitSideMenu
 	call PokedexToIndex
-	ld hl,wTopMenuItemY
-	ld a,10
-	ld [hli],a ; top menu item Y
-	ld a,15
-	ld [hli],a ; top menu item X
+	ld hl, wTopMenuItemY
+	ld a, 10
+	ld [hli], a ; top menu item Y
+	ld a, 15
+	ld [hli], a ; top menu item X
 	xor a
-	ld [hli],a ; current menu item ID
+	ld [hli], a ; current menu item ID
 	inc hl
-	ld a,3
-	ld [hli],a ; max menu item ID
+	ld a, 3
+	ld [hli], a ; max menu item ID
 	;ld a, A_BUTTON | B_BUTTON
-	ld [hli],a ; menu watched keys (A button and B button)
+	ld [hli], a ; menu watched keys (A button and B button)
 	xor a
-	ld [hli],a ; old menu item ID
-	ld [wMenuWatchMovingOutOfBounds],a
+	ld [hli], a ; old menu item ID
+	ld [wMenuWatchMovingOutOfBounds], a
 .handleMenuInput
 	call HandleMenuInput
-	bit 1,a ; was the B button pressed?
-	ld b,2
-	jr nz,.buttonBPressed
-	ld a,[wCurrentMenuItem]
+	bit 1, a ; was the B button pressed?
+	ld b, 2
+	jr nz, .buttonBPressed
+	ld a, [wCurrentMenuItem]
 	and a
-	jr z,.choseData
+	jr z, .choseData
 	dec a
-	jr z,.choseCry
+	jr z, .choseCry
 	dec a
-	jr z,.choseArea
+	jr z, .choseArea
 .choseQuit
-	ld b,1
+	ld b, 1
 .exitSideMenu
 	pop af
-	ld [wDexMaxSeenMon],a
+	ld [wDexMaxSeenMon], a
 	pop af
-	ld [wd11e],a
+	ld [wd11e], a
 	pop af
-	ld [wListScrollOffset],a
+	ld [wListScrollOffset], a
 	pop af
-	ld [wLastMenuItem],a
+	ld [wLastMenuItem], a
 	pop af
-	ld [wCurrentMenuItem],a
+	ld [wCurrentMenuItem], a
 	push bc
 	coord hl, 0, 3
-	ld de,20
+	ld de, 20
 	lb bc, " ", 13
 	call DrawTileLine ; cover up the menu cursor in the pokemon list
 	pop bc
@@ -129,7 +129,7 @@ HandlePokedexSideMenu:
 .buttonBPressed
 	push bc
 	coord hl, 15, 10
-	ld de,20
+	ld de, 20
 	lb bc, " ", 7
 	call DrawTileLine ; cover up the menu cursor in the side menu
 	pop bc
@@ -137,130 +137,130 @@ HandlePokedexSideMenu:
 
 .choseData
 	call ShowPokedexDataInternal
-	ld b,0
+	ld b, 0
 	jr .exitSideMenu
 
 ; play pokemon cry
 .choseCry
-	ld a,[wd11e]
+	ld a, [wd11e]
 	call GetCryData
 	call PlaySound
 	jr .handleMenuInput
 
 .choseArea
 	predef LoadTownMap_Nest ; display pokemon areas
-	ld b,0
+	ld b, 0
 	jr .exitSideMenu
 
 ; handles the list of pokemon on the left of the pokedex screen
 ; sets carry flag if player presses A, unsets carry flag if player presses B
 HandlePokedexListMenu:
 	xor a
-	ld [H_AUTOBGTRANSFERENABLED],a
+	ld [H_AUTOBGTRANSFERENABLED], a
 ; draw the horizontal line separating the seen and owned amounts from the menu
 	coord hl, 15, 8
-	ld a,"─"
-	ld [hli],a
-	ld [hli],a
-	ld [hli],a
-	ld [hli],a
-	ld [hli],a
+	ld a, "─"
+	ld [hli], a
+	ld [hli], a
+	ld [hli], a
+	ld [hli], a
+	ld [hli], a
 	coord hl, 14, 0
-	ld [hl],$71 ; vertical line tile
+	ld [hl], $71 ; vertical line tile
 	coord hl, 14, 1
 	call DrawPokedexVerticalLine
 	coord hl, 14, 9
 	call DrawPokedexVerticalLine
-	ld hl,wPokedexSeen
-	ld b,wPokedexSeenEnd - wPokedexSeen
+	ld hl, wPokedexSeen
+	ld b, wPokedexSeenEnd - wPokedexSeen
 	call CountSetBits
 	ld de, wNumSetBits
 	coord hl, 16, 3
 	lb bc, 1, 3
 	call PrintNumber ; print number of seen pokemon
-	ld hl,wPokedexOwned
-	ld b,wPokedexOwnedEnd - wPokedexOwned
+	ld hl, wPokedexOwned
+	ld b, wPokedexOwnedEnd - wPokedexOwned
 	call CountSetBits
 	ld de, wNumSetBits
 	coord hl, 16, 6
 	lb bc, 1, 3
 	call PrintNumber ; print number of owned pokemon
 	coord hl, 16, 2
-	ld de,PokedexSeenText
+	ld de, PokedexSeenText
 	call PlaceString
 	coord hl, 16, 5
-	ld de,PokedexOwnText
+	ld de, PokedexOwnText
 	call PlaceString
 	coord hl, 1, 1
-	ld de,PokedexContentsText
+	ld de, PokedexContentsText
 	call PlaceString
 	coord hl, 16, 10
-	ld de,PokedexMenuItemsText
+	ld de, PokedexMenuItemsText
 	call PlaceString
 ; find the highest pokedex number among the pokemon the player has seen
-	ld hl,wPokedexSeenEnd - 1
-	ld b,(wPokedexSeenEnd - wPokedexSeen) * 8 + 1
+	ld hl, wPokedexSeenEnd - 1
+	ld b, (wPokedexSeenEnd - wPokedexSeen) * 8 + 1
 .maxSeenPokemonLoop
-	ld a,[hld]
-	ld c,8
+	ld a, [hld]
+	ld c, 8
 .maxSeenPokemonInnerLoop
 	dec b
 	sla a
-	jr c,.storeMaxSeenPokemon
+	jr c, .storeMaxSeenPokemon
 	dec c
-	jr nz,.maxSeenPokemonInnerLoop
+	jr nz, .maxSeenPokemonInnerLoop
 	jr .maxSeenPokemonLoop
 
 .storeMaxSeenPokemon
-	ld a,b
-	ld [wDexMaxSeenMon],a
+	ld a, b
+	ld [wDexMaxSeenMon], a
 .loop
 	xor a
-	ld [H_AUTOBGTRANSFERENABLED],a
+	ld [H_AUTOBGTRANSFERENABLED], a
 	coord hl, 4, 2
 	lb bc, 14, 10
 	call ClearScreenArea
 	coord hl, 1, 3
-	ld a,[wListScrollOffset]
-	ld [wd11e],a
-	ld d,7
-	ld a,[wDexMaxSeenMon]
-	cp a,7
-	jr nc,.printPokemonLoop
-	ld d,a
+	ld a, [wListScrollOffset]
+	ld [wd11e], a
+	ld d, 7
+	ld a, [wDexMaxSeenMon]
+	cp 7
+	jr nc, .printPokemonLoop
+	ld d, a
 	dec a
-	ld [wMaxMenuItem],a
+	ld [wMaxMenuItem], a
 ; loop to print pokemon pokedex numbers and names
 ; if the player has owned the pokemon, it puts a pokeball beside the name
 .printPokemonLoop
-	ld a,[wd11e]
+	ld a, [wd11e]
 	inc a
-	ld [wd11e],a
+	ld [wd11e], a
 	push af
 	push de
 	push hl
-	ld de,-SCREEN_WIDTH
-	add hl,de
-	ld de,wd11e
+	ld de, -SCREEN_WIDTH
+	add hl, de
+	ld de, wd11e
 	lb bc, LEADING_ZEROES | 1, 3
 	call PrintNumber ; print the pokedex number
-	ld de,SCREEN_WIDTH
-	add hl,de
+	ld de, SCREEN_WIDTH
+	add hl, de
 	dec hl
 	push hl
-	ld hl,wPokedexOwned
+	ld hl, wPokedexOwned
 	call IsPokemonBitSet
 	pop hl
-	ld a," "
-	jr z,.writeTile
-	ld a,$72 ; pokeball tile
+	ld a, " "
+	jr z, .writeTile
+	ld a, $72 ; pokeball tile
 .writeTile
-	ld [hl],a ; put a pokeball next to pokemon that the player has owned
+	ld [hl], a ; put a pokeball next to pokemon that the player has owned
 	push hl
-	ld hl,wPokedexSeen
+	ld hl, wPokedexSeen
 	call IsPokemonBitSet
-	jr nz,.getPokemonName ; if the player has seen the pokemon
-	ld de,.dashedLine ; print a dashed line in place of the name if the player hasn't seen the pokemon
+	jr nz, .getPokemonName ; if the player has seen the pokemon
+	ld de, .dashedLine ; print a dashed line in place of the name if the player hasn't seen the pokemon
 	jr .skipGettingName
 .dashedLine ; for unseen pokemon in the list
 	db "----------@"
@@ -272,73 +272,73 @@ HandlePokedexListMenu:
 	inc hl
 	call PlaceString
 	pop hl
-	ld bc,2 * SCREEN_WIDTH
-	add hl,bc
+	ld bc, 2 * SCREEN_WIDTH
+	add hl, bc
 	pop de
 	pop af
-	ld [wd11e],a
+	ld [wd11e], a
 	dec d
-	jr nz,.printPokemonLoop
-	ld a,01
-	ld [H_AUTOBGTRANSFERENABLED],a
+	jr nz, .printPokemonLoop
+	ld a, 01
+	ld [H_AUTOBGTRANSFERENABLED], a
 	call Delay3
 	call GBPalNormal
 	call HandleMenuInput
-	bit 1,a ; was the B button pressed?
-	jp nz,.buttonBPressed
+	bit 1, a ; was the B button pressed?
+	jp nz, .buttonBPressed
 .checkIfUpPressed
-	bit 6,a ; was Up pressed?
-	jr z,.checkIfDownPressed
+	bit 6, a ; was Up pressed?
+	jr z, .checkIfDownPressed
 .upPressed ; scroll up one row
-	ld a,[wListScrollOffset]
+	ld a, [wListScrollOffset]
 	and a
-	jp z,.loop
+	jp z, .loop
 	dec a
-	ld [wListScrollOffset],a
+	ld [wListScrollOffset], a
 	jp .loop
 .checkIfDownPressed
-	bit 7,a ; was Down pressed?
-	jr z,.checkIfRightPressed
+	bit 7, a ; was Down pressed?
+	jr z, .checkIfRightPressed
 .downPressed ; scroll down one row
-	ld a,[wDexMaxSeenMon]
-	cp a,7
-	jp c,.loop ; can't if the list is shorter than 7
-	sub a,7
-	ld b,a
-	ld a,[wListScrollOffset]
+	ld a, [wDexMaxSeenMon]
+	cp 7
+	jp c, .loop ; can't if the list is shorter than 7
+	sub 7
+	ld b, a
+	ld a, [wListScrollOffset]
 	cp b
-	jp z,.loop
+	jp z, .loop
 	inc a
-	ld [wListScrollOffset],a
+	ld [wListScrollOffset], a
 	jp .loop
 .checkIfRightPressed
-	bit 4,a ; was Right pressed?
-	jr z,.checkIfLeftPressed
+	bit 4, a ; was Right pressed?
+	jr z, .checkIfLeftPressed
 .rightPressed ; scroll down 7 rows
-	ld a,[wDexMaxSeenMon]
-	cp a,7
-	jp c,.loop ; can't if the list is shorter than 7
-	sub a,6
-	ld b,a
-	ld a,[wListScrollOffset]
-	add a,7
-	ld [wListScrollOffset],a
+	ld a, [wDexMaxSeenMon]
+	cp 7
+	jp c, .loop ; can't if the list is shorter than 7
+	sub 6
+	ld b, a
+	ld a, [wListScrollOffset]
+	add 7
+	ld [wListScrollOffset], a
 	cp b
-	jp c,.loop
+	jp c, .loop
 	dec b
-	ld a,b
-	ld [wListScrollOffset],a
+	ld a, b
+	ld [wListScrollOffset], a
 	jp .loop
 .checkIfLeftPressed ; scroll up 7 rows
-	bit 5,a ; was Left pressed?
-	jr z,.buttonAPressed
+	bit 5, a ; was Left pressed?
+	jr z, .buttonAPressed
 .leftPressed
-	ld a,[wListScrollOffset]
-	sub a,7
-	ld [wListScrollOffset],a
-	jp nc,.loop
+	ld a, [wListScrollOffset]
+	sub 7
+	ld [wListScrollOffset], a
+	jp nc, .loop
 	xor a
-	ld [wListScrollOffset],a
+	ld [wListScrollOffset], a
 	jp .loop
 .buttonAPressed
 	scf
@@ -348,15 +348,15 @@ HandlePokedexListMenu:
 	ret
 
 DrawPokedexVerticalLine:
-	ld c,9 ; height of line
-	ld de,SCREEN_WIDTH
-	ld a,$71 ; vertical line tile
+	ld c, 9 ; height of line
+	ld de, SCREEN_WIDTH
+	ld a, $71 ; vertical line tile
 .loop
-	ld [hl],a
-	add hl,de
-	xor a,1 ; toggle between vertical line tile and box tile
+	ld [hl], a
+	add hl, de
+	xor 1 ; toggle between vertical line tile and box tile
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 PokedexSeenText:
@@ -379,12 +379,12 @@ PokedexMenuItemsText:
 ; [wd11e] = pokedex number
 ; hl = address of bit field
 IsPokemonBitSet:
-	ld a,[wd11e]
+	ld a, [wd11e]
 	dec a
-	ld c,a
-	ld b,FLAG_TEST
+	ld c, a
+	ld b, FLAG_TEST
 	predef FlagActionPredef
-	ld a,c
+	ld a, c
 	and a
 	ret
 
@@ -397,26 +397,26 @@ ShowPokedexData:
 
 ; function to display pokedex data from inside the pokedex
 ShowPokedexDataInternal:
-	ld hl,wd72c
-	set 1,[hl]
-	ld a,$33 ; 3/7 volume
-	ld [rNR50],a
+	ld hl, wd72c
+	set 1, [hl]
+	ld a, $33 ; 3/7 volume
+	ld [rNR50], a
 	call GBPalWhiteOut ; zero all palettes
 	call ClearScreen
-	ld a,[wd11e] ; pokemon ID
-	ld [wcf91],a
+	ld a, [wd11e] ; pokemon ID
+	ld [wcf91], a
 	push af
 	ld b, SET_PAL_POKEDEX
 	call RunPaletteCommand
 	pop af
-	ld [wd11e],a
-	ld a,[hTilesetType]
+	ld [wd11e], a
+	ld a, [hTilesetType]
 	push af
 	xor a
-	ld [hTilesetType],a
+	ld [hTilesetType], a
 
 	coord hl, 0, 0
-	ld de,1
+	ld de, 1
 	lb bc, $64, SCREEN_WIDTH
 	call DrawTileLine ; draw top border
 
@@ -425,71 +425,71 @@ ShowPokedexDataInternal:
 	call DrawTileLine ; draw bottom border
 
 	coord hl, 0, 1
-	ld de,20
+	ld de, 20
 	lb bc, $66, $10
 	call DrawTileLine ; draw left border
 
 	coord hl, 19, 1
-	ld b,$67
+	ld b, $67
 	call DrawTileLine ; draw right border
 
-	ld a,$63 ; upper left corner tile
+	ld a, $63 ; upper left corner tile
 	Coorda 0, 0
-	ld a,$65 ; upper right corner tile
+	ld a, $65 ; upper right corner tile
 	Coorda 19, 0
-	ld a,$6c ; lower left corner tile
+	ld a, $6c ; lower left corner tile
 	Coorda 0, 17
-	ld a,$6e ; lower right corner tile
+	ld a, $6e ; lower right corner tile
 	Coorda 19, 17
 
 	coord hl, 0, 9
-	ld de,PokedexDataDividerLine
+	ld de, PokedexDataDividerLine
 	call PlaceString ; draw horizontal divider line
 
 	coord hl, 9, 6
-	ld de,HeightWeightText
+	ld de, HeightWeightText
 	call PlaceString
 
 	call GetMonName
 	coord hl, 9, 2
 	call PlaceString
 
-	ld hl,PokedexEntryPointers
-	ld a,[wd11e]
+	ld hl, PokedexEntryPointers
+	ld a, [wd11e]
 	dec a
-	ld e,a
-	ld d,0
-	add hl,de
-	add hl,de
-	ld a,[hli]
-	ld e,a
-	ld d,[hl] ; de = address of pokedex entry
+	ld e, a
+	ld d, 0
+	add hl, de
+	add hl, de
+	ld a, [hli]
+	ld e, a
+	ld d, [hl] ; de = address of pokedex entry
 
 	coord hl, 9, 4
 	call PlaceString ; print species name
 
-	ld h,b
-	ld l,c
+	ld h, b
+	ld l, c
 	push de
-	ld a,[wd11e]
+	ld a, [wd11e]
 	push af
 	call IndexToPokedex
 
 	coord hl, 2, 8
 	ld a, "№"
-	ld [hli],a
-	ld a,"⠄"
-	ld [hli],a
-	ld de,wd11e
+	ld [hli], a
+	ld a, "⠄"
+	ld [hli], a
+	ld de, wd11e
 	lb bc, LEADING_ZEROES | 1, 3
 	call PrintNumber ; print pokedex number
 
-	ld hl,wPokedexOwned
+	ld hl, wPokedexOwned
 	call IsPokemonBitSet
 	pop af
-	ld [wd11e],a
-	ld a,[wcf91]
-	ld [wd0b5],a
+	ld [wd11e], a
+	ld a, [wcf91]
+	ld [wd0b5], a
 	pop de
 
 	push af
@@ -502,7 +502,7 @@ ShowPokedexDataInternal:
 	call GetMonHeader ; load pokemon picture location
 	coord hl, 1, 1
 	call LoadFlippedFrontSpriteByMonIndex ; draw pokemon picture
-	ld a,[wcf91]
+	ld a, [wcf91]
 	call PlayCry ; play pokemon cry
 
 	pop hl
@@ -510,83 +510,83 @@ ShowPokedexDataInternal:
 	pop bc
 	pop af
 
-	ld a,c
+	ld a, c
 	and a
-	jp z,.waitForButtonPress ; if the pokemon has not been owned, don't print the height, weight, or description
+	jp z, .waitForButtonPress ; if the pokemon has not been owned, don't print the height, weight, or description
 	inc de ; de = address of feet (height)
-	ld a,[de] ; reads feet, but a is overwritten without being used
+	ld a, [de] ; reads feet, but a is overwritten without being used
 	coord hl, 12, 6
 	lb bc, 1, 2
 	call PrintNumber ; print feet (height)
-	ld a,$60 ; feet symbol tile (one tick)
-	ld [hl],a
+	ld a, $60 ; feet symbol tile (one tick)
+	ld [hl], a
 	inc de
 	inc de ; de = address of inches (height)
 	coord hl, 15, 6
 	lb bc, LEADING_ZEROES | 1, 2
 	call PrintNumber ; print inches (height)
-	ld a,$61 ; inches symbol tile (two ticks)
-	ld [hl],a
+	ld a, $61 ; inches symbol tile (two ticks)
+	ld [hl], a
 ; now print the weight (note that weight is stored in tenths of pounds internally)
 	inc de
 	inc de
 	inc de ; de = address of upper byte of weight
 	push de
 ; put weight in big-endian order at hDexWeight
-	ld hl,hDexWeight
-	ld a,[hl] ; save existing value of [hDexWeight]
+	ld hl, hDexWeight
+	ld a, [hl] ; save existing value of [hDexWeight]
 	push af
-	ld a,[de] ; a = upper byte of weight
-	ld [hli],a ; store upper byte of weight in [hDexWeight]
-	ld a,[hl] ; save existing value of [hDexWeight + 1]
+	ld a, [de] ; a = upper byte of weight
+	ld [hli], a ; store upper byte of weight in [hDexWeight]
+	ld a, [hl] ; save existing value of [hDexWeight + 1]
 	push af
 	dec de
-	ld a,[de] ; a = lower byte of weight
-	ld [hl],a ; store lower byte of weight in [hDexWeight + 1]
-	ld de,hDexWeight
+	ld a, [de] ; a = lower byte of weight
+	ld [hl], a ; store lower byte of weight in [hDexWeight + 1]
+	ld de, hDexWeight
 	coord hl, 11, 8
 	lb bc, 2, 5 ; 2 bytes, 5 digits
 	call PrintNumber ; print weight
 	coord hl, 14, 8
-	ld a,[hDexWeight + 1]
-	sub a,10
-	ld a,[hDexWeight]
-	sbc a,0
-	jr nc,.next
-	ld [hl],"0" ; if the weight is less than 10, put a 0 before the decimal point
+	ld a, [hDexWeight + 1]
+	sub 10
+	ld a, [hDexWeight]
+	sbc 0
+	jr nc, .next
+	ld [hl], "0" ; if the weight is less than 10, put a 0 before the decimal point
 .next
 	inc hl
-	ld a,[hli]
-	ld [hld],a ; make space for the decimal point by moving the last digit forward one tile
-	ld [hl],"⠄" ; decimal point tile
+	ld a, [hli]
+	ld [hld], a ; make space for the decimal point by moving the last digit forward one tile
+	ld [hl], "⠄" ; decimal point tile
 	pop af
-	ld [hDexWeight + 1],a ; restore original value of [hDexWeight + 1]
+	ld [hDexWeight + 1], a ; restore original value of [hDexWeight + 1]
 	pop af
-	ld [hDexWeight],a ; restore original value of [hDexWeight]
+	ld [hDexWeight], a ; restore original value of [hDexWeight]
 	pop hl
 	inc hl ; hl = address of pokedex description text
 	coord bc, 1, 11
-	ld a,2
-	ld [$fff4],a
+	ld a, 2
+	ld [$fff4], a
 	call TextCommandProcessor ; print pokedex description text
 	xor a
-	ld [$fff4],a
+	ld [$fff4], a
 .waitForButtonPress
 	call JoypadLowSensitivity
-	ld a,[hJoy5]
-	and a,A_BUTTON | B_BUTTON
-	jr z,.waitForButtonPress
+	ld a, [hJoy5]
+	and A_BUTTON | B_BUTTON
+	jr z, .waitForButtonPress
 	pop af
-	ld [hTilesetType],a
+	ld [hTilesetType], a
 	call GBPalWhiteOut
 	call ClearScreen
 	call RunDefaultPaletteCommand
 	call LoadTextBoxTilePatterns
 	call GBPalNormal
-	ld hl,wd72c
-	res 1,[hl]
-	ld a,$77 ; max volume
-	ld [rNR50],a
+	ld hl, wd72c
+	res 1, [hl]
+	ld a, $77 ; max volume
+	ld [rNR50], a
 	ret
 
 HeightWeightText:
@@ -615,10 +615,10 @@ DrawTileLine:
 	push bc
 	push de
 .loop
-	ld [hl],b
-	add hl,de
+	ld [hl], b
+	add hl, de
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 	pop de
 	pop bc
 	ret
@@ -629,19 +629,19 @@ PokedexToIndex:
 	; converts the Pokédex number at wd11e to an index
 	push bc
 	push hl
-	ld a,[wd11e]
-	ld b,a
-	ld c,0
-	ld hl,PokedexOrder
+	ld a, [wd11e]
+	ld b, a
+	ld c, 0
+	ld hl, PokedexOrder
 
 .loop ; go through the list until we find an entry with a matching dex number
 	inc c
-	ld a,[hli]
+	ld a, [hli]
 	cp b
-	jr nz,.loop
+	jr nz, .loop
 
-	ld a,c
-	ld [wd11e],a
+	ld a, c
+	ld [wd11e], a
 	pop hl
 	pop bc
 	ret
@@ -650,14 +650,14 @@ IndexToPokedex:
 	; converts the index number at wd11e to a Pokédex number
 	push bc
 	push hl
-	ld a,[wd11e]
+	ld a, [wd11e]
 	dec a
-	ld hl,PokedexOrder
-	ld b,0
-	ld c,a
-	add hl,bc
-	ld a,[hl]
-	ld [wd11e],a
+	ld hl, PokedexOrder
+	ld b, 0
+	ld c, a
+	add hl, bc
+	ld a, [hl]
+	ld [wd11e], a
 	pop hl
 	pop bc
 	ret

--- a/engine/menu/prize_menu.asm
+++ b/engine/menu/prize_menu.asm
@@ -1,26 +1,26 @@
 CeladonPrizeMenu:
-	ld b,COIN_CASE
+	ld b, COIN_CASE
 	call IsItemInBag
-	jr nz,.havingCoinCase
-	ld hl,RequireCoinCaseTextPtr
+	jr nz, .havingCoinCase
+	ld hl, RequireCoinCaseTextPtr
 	jp PrintText
 .havingCoinCase
-	ld hl,wd730
-	set 6,[hl] ; disable letter-printing delay
-	ld hl,ExchangeCoinsForPrizesTextPtr
+	ld hl, wd730
+	set 6, [hl] ; disable letter-printing delay
+	ld hl, ExchangeCoinsForPrizesTextPtr
 	call PrintText
 ; the following are the menu settings
 	xor a
-	ld [wCurrentMenuItem],a
-	ld [wLastMenuItem],a
-	ld a,A_BUTTON | B_BUTTON
-	ld [wMenuWatchedKeys],a
-	ld a,$03
-	ld [wMaxMenuItem],a
-	ld a,$04
-	ld [wTopMenuItemY],a
-	ld a,$01
-	ld [wTopMenuItemX],a
+	ld [wCurrentMenuItem], a
+	ld [wLastMenuItem], a
+	ld a, A_BUTTON | B_BUTTON
+	ld [wMenuWatchedKeys], a
+	ld a, $03
+	ld [wMaxMenuItem], a
+	ld a, $04
+	ld [wTopMenuItemY], a
+	ld a, $01
+	ld [wTopMenuItemX], a
 	call PrintPrizePrice
 	coord hl, 0, 2
 	ld b, 8
@@ -28,18 +28,18 @@ CeladonPrizeMenu:
 	call TextBoxBorder
 	call GetPrizeMenuId
 	call UpdateSprites
-	ld hl,WhichPrizeTextPtr
+	ld hl, WhichPrizeTextPtr
 	call PrintText
 	call HandleMenuInput ; menu choice handler
-	bit 1,a ; keypress = B (Cancel)
+	bit 1, a ; keypress = B (Cancel)
 	jr nz, .noChoice
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	cp 3 ; "NO,THANKS" choice
 	jr z, .noChoice
 	call HandlePrizeChoice
 .noChoice
-	ld hl,wd730
-	res 6,[hl]
+	ld hl, wd730
+	res 6, [hl]
 	ret
 
 RequireCoinCaseTextPtr:
@@ -64,85 +64,85 @@ GetPrizeMenuId:
 ; display the three prizes' names
 ; (distinguishing between Pokemon names
 ; and Items (specifically TMs) names)
-	ld a,[hSpriteIndexOrTextID]
+	ld a, [hSpriteIndexOrTextID]
 	sub 3       ; prize-texts' id are 3, 4 and 5
-	ld [wWhichPrizeWindow],a    ; prize-texts' id (relative, i.e. 0, 1 or 2)
+	ld [wWhichPrizeWindow], a    ; prize-texts' id (relative, i.e. 0, 1 or 2)
 	add a
 	add a
-	ld d,0
-	ld e,a
-	ld hl,PrizeDifferentMenuPtrs
-	add hl,de
-	ld a,[hli]
-	ld d,[hl]
-	ld e,a
+	ld d, 0
+	ld e, a
+	ld hl, PrizeDifferentMenuPtrs
+	add hl, de
+	ld a, [hli]
+	ld d, [hl]
+	ld e, a
 	inc hl
 	push hl
-	ld hl,wPrize1
+	ld hl, wPrize1
 	call CopyString
 	pop hl
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
-	ld de,wPrize1Price
-	ld bc,6
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
+	ld de, wPrize1Price
+	ld bc, 6
 	call CopyData
-	ld a,[wWhichPrizeWindow]
+	ld a, [wWhichPrizeWindow]
 	cp 2        ;is TM_menu?
-	jr nz,.putMonName
-	ld a,[wPrize1]
-	ld [wd11e],a
+	jr nz, .putMonName
+	ld a, [wPrize1]
+	ld [wd11e], a
 	call GetItemName
 	coord hl, 2, 4
 	call PlaceString
-	ld a,[wPrize2]
-	ld [wd11e],a
+	ld a, [wPrize2]
+	ld [wd11e], a
 	call GetItemName
 	coord hl, 2, 6
 	call PlaceString
-	ld a,[wPrize3]
-	ld [wd11e],a
+	ld a, [wPrize3]
+	ld [wd11e], a
 	call GetItemName
 	coord hl, 2, 8
 	call PlaceString
 	jr .putNoThanksText
 .putMonName
-	ld a,[wPrize1]
-	ld [wd11e],a
+	ld a, [wPrize1]
+	ld [wd11e], a
 	call GetMonName
 	coord hl, 2, 4
 	call PlaceString
-	ld a,[wPrize2]
-	ld [wd11e],a
+	ld a, [wPrize2]
+	ld [wd11e], a
 	call GetMonName
 	coord hl, 2, 6
 	call PlaceString
-	ld a,[wPrize3]
-	ld [wd11e],a
+	ld a, [wPrize3]
+	ld [wd11e], a
 	call GetMonName
 	coord hl, 2, 8
 	call PlaceString
 .putNoThanksText
 	coord hl, 2, 10
-	ld de,NoThanksText
+	ld de, NoThanksText
 	call PlaceString
 ; put prices on the right side of the textbox
-	ld de,wPrize1Price
+	ld de, wPrize1Price
 	coord hl, 13, 5
 ; reg. c:
 ; [low nybble] number of bytes
 ; [bit 765 = %100] space-padding (not zero-padding)
-	ld c,(1 << 7 | 2)
+	ld c, (1 << 7 | 2)
 ; Function $15CD displays BCD value (same routine
 ; used by text-command $02)
 	call PrintBCDNumber
-	ld de,wPrize2Price
+	ld de, wPrize2Price
 	coord hl, 13, 7
-	ld c,(1 << 7 | 2)
+	ld c, (1 << 7 | 2)
 	call PrintBCDNumber
-	ld de,wPrize3Price
+	ld de, wPrize3Price
 	coord hl, 13, 9
-	ld c,(1 << 7 | 2)
+	ld c, (1 << 7 | 2)
 	jp PrintBCDNumber
 
 INCLUDE "data/prizes.asm"
@@ -160,8 +160,8 @@ PrintPrizePrice:
 	ld de, .SixSpacesString
 	call PlaceString
 	coord hl, 13, 1
-	ld de,wPlayerCoins
-	ld c,%10000010
+	ld de, wPlayerCoins
+	ld c, %10000010
 	call PrintBCDNumber
 	ret
 
@@ -172,30 +172,30 @@ PrintPrizePrice:
 	db "      @"
 
 LoadCoinsToSubtract:
-	ld a,[wWhichPrize]
+	ld a, [wWhichPrize]
 	add a
-	ld d,0
-	ld e,a
-	ld hl,wPrize1Price
-	add hl,de ; get selected prize's price
+	ld d, 0
+	ld e, a
+	ld hl, wPrize1Price
+	add hl, de ; get selected prize's price
 	xor a
-	ld [hUnusedCoinsByte],a
-	ld a,[hli]
-	ld [hCoins],a
-	ld a,[hl]
-	ld [hCoins + 1],a
+	ld [hUnusedCoinsByte], a
+	ld a, [hli]
+	ld [hCoins], a
+	ld a, [hl]
+	ld [hCoins + 1], a
 	ret
 
 HandlePrizeChoice:
-	ld a,[wCurrentMenuItem]
-	ld [wWhichPrize],a
-	ld d,0
-	ld e,a
-	ld hl,wPrize1
-	add hl,de
-	ld a,[hl]
-	ld [wd11e],a
-	ld a,[wWhichPrizeWindow]
+	ld a, [wCurrentMenuItem]
+	ld [wWhichPrize], a
+	ld d, 0
+	ld e, a
+	ld hl, wPrize1
+	add hl, de
+	ld a, [hl]
+	ld [wd11e], a
+	ld a, [wWhichPrizeWindow]
 	cp 2 ; is prize a TM?
 	jr nz, .getMonName
 	call GetItemName
@@ -203,40 +203,40 @@ HandlePrizeChoice:
 .getMonName
 	call GetMonName
 .givePrize
-	ld hl,SoYouWantPrizeTextPtr
+	ld hl, SoYouWantPrizeTextPtr
 	call PrintText
 	call YesNoChoice
-	ld a,[wCurrentMenuItem] ; yes/no answer (Y=0, N=1)
+	ld a, [wCurrentMenuItem] ; yes/no answer (Y=0, N=1)
 	and a
 	jr nz, .printOhFineThen
 	call LoadCoinsToSubtract
 	call HasEnoughCoins
 	jr c, .notEnoughCoins
-	ld a,[wWhichPrizeWindow]
+	ld a, [wWhichPrizeWindow]
 	cp $02
 	jr nz, .giveMon
-	ld a,[wd11e]
-	ld b,a
-	ld a,1
-	ld c,a
+	ld a, [wd11e]
+	ld b, a
+	ld a, 1
+	ld c, a
 	call GiveItem
 	jr nc, .bagFull
 	jr .subtractCoins
 .giveMon
-	ld a,[wd11e]
-	ld [wcf91],a
+	ld a, [wd11e]
+	ld [wcf91], a
 	push af
 	call GetPrizeMonLevel
-	ld c,a
+	ld c, a
 	pop af
-	ld b,a
+	ld b, a
 	call GivePokemon
 
 ; If either the party or box was full, wait after displaying message.
 	push af
-	ld a,[wAddedToParty]
+	ld a, [wAddedToParty]
 	and a
-	call z,WaitForTextScrollButtonPress
+	call z, WaitForTextScrollButtonPress
 	pop af
 
 ; If the mon couldn't be given to the player (because both the party and box
@@ -245,19 +245,19 @@ HandlePrizeChoice:
 
 .subtractCoins
 	call LoadCoinsToSubtract
-	ld hl,hCoins + 1
-	ld de,wPlayerCoins + 1
-	ld c,$02 ; how many bytes
+	ld hl, hCoins + 1
+	ld de, wPlayerCoins + 1
+	ld c, $02 ; how many bytes
 	predef SubBCDPredef
 	jp PrintPrizePrice
 .bagFull
-	ld hl,PrizeRoomBagIsFullTextPtr
+	ld hl, PrizeRoomBagIsFullTextPtr
 	jp PrintText
 .notEnoughCoins
-	ld hl,SorryNeedMoreCoinsText
+	ld hl, SorryNeedMoreCoinsText
 	jp PrintText
 .printOhFineThen
-	ld hl,OhFineThenTextPtr
+	ld hl, OhFineThenTextPtr
 	jp PrintText
 
 UnknownPrizeData:
@@ -289,18 +289,18 @@ OhFineThenTextPtr:
 	db "@"
 
 GetPrizeMonLevel:
-	ld a,[wcf91]
-	ld b,a
-	ld hl,PrizeMonLevelDictionary
+	ld a, [wcf91]
+	ld b, a
+	ld hl, PrizeMonLevelDictionary
 .loop
-	ld a,[hli]
+	ld a, [hli]
 	cp b
-	jr z,.matchFound
+	jr z, .matchFound
 	inc hl
 	jr .loop
 .matchFound
-	ld a,[hl]
-	ld [wCurEnemyLVL],a
+	ld a, [hl]
+	ld [wCurEnemyLVL], a
 	ret
 
 INCLUDE "data/prize_mon_levels.asm"

--- a/engine/menu/start_menu.asm
+++ b/engine/menu/start_menu.asm
@@ -1,9 +1,9 @@
 DisplayStartMenu::
-	ld a,BANK(StartMenu_Pokedex)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
-	ld a,[wWalkBikeSurfState] ; walking/biking/surfing
-	ld [wWalkBikeSurfStateCopy],a
+	ld a, BANK(StartMenu_Pokedex)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
+	ld a, [wWalkBikeSurfState] ; walking/biking/surfing
+	ld [wWalkBikeSurfStateCopy], a
 	ld a, SFX_START_MENU
 	call PlaySound
 
@@ -13,73 +13,73 @@ RedisplayStartMenu::
 	call UpdateSprites
 .loop
 	call HandleMenuInput
-	ld b,a
+	ld b, a
 .checkIfUpPressed
-	bit 6,a ; was Up pressed?
-	jr z,.checkIfDownPressed
-	ld a,[wCurrentMenuItem] ; menu selection
+	bit 6, a ; was Up pressed?
+	jr z, .checkIfDownPressed
+	ld a, [wCurrentMenuItem] ; menu selection
 	and a
-	jr nz,.loop
-	ld a,[wLastMenuItem]
+	jr nz, .loop
+	ld a, [wLastMenuItem]
 	and a
-	jr nz,.loop
+	jr nz, .loop
 ; if the player pressed tried to go past the top item, wrap around to the bottom
 	CheckEvent EVENT_GOT_POKEDEX
-	ld a,6 ; there are 7 menu items with the pokedex, so the max index is 6
-	jr nz,.wrapMenuItemId
+	ld a, 6 ; there are 7 menu items with the pokedex, so the max index is 6
+	jr nz, .wrapMenuItemId
 	dec a ; there are only 6 menu items without the pokedex
 .wrapMenuItemId
-	ld [wCurrentMenuItem],a
+	ld [wCurrentMenuItem], a
 	call EraseMenuCursor
 	jr .loop
 .checkIfDownPressed
-	bit 7,a
-	jr z,.buttonPressed
+	bit 7, a
+	jr z, .buttonPressed
 ; if the player pressed tried to go past the bottom item, wrap around to the top
 	CheckEvent EVENT_GOT_POKEDEX
-	ld a,[wCurrentMenuItem]
-	ld c,7 ; there are 7 menu items with the pokedex
-	jr nz,.checkIfPastBottom
+	ld a, [wCurrentMenuItem]
+	ld c, 7 ; there are 7 menu items with the pokedex
+	jr nz, .checkIfPastBottom
 	dec c ; there are only 6 menu items without the pokedex
 .checkIfPastBottom
 	cp c
-	jr nz,.loop
+	jr nz, .loop
 ; the player went past the bottom, so wrap to the top
 	xor a
-	ld [wCurrentMenuItem],a
+	ld [wCurrentMenuItem], a
 	call EraseMenuCursor
 	jr .loop
 .buttonPressed ; A, B, or Start button pressed
 	call PlaceUnfilledArrowMenuCursor
-	ld a,[wCurrentMenuItem]
-	ld [wBattleAndStartSavedMenuItem],a ; save current menu selection
-	ld a,b
-	and a,%00001010 ; was the Start button or B button pressed?
-	jp nz,CloseStartMenu
+	ld a, [wCurrentMenuItem]
+	ld [wBattleAndStartSavedMenuItem], a ; save current menu selection
+	ld a, b
+	and %00001010 ; was the Start button or B button pressed?
+	jp nz, CloseStartMenu
 	call SaveScreenTilesToBuffer2 ; copy background from wTileMap to wTileMapBackup2
 	CheckEvent EVENT_GOT_POKEDEX
-	ld a,[wCurrentMenuItem]
-	jr nz,.displayMenuItem
+	ld a, [wCurrentMenuItem]
+	jr nz, .displayMenuItem
 	inc a ; adjust position to account for missing pokedex menu item
 .displayMenuItem
-	cp a,0
-	jp z,StartMenu_Pokedex
-	cp a,1
-	jp z,StartMenu_Pokemon
-	cp a,2
-	jp z,StartMenu_Item
-	cp a,3
-	jp z,StartMenu_TrainerInfo
-	cp a,4
-	jp z,StartMenu_SaveReset
-	cp a,5
-	jp z,StartMenu_Option
+	cp 0
+	jp z, StartMenu_Pokedex
+	cp 1
+	jp z, StartMenu_Pokemon
+	cp 2
+	jp z, StartMenu_Item
+	cp 3
+	jp z, StartMenu_TrainerInfo
+	cp 4
+	jp z, StartMenu_SaveReset
+	cp 5
+	jp z, StartMenu_Option
 
 ; EXIT falls through to here
 CloseStartMenu::
 	call Joypad
-	ld a,[hJoyPressed]
-	bit 0,a ; was A button newly pressed?
-	jr nz,CloseStartMenu
+	ld a, [hJoyPressed]
+	bit 0, a ; was A button newly pressed?
+	jr nz, CloseStartMenu
 	call LoadTextBoxTilePatterns
 	jp CloseTextDisplay

--- a/engine/menu/start_sub_menus.asm
+++ b/engine/menu/start_sub_menus.asm
@@ -7,22 +7,22 @@ StartMenu_Pokedex:
 	jp RedisplayStartMenu
 
 StartMenu_Pokemon:
-	ld a,[wPartyCount]
+	ld a, [wPartyCount]
 	and a
-	jp z,RedisplayStartMenu
+	jp z, RedisplayStartMenu
 	xor a
-	ld [wMenuItemToSwap],a
-	ld [wPartyMenuTypeOrMessageID],a
-	ld [wUpdateSpritesEnabled],a
+	ld [wMenuItemToSwap], a
+	ld [wPartyMenuTypeOrMessageID], a
+	ld [wUpdateSpritesEnabled], a
 	call DisplayPartyMenu
 	jr .checkIfPokemonChosen
 .loop
 	xor a
-	ld [wMenuItemToSwap],a
-	ld [wPartyMenuTypeOrMessageID],a
+	ld [wMenuItemToSwap], a
+	ld [wPartyMenuTypeOrMessageID], a
 	call GoBackToPartyMenu
 .checkIfPokemonChosen
-	jr nc,.chosePokemon
+	jr nc, .chosePokemon
 .exitMenu
 	call GBPalWhiteOutWithDelay3
 	call RestoreScreenTilesAndReloadTilePatterns
@@ -30,94 +30,94 @@ StartMenu_Pokemon:
 	jp RedisplayStartMenu
 .chosePokemon
 	call SaveScreenTilesToBuffer1
-	ld a,FIELD_MOVE_MON_MENU
-	ld [wTextBoxID],a
+	ld a, FIELD_MOVE_MON_MENU
+	ld [wTextBoxID], a
 	call DisplayTextBoxID ; display pokemon menu options
-	ld hl,wFieldMoves
+	ld hl, wFieldMoves
 	lb bc, 2, 12 ; max menu item ID, top menu item Y
-	ld e,5
+	ld e, 5
 .adjustMenuVariablesLoop
 	dec e
-	jr z,.storeMenuVariables
-	ld a,[hli]
+	jr z, .storeMenuVariables
+	ld a, [hli]
 	and a ; end of field moves?
-	jr z,.storeMenuVariables
+	jr z, .storeMenuVariables
 	inc b
 	dec c
 	dec c
 	jr .adjustMenuVariablesLoop
 .storeMenuVariables
-	ld hl,wTopMenuItemY
-	ld a,c
-	ld [hli],a ; top menu item Y
-	ld a,[hFieldMoveMonMenuTopMenuItemX]
-	ld [hli],a ; top menu item X
+	ld hl, wTopMenuItemY
+	ld a, c
+	ld [hli], a ; top menu item Y
+	ld a, [hFieldMoveMonMenuTopMenuItemX]
+	ld [hli], a ; top menu item X
 	xor a
-	ld [hli],a ; current menu item ID
+	ld [hli], a ; current menu item ID
 	inc hl
-	ld a,b
-	ld [hli],a ; max menu item ID
-	ld a,A_BUTTON | B_BUTTON
-	ld [hli],a ; menu watched keys
+	ld a, b
+	ld [hli], a ; max menu item ID
+	ld a, A_BUTTON | B_BUTTON
+	ld [hli], a ; menu watched keys
 	xor a
-	ld [hl],a
+	ld [hl], a
 	call HandleMenuInput
 	push af
 	call LoadScreenTilesFromBuffer1 ; restore saved screen
 	pop af
-	bit 1,a ; was the B button pressed?
-	jp nz,.loop
+	bit 1, a ; was the B button pressed?
+	jp nz, .loop
 ; if the B button wasn't pressed
-	ld a,[wMaxMenuItem]
-	ld b,a
-	ld a,[wCurrentMenuItem] ; menu selection
+	ld a, [wMaxMenuItem]
+	ld b, a
+	ld a, [wCurrentMenuItem] ; menu selection
 	cp b
-	jp z,.exitMenu ; if the player chose Cancel
+	jp z, .exitMenu ; if the player chose Cancel
 	dec b
 	cp b
-	jr z,.choseSwitch
+	jr z, .choseSwitch
 	dec b
 	cp b
-	jp z,.choseStats
-	ld c,a
-	ld b,0
-	ld hl,wFieldMoves
-	add hl,bc
+	jp z, .choseStats
+	ld c, a
+	ld b, 0
+	ld hl, wFieldMoves
+	add hl, bc
 	jp .choseOutOfBattleMove
 .choseSwitch
-	ld a,[wPartyCount]
-	cp a,2 ; is there more than one pokemon in the party?
-	jp c,StartMenu_Pokemon ; if not, no switching
+	ld a, [wPartyCount]
+	cp 2 ; is there more than one pokemon in the party?
+	jp c, StartMenu_Pokemon ; if not, no switching
 	call SwitchPartyMon_InitVarOrSwapData ; init [wMenuItemToSwap]
-	ld a,SWAP_MONS_PARTY_MENU
-	ld [wPartyMenuTypeOrMessageID],a
+	ld a, SWAP_MONS_PARTY_MENU
+	ld [wPartyMenuTypeOrMessageID], a
 	call GoBackToPartyMenu
 	jp .checkIfPokemonChosen
 .choseStats
 	call ClearSprites
 	xor a ; PLAYER_PARTY_DATA
-	ld [wMonDataLocation],a
+	ld [wMonDataLocation], a
 	predef StatusScreen
 	predef StatusScreen2
 	call ReloadMapData
 	jp StartMenu_Pokemon
 .choseOutOfBattleMove
 	push hl
-	ld a,[wWhichPokemon]
-	ld hl,wPartyMonNicks
+	ld a, [wWhichPokemon]
+	ld hl, wPartyMonNicks
 	call GetPartyMonName
 	pop hl
-	ld a,[hl]
+	ld a, [hl]
 	dec a
 	add a
-	ld b,0
-	ld c,a
-	ld hl,.outOfBattleMovePointers
-	add hl,bc
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
-	ld a,[wObtainedBadges] ; badges obtained
+	ld b, 0
+	ld c, a
+	ld hl, .outOfBattleMovePointers
+	add hl, bc
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
+	ld a, [wObtainedBadges] ; badges obtained
 	jp hl
 .outOfBattleMovePointers
 	dw .cut
@@ -130,62 +130,62 @@ StartMenu_Pokemon:
 	dw .teleport
 	dw .softboiled
 .fly
-	bit 2,a ; does the player have the Thunder Badge?
-	jp z,.newBadgeRequired
+	bit 2, a ; does the player have the Thunder Badge?
+	jp z, .newBadgeRequired
 	call CheckIfInOutsideMap
-	jr z,.canFly
-	ld a,[wWhichPokemon]
-	ld hl,wPartyMonNicks
+	jr z, .canFly
+	ld a, [wWhichPokemon]
+	ld hl, wPartyMonNicks
 	call GetPartyMonName
-	ld hl,.cannotFlyHereText
+	ld hl, .cannotFlyHereText
 	call PrintText
 	jp .loop
 .canFly
 	call ChooseFlyDestination
-	ld a,[wd732]
-	bit 3,a ; did the player decide to fly?
-	jp nz,.goBackToMap
+	ld a, [wd732]
+	bit 3, a ; did the player decide to fly?
+	jp nz, .goBackToMap
 	call LoadFontTilePatterns
-	ld hl,wd72e
-	set 1,[hl]
+	ld hl, wd72e
+	set 1, [hl]
 	jp StartMenu_Pokemon
 .cut
-	bit 1,a ; does the player have the Cascade Badge?
-	jp z,.newBadgeRequired
+	bit 1, a ; does the player have the Cascade Badge?
+	jp z, .newBadgeRequired
 	predef UsedCut
-	ld a,[wActionResultOrTookBattleTurn]
+	ld a, [wActionResultOrTookBattleTurn]
 	and a
-	jp z,.loop
+	jp z, .loop
 	jp CloseTextDisplay
 .surf
-	bit 4,a ; does the player have the Soul Badge?
-	jp z,.newBadgeRequired
+	bit 4, a ; does the player have the Soul Badge?
+	jp z, .newBadgeRequired
 	callba IsSurfingAllowed
-	ld hl,wd728
-	bit 1,[hl]
-	res 1,[hl]
-	jp z,.loop
-	ld a,SURFBOARD
-	ld [wcf91],a
-	ld [wPseudoItemID],a
+	ld hl, wd728
+	bit 1, [hl]
+	res 1, [hl]
+	jp z, .loop
+	ld a, SURFBOARD
+	ld [wcf91], a
+	ld [wPseudoItemID], a
 	call UseItem
-	ld a,[wActionResultOrTookBattleTurn]
+	ld a, [wActionResultOrTookBattleTurn]
 	and a
-	jp z,.loop
+	jp z, .loop
 	call GBPalWhiteOutWithDelay3
 	jp .goBackToMap
 .strength
-	bit 3,a ; does the player have the Rainbow Badge?
-	jp z,.newBadgeRequired
+	bit 3, a ; does the player have the Rainbow Badge?
+	jp z, .newBadgeRequired
 	predef PrintStrengthTxt
 	call GBPalWhiteOutWithDelay3
 	jp .goBackToMap
 .flash
-	bit 0,a ; does the player have the Boulder Badge?
-	jp z,.newBadgeRequired
+	bit 0, a ; does the player have the Boulder Badge?
+	jp z, .newBadgeRequired
 	xor a
-	ld [wMapPalOffset],a
-	ld hl,.flashLightsAreaText
+	ld [wMapPalOffset], a
+	ld hl, .flashLightsAreaText
 	call PrintText
 	call GBPalWhiteOutWithDelay3
 	jp .goBackToMap
@@ -193,34 +193,34 @@ StartMenu_Pokemon:
 	TX_FAR _FlashLightsAreaText
 	db "@"
 .dig
-	ld a,ESCAPE_ROPE
-	ld [wcf91],a
-	ld [wPseudoItemID],a
+	ld a, ESCAPE_ROPE
+	ld [wcf91], a
+	ld [wPseudoItemID], a
 	call UseItem
-	ld a,[wActionResultOrTookBattleTurn]
+	ld a, [wActionResultOrTookBattleTurn]
 	and a
-	jp z,.loop
+	jp z, .loop
 	call GBPalWhiteOutWithDelay3
 	jp .goBackToMap
 .teleport
 	call CheckIfInOutsideMap
-	jr z,.canTeleport
-	ld a,[wWhichPokemon]
-	ld hl,wPartyMonNicks
+	jr z, .canTeleport
+	ld a, [wWhichPokemon]
+	ld hl, wPartyMonNicks
 	call GetPartyMonName
-	ld hl,.cannotUseTeleportNowText
+	ld hl, .cannotUseTeleportNowText
 	call PrintText
 	jp .loop
 .canTeleport
-	ld hl,.warpToLastPokemonCenterText
+	ld hl, .warpToLastPokemonCenterText
 	call PrintText
-	ld hl,wd732
-	set 3,[hl]
-	set 6,[hl]
-	ld hl,wd72e
-	set 1,[hl]
-	res 4,[hl]
-	ld c,60
+	ld hl, wd732
+	set 3, [hl]
+	set 6, [hl]
+	ld hl, wd72e
+	set 1, [hl]
+	res 4, [hl]
+	ld c, 60
 	call DelayFrames
 	call GBPalWhiteOutWithDelay3
 	jp .goBackToMap
@@ -234,39 +234,39 @@ StartMenu_Pokemon:
 	TX_FAR _CannotFlyHereText
 	db "@"
 .softboiled
-	ld hl,wPartyMon1MaxHP
-	ld a,[wWhichPokemon]
-	ld bc,wPartyMon2 - wPartyMon1
+	ld hl, wPartyMon1MaxHP
+	ld a, [wWhichPokemon]
+	ld bc, wPartyMon2 - wPartyMon1
 	call AddNTimes
-	ld a,[hli]
-	ld [H_DIVIDEND],a
-	ld a,[hl]
-	ld [H_DIVIDEND + 1],a
-	ld a,5
-	ld [H_DIVISOR],a
-	ld b,2 ; number of bytes
+	ld a, [hli]
+	ld [H_DIVIDEND], a
+	ld a, [hl]
+	ld [H_DIVIDEND + 1], a
+	ld a, 5
+	ld [H_DIVISOR], a
+	ld b, 2 ; number of bytes
 	call Divide
-	ld bc,wPartyMon1HP - wPartyMon1MaxHP
-	add hl,bc
-	ld a,[hld]
-	ld b,a
-	ld a,[H_QUOTIENT + 3]
+	ld bc, wPartyMon1HP - wPartyMon1MaxHP
+	add hl, bc
+	ld a, [hld]
+	ld b, a
+	ld a, [H_QUOTIENT + 3]
 	sub b
-	ld b,[hl]
-	ld a,[H_QUOTIENT + 2]
+	ld b, [hl]
+	ld a, [H_QUOTIENT + 2]
 	sbc b
-	jp nc,.notHealthyEnough
-	ld a,[wPartyAndBillsPCSavedMenuItem]
+	jp nc, .notHealthyEnough
+	ld a, [wPartyAndBillsPCSavedMenuItem]
 	push af
-	ld a,POTION
-	ld [wcf91],a
-	ld [wPseudoItemID],a
+	ld a, POTION
+	ld [wcf91], a
+	ld [wPseudoItemID], a
 	call UseItem
 	pop af
-	ld [wPartyAndBillsPCSavedMenuItem],a
+	ld [wPartyAndBillsPCSavedMenuItem], a
 	jp .loop
 .notHealthyEnough ; if current HP is less than 1/5 of max HP
-	ld hl,.notHealthyEnoughText
+	ld hl, .notHealthyEnoughText
 	call PrintText
 	jp .loop
 .notHealthyEnoughText
@@ -276,7 +276,7 @@ StartMenu_Pokemon:
 	call RestoreScreenTilesAndReloadTilePatterns
 	jp CloseTextDisplay
 .newBadgeRequired
-	ld hl,.newBadgeRequiredText
+	ld hl, .newBadgeRequiredText
 	call PrintText
 	jp .loop
 .newBadgeRequiredText
@@ -286,13 +286,13 @@ StartMenu_Pokemon:
 ; writes a blank tile to all possible menu cursor positions on the party menu
 ErasePartyMenuCursors:
 	coord hl, 0, 1
-	ld bc,2 * 20 ; menu cursor positions are 2 rows apart
-	ld a,6 ; 6 menu cursor positions
+	ld bc, 2 * 20 ; menu cursor positions are 2 rows apart
+	ld a, 6 ; 6 menu cursor positions
 .loop
-	ld [hl]," "
-	add hl,bc
+	ld [hl], " "
+	add hl, bc
 	dec a
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 ItemMenuLoop:
@@ -300,28 +300,28 @@ ItemMenuLoop:
 	call RunDefaultPaletteCommand
 
 StartMenu_Item:
-	ld a,[wLinkState]
+	ld a, [wLinkState]
 	dec a ; is the player in the Colosseum or Trade Centre?
-	jr nz,.notInCableClubRoom
-	ld hl,CannotUseItemsHereText
+	jr nz, .notInCableClubRoom
+	ld hl, CannotUseItemsHereText
 	call PrintText
 	jr .exitMenu
 .notInCableClubRoom
-	ld bc,wNumBagItems
-	ld hl,wListPointer
-	ld a,c
-	ld [hli],a
-	ld [hl],b ; store item bag pointer in wListPointer (for DisplayListMenuID)
+	ld bc, wNumBagItems
+	ld hl, wListPointer
+	ld a, c
+	ld [hli], a
+	ld [hl], b ; store item bag pointer in wListPointer (for DisplayListMenuID)
 	xor a
-	ld [wPrintItemPrices],a
-	ld a,ITEMLISTMENU
-	ld [wListMenuID],a
-	ld a,[wBagSavedMenuItem]
-	ld [wCurrentMenuItem],a
+	ld [wPrintItemPrices], a
+	ld a, ITEMLISTMENU
+	ld [wListMenuID], a
+	ld a, [wBagSavedMenuItem]
+	ld [wCurrentMenuItem], a
 	call DisplayListMenuID
-	ld a,[wCurrentMenuItem]
-	ld [wBagSavedMenuItem],a
-	jr nc,.choseItem
+	ld a, [wCurrentMenuItem]
+	ld [wBagSavedMenuItem], a
+	jr nc, .choseItem
 .exitMenu
 	call LoadScreenTilesFromBuffer2 ; restore saved screen
 	call LoadTextBoxTilePatterns
@@ -329,111 +329,111 @@ StartMenu_Item:
 	jp RedisplayStartMenu
 .choseItem
 ; erase menu cursor (blank each tile in front of an item name)
-	ld a," "
+	ld a, " "
 	Coorda 5, 4
 	Coorda 5, 6
 	Coorda 5, 8
 	Coorda 5, 10
 	call PlaceUnfilledArrowMenuCursor
 	xor a
-	ld [wMenuItemToSwap],a
-	ld a,[wcf91]
-	cp a,BICYCLE
-	jp z,.useOrTossItem
+	ld [wMenuItemToSwap], a
+	ld a, [wcf91]
+	cp BICYCLE
+	jp z, .useOrTossItem
 .notBicycle1
-	ld a,USE_TOSS_MENU_TEMPLATE
-	ld [wTextBoxID],a
+	ld a, USE_TOSS_MENU_TEMPLATE
+	ld [wTextBoxID], a
 	call DisplayTextBoxID
-	ld hl,wTopMenuItemY
-	ld a,11
-	ld [hli],a ; top menu item Y
-	ld a,14
-	ld [hli],a ; top menu item X
+	ld hl, wTopMenuItemY
+	ld a, 11
+	ld [hli], a ; top menu item Y
+	ld a, 14
+	ld [hli], a ; top menu item X
 	xor a
-	ld [hli],a ; current menu item ID
+	ld [hli], a ; current menu item ID
 	inc hl
 	inc a ; a = 1
-	ld [hli],a ; max menu item ID
-	ld a,A_BUTTON | B_BUTTON
-	ld [hli],a ; menu watched keys
+	ld [hli], a ; max menu item ID
+	ld a, A_BUTTON | B_BUTTON
+	ld [hli], a ; menu watched keys
 	xor a
-	ld [hl],a ; old menu item id
+	ld [hl], a ; old menu item id
 	call HandleMenuInput
 	call PlaceUnfilledArrowMenuCursor
-	bit 1,a ; was the B button pressed?
-	jr z,.useOrTossItem
+	bit 1, a ; was the B button pressed?
+	jr z, .useOrTossItem
 	jp ItemMenuLoop
 .useOrTossItem ; if the player made the choice to use or toss the item
-	ld a,[wcf91]
-	ld [wd11e],a
+	ld a, [wcf91]
+	ld [wd11e], a
 	call GetItemName
 	call CopyStringToCF4B ; copy name to wcf4b
-	ld a,[wcf91]
-	cp a,BICYCLE
-	jr nz,.notBicycle2
-	ld a,[wd732]
-	bit 5,a
-	jr z,.useItem_closeMenu
-	ld hl,CannotGetOffHereText
+	ld a, [wcf91]
+	cp BICYCLE
+	jr nz, .notBicycle2
+	ld a, [wd732]
+	bit 5, a
+	jr z, .useItem_closeMenu
+	ld hl, CannotGetOffHereText
 	call PrintText
 	jp ItemMenuLoop
 .notBicycle2
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	and a
-	jr nz,.tossItem
+	jr nz, .tossItem
 ; use item
-	ld [wPseudoItemID],a ; a must be 0 due to above conditional jump
-	ld a,[wcf91]
-	cp a,HM_01
-	jr nc,.useItem_partyMenu
-	ld hl,UsableItems_CloseMenu
-	ld de,1
+	ld [wPseudoItemID], a ; a must be 0 due to above conditional jump
+	ld a, [wcf91]
+	cp HM_01
+	jr nc, .useItem_partyMenu
+	ld hl, UsableItems_CloseMenu
+	ld de, 1
 	call IsInArray
-	jr c,.useItem_closeMenu
-	ld a,[wcf91]
-	ld hl,UsableItems_PartyMenu
-	ld de,1
+	jr c, .useItem_closeMenu
+	ld a, [wcf91]
+	ld hl, UsableItems_PartyMenu
+	ld de, 1
 	call IsInArray
-	jr c,.useItem_partyMenu
+	jr c, .useItem_partyMenu
 	call UseItem
 	jp ItemMenuLoop
 .useItem_closeMenu
 	xor a
-	ld [wPseudoItemID],a
+	ld [wPseudoItemID], a
 	call UseItem
-	ld a,[wActionResultOrTookBattleTurn]
+	ld a, [wActionResultOrTookBattleTurn]
 	and a
-	jp z,ItemMenuLoop
+	jp z, ItemMenuLoop
 	jp CloseStartMenu
 .useItem_partyMenu
-	ld a,[wUpdateSpritesEnabled]
+	ld a, [wUpdateSpritesEnabled]
 	push af
 	call UseItem
-	ld a,[wActionResultOrTookBattleTurn]
-	cp a,$02
-	jp z,.partyMenuNotDisplayed
+	ld a, [wActionResultOrTookBattleTurn]
+	cp $02
+	jp z, .partyMenuNotDisplayed
 	call GBPalWhiteOutWithDelay3
 	call RestoreScreenTilesAndReloadTilePatterns
 	pop af
-	ld [wUpdateSpritesEnabled],a
+	ld [wUpdateSpritesEnabled], a
 	jp StartMenu_Item
 .partyMenuNotDisplayed
 	pop af
-	ld [wUpdateSpritesEnabled],a
+	ld [wUpdateSpritesEnabled], a
 	jp ItemMenuLoop
 .tossItem
 	call IsKeyItem
-	ld a,[wIsKeyItem]
+	ld a, [wIsKeyItem]
 	and a
-	jr nz,.skipAskingQuantity
-	ld a,[wcf91]
+	jr nz, .skipAskingQuantity
+	ld a, [wcf91]
 	call IsItemHM
-	jr c,.skipAskingQuantity
+	jr c, .skipAskingQuantity
 	call DisplayChooseQuantityMenu
 	inc a
-	jr z,.tossZeroItems
+	jr z, .tossZeroItems
 .skipAskingQuantity
-	ld hl,wNumBagItems
+	ld hl, wNumBagItems
 	call TossItem
 .tossZeroItems
 	jp ItemMenuLoop
@@ -500,10 +500,10 @@ StartMenu_TrainerInfo:
 	call GBPalWhiteOut
 	call ClearScreen
 	call UpdateSprites
-	ld a,[hTilesetType]
+	ld a, [hTilesetType]
 	push af
 	xor a
-	ld [hTilesetType],a
+	ld [hTilesetType], a
 	call DrawTrainerInfo
 	predef DrawBadges ; draw badges
 	ld b, SET_PAL_TRAINER_CARD
@@ -517,101 +517,101 @@ StartMenu_TrainerInfo:
 	call ReloadMapData
 	call LoadGBPal
 	pop af
-	ld [hTilesetType],a
+	ld [hTilesetType], a
 	jp RedisplayStartMenu
 
 ; loads tile patterns and draws everything except for gym leader faces / badges
 DrawTrainerInfo:
-	ld de,RedPicFront
+	ld de, RedPicFront
 	lb bc, BANK(RedPicFront), $01
 	predef DisplayPicCenteredOrUpperRight
 	call DisableLCD
 	coord hl, 0, 2
-	ld a," "
+	ld a, " "
 	call TrainerInfo_DrawVerticalLine
 	coord hl, 1, 2
 	call TrainerInfo_DrawVerticalLine
-	ld hl,vChars2 + $70
-	ld de,vChars2
-	ld bc,$70 * 4
+	ld hl, vChars2 + $70
+	ld de, vChars2
+	ld bc, $70 * 4
 	call CopyData
-	ld hl,TrainerInfoTextBoxTileGraphics ; trainer info text box tile patterns
-	ld de,vChars2 + $770
-	ld bc,$0080
+	ld hl, TrainerInfoTextBoxTileGraphics ; trainer info text box tile patterns
+	ld de, vChars2 + $770
+	ld bc, $0080
 	push bc
 	call TrainerInfo_FarCopyData
-	ld hl,BlankLeaderNames
-	ld de,vChars2 + $600
-	ld bc,$0170
+	ld hl, BlankLeaderNames
+	ld de, vChars2 + $600
+	ld bc, $0170
 	call TrainerInfo_FarCopyData
 	pop bc
-	ld hl,BadgeNumbersTileGraphics  ; badge number tile patterns
-	ld de,vChars1 + $580
+	ld hl, BadgeNumbersTileGraphics  ; badge number tile patterns
+	ld de, vChars1 + $580
 	call TrainerInfo_FarCopyData
-	ld hl,GymLeaderFaceAndBadgeTileGraphics  ; gym leader face and badge tile patterns
-	ld de,vChars2 + $200
-	ld bc,$0400
-	ld a,$03
+	ld hl, GymLeaderFaceAndBadgeTileGraphics  ; gym leader face and badge tile patterns
+	ld de, vChars2 + $200
+	ld bc, $0400
+	ld a, $03
 	call FarCopyData2
-	ld hl,TextBoxGraphics
-	ld de,$00d0
-	add hl,de ; hl = colon tile pattern
-	ld de,vChars1 + $560
-	ld bc,$0010
-	ld a,$04
+	ld hl, TextBoxGraphics
+	ld de, $00d0
+	add hl, de ; hl = colon tile pattern
+	ld de, vChars1 + $560
+	ld bc, $0010
+	ld a, $04
 	push bc
 	call FarCopyData2
 	pop bc
-	ld hl,TrainerInfoTextBoxTileGraphics + $80  ; background tile pattern
-	ld de,vChars1 + $570
+	ld hl, TrainerInfoTextBoxTileGraphics + $80  ; background tile pattern
+	ld de, vChars1 + $570
 	call TrainerInfo_FarCopyData
 	call EnableLCD
-	ld hl,wTrainerInfoTextBoxWidthPlus1
-	ld a,18 + 1
-	ld [hli],a
+	ld hl, wTrainerInfoTextBoxWidthPlus1
+	ld a, 18 + 1
+	ld [hli], a
 	dec a
-	ld [hli],a
-	ld [hl],1
+	ld [hli], a
+	ld [hl], 1
 	coord hl, 0, 0
 	call TrainerInfo_DrawTextBox
-	ld hl,wTrainerInfoTextBoxWidthPlus1
-	ld a,16 + 1
-	ld [hli],a
+	ld hl, wTrainerInfoTextBoxWidthPlus1
+	ld a, 16 + 1
+	ld [hli], a
 	dec a
-	ld [hli],a
-	ld [hl],3
+	ld [hli], a
+	ld [hl], 3
 	coord hl, 1, 10
 	call TrainerInfo_DrawTextBox
 	coord hl, 0, 10
-	ld a,$d7
+	ld a, $d7
 	call TrainerInfo_DrawVerticalLine
 	coord hl, 19, 10
 	call TrainerInfo_DrawVerticalLine
 	coord hl, 6, 9
-	ld de,TrainerInfo_BadgesText
+	ld de, TrainerInfo_BadgesText
 	call PlaceString
 	coord hl, 2, 2
-	ld de,TrainerInfo_NameMoneyTimeText
+	ld de, TrainerInfo_NameMoneyTimeText
 	call PlaceString
 	coord hl, 7, 2
-	ld de,wPlayerName
+	ld de, wPlayerName
 	call PlaceString
 	coord hl, 8, 4
-	ld de,wPlayerMoney
-	ld c,$e3
+	ld de, wPlayerMoney
+	ld c, $e3
 	call PrintBCDNumber
 	coord hl, 9, 6
-	ld de,wPlayTimeHours ; hours
+	ld de, wPlayTimeHours ; hours
 	lb bc, LEFT_ALIGN | 1, 3
 	call PrintNumber
-	ld [hl],$d6 ; colon tile ID
+	ld [hl], $d6 ; colon tile ID
 	inc hl
-	ld de,wPlayTimeMinutes ; minutes
+	ld de, wPlayTimeMinutes ; minutes
 	lb bc, LEADING_ZEROES | 1, 2
 	jp PrintNumber
 
 TrainerInfo_FarCopyData:
-	ld a,BANK(TrainerInfoTextBoxTileGraphics)
+	ld a, BANK(TrainerInfoTextBoxTileGraphics)
 	jp FarCopyData2
 
 TrainerInfo_NameMoneyTimeText:
@@ -631,43 +631,43 @@ TrainerInfo_BadgesText:
 ; [wTrainerInfoTextBoxWidth] = width - 1
 ; [wTrainerInfoTextBoxNextRowOffset] = distance from the end of a text box row to the start of the next
 TrainerInfo_DrawTextBox:
-	ld a,$79 ; upper left corner tile ID
+	ld a, $79 ; upper left corner tile ID
 	lb de, $7a, $7b ; top edge and upper right corner tile ID's
 	call TrainerInfo_DrawHorizontalEdge ; draw top edge
 	call TrainerInfo_NextTextBoxRow
-	ld a,[wTrainerInfoTextBoxWidthPlus1]
-	ld e,a
-	ld d,0
-	ld c,6 ; height of the text box
+	ld a, [wTrainerInfoTextBoxWidthPlus1]
+	ld e, a
+	ld d, 0
+	ld c, 6 ; height of the text box
 .loop
-	ld [hl],$7c ; left edge tile ID
-	add hl,de
-	ld [hl],$78 ; right edge tile ID
+	ld [hl], $7c ; left edge tile ID
+	add hl, de
+	ld [hl], $78 ; right edge tile ID
 	call TrainerInfo_NextTextBoxRow
 	dec c
-	jr nz,.loop
-	ld a,$7d ; lower left corner tile ID
-	lb de,$77, $7e ; bottom edge and lower right corner tile ID's
+	jr nz, .loop
+	ld a, $7d ; lower left corner tile ID
+	lb de, $77, $7e ; bottom edge and lower right corner tile ID's
 
 TrainerInfo_DrawHorizontalEdge:
-	ld [hli],a ; place left corner tile
-	ld a,[wTrainerInfoTextBoxWidth]
-	ld c,a
-	ld a,d
+	ld [hli], a ; place left corner tile
+	ld a, [wTrainerInfoTextBoxWidth]
+	ld c, a
+	ld a, d
 .loop
-	ld [hli],a ; place edge tile
+	ld [hli], a ; place edge tile
 	dec c
-	jr nz,.loop
-	ld a,e
-	ld [hl],a ; place right corner tile
+	jr nz, .loop
+	ld a, e
+	ld [hl], a ; place right corner tile
 	ret
 
 TrainerInfo_NextTextBoxRow:
-	ld a,[wTrainerInfoTextBoxNextRowOffset] ; distance to the start of the next row
+	ld a, [wTrainerInfoTextBoxNextRowOffset] ; distance to the start of the next row
 .loop
 	inc hl
 	dec a
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 ; draws a vertical line
@@ -675,26 +675,26 @@ TrainerInfo_NextTextBoxRow:
 ; hl = address of top tile in the line
 ; a = tile ID
 TrainerInfo_DrawVerticalLine:
-	ld de,SCREEN_WIDTH
-	ld c,8
+	ld de, SCREEN_WIDTH
+	ld c, 8
 .loop
-	ld [hl],a
-	add hl,de
+	ld [hl], a
+	add hl, de
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 StartMenu_SaveReset:
-	ld a,[wd72e]
-	bit 6,a ; is the player using the link feature?
-	jp nz,Init
+	ld a, [wd72e]
+	bit 6, a ; is the player using the link feature?
+	jp nz, Init
 	predef SaveSAV ; save the game
 	call LoadScreenTilesFromBuffer2 ; restore saved screen
 	jp HoldTextDisplayOpen
 
 StartMenu_Option:
 	xor a
-	ld [H_AUTOBGTRANSFERENABLED],a
+	ld [H_AUTOBGTRANSFERENABLED], a
 	call ClearScreen
 	call UpdateSprites
 	callab DisplayOptionMenu

--- a/engine/menu/swap_items.asm
+++ b/engine/menu/swap_items.asm
@@ -1,149 +1,149 @@
 HandleItemListSwapping:
-	ld a,[wListMenuID]
-	cp a,ITEMLISTMENU
-	jp nz,DisplayListMenuIDLoop ; only rearrange item list menus
+	ld a, [wListMenuID]
+	cp ITEMLISTMENU
+	jp nz, DisplayListMenuIDLoop ; only rearrange item list menus
 	push hl
-	ld hl,wListPointer
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld hl, wListPointer
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 	inc hl ; hl = beginning of list entries
-	ld a,[wCurrentMenuItem]
-	ld b,a
-	ld a,[wListScrollOffset]
+	ld a, [wCurrentMenuItem]
+	ld b, a
+	ld a, [wListScrollOffset]
 	add b
 	add a
-	ld c,a
-	ld b,0
-	add hl,bc ; hl = address of currently selected item entry
-	ld a,[hl]
+	ld c, a
+	ld b, 0
+	add hl, bc ; hl = address of currently selected item entry
+	ld a, [hl]
 	pop hl
 	inc a
-	jp z,DisplayListMenuIDLoop ; ignore attempts to swap the Cancel menu item
-	ld a,[wMenuItemToSwap] ; ID of item chosen for swapping (counts from 1)
+	jp z, DisplayListMenuIDLoop ; ignore attempts to swap the Cancel menu item
+	ld a, [wMenuItemToSwap] ; ID of item chosen for swapping (counts from 1)
 	and a ; has the first item to swap already been chosen?
-	jr nz,.swapItems
+	jr nz, .swapItems
 ; if not, set the currently selected item as the first item
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	inc a
-	ld b,a
-	ld a,[wListScrollOffset] ; index of top (visible) menu item within the list
+	ld b, a
+	ld a, [wListScrollOffset] ; index of top (visible) menu item within the list
 	add b
-	ld [wMenuItemToSwap],a ; ID of item chosen for swapping (counts from 1)
-	ld c,20
+	ld [wMenuItemToSwap], a ; ID of item chosen for swapping (counts from 1)
+	ld c, 20
 	call DelayFrames
 	jp DisplayListMenuIDLoop
 .swapItems
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	inc a
-	ld b,a
-	ld a,[wListScrollOffset]
+	ld b, a
+	ld a, [wListScrollOffset]
 	add b
-	ld b,a
-	ld a,[wMenuItemToSwap] ; ID of item chosen for swapping (counts from 1)
+	ld b, a
+	ld a, [wMenuItemToSwap] ; ID of item chosen for swapping (counts from 1)
 	cp b ; is the currently selected item the same as the first item to swap?
-	jp z,DisplayListMenuIDLoop ; ignore attempts to swap an item with itself
+	jp z, DisplayListMenuIDLoop ; ignore attempts to swap an item with itself
 	dec a
-	ld [wMenuItemToSwap],a ; ID of item chosen for swapping (counts from 1)
-	ld c,20
+	ld [wMenuItemToSwap], a ; ID of item chosen for swapping (counts from 1)
+	ld c, 20
 	call DelayFrames
 	push hl
 	push de
-	ld hl,wListPointer
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld hl, wListPointer
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 	inc hl ; hl = beginning of list entries
-	ld d,h
-	ld e,l ; de = beginning of list entries
-	ld a,[wCurrentMenuItem]
-	ld b,a
-	ld a,[wListScrollOffset]
+	ld d, h
+	ld e, l ; de = beginning of list entries
+	ld a, [wCurrentMenuItem]
+	ld b, a
+	ld a, [wListScrollOffset]
 	add b
 	add a
-	ld c,a
-	ld b,0
-	add hl,bc ; hl = address of currently selected item entry
-	ld a,[wMenuItemToSwap] ; ID of item chosen for swapping (counts from 1)
+	ld c, a
+	ld b, 0
+	add hl, bc ; hl = address of currently selected item entry
+	ld a, [wMenuItemToSwap] ; ID of item chosen for swapping (counts from 1)
 	add a
 	add e
-	ld e,a
-	jr nc,.noCarry
+	ld e, a
+	jr nc, .noCarry
 	inc d
 .noCarry ; de = address of first item to swap
-	ld a,[de]
-	ld b,a
-	ld a,[hli]
+	ld a, [de]
+	ld b, a
+	ld a, [hli]
 	cp b
-	jr z,.swapSameItemType
+	jr z, .swapSameItemType
 .swapDifferentItems
-	ld [$ff95],a ; [$ff95] = second item ID
-	ld a,[hld]
-	ld [$ff96],a ; [$ff96] = second item quantity
-	ld a,[de]
-	ld [hli],a ; put first item ID in second item slot
+	ld [$ff95], a ; [$ff95] = second item ID
+	ld a, [hld]
+	ld [$ff96], a ; [$ff96] = second item quantity
+	ld a, [de]
+	ld [hli], a ; put first item ID in second item slot
 	inc de
-	ld a,[de]
-	ld [hl],a ; put first item quantity in second item slot
-	ld a,[$ff96]
-	ld [de],a ; put second item quantity in first item slot
+	ld a, [de]
+	ld [hl], a ; put first item quantity in second item slot
+	ld a, [$ff96]
+	ld [de], a ; put second item quantity in first item slot
 	dec de
-	ld a,[$ff95]
-	ld [de],a ; put second item ID in first item slot
+	ld a, [$ff95]
+	ld [de], a ; put second item ID in first item slot
 	xor a
-	ld [wMenuItemToSwap],a ; 0 means no item is currently being swapped
+	ld [wMenuItemToSwap], a ; 0 means no item is currently being swapped
 	pop de
 	pop hl
 	jp DisplayListMenuIDLoop
 .swapSameItemType
 	inc de
-	ld a,[hl]
-	ld b,a
-	ld a,[de]
+	ld a, [hl]
+	ld b, a
+	ld a, [de]
 	add b ; a = sum of both item quantities
-	cp a,100 ; is the sum too big for one item slot?
-	jr c,.combineItemSlots
+	cp 100 ; is the sum too big for one item slot?
+	jr c, .combineItemSlots
 ; swap enough items from the first slot to max out the second slot if they can't be combined
-	sub a,99
-	ld [de],a
-	ld a,99
-	ld [hl],a
+	sub 99
+	ld [de], a
+	ld a, 99
+	ld [hl], a
 	jr .done
 .combineItemSlots
-	ld [hl],a ; put the sum in the second item slot
-	ld hl,wListPointer
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld [hl], a ; put the sum in the second item slot
+	ld hl, wListPointer
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 	dec [hl] ; decrease the number of items
-	ld a,[hl]
-	ld [wListCount],a ; update number of items variable
-	cp a,1
-	jr nz,.skipSettingMaxMenuItemID
-	ld [wMaxMenuItem],a ; if the number of items is only one now, update the max menu item ID
+	ld a, [hl]
+	ld [wListCount], a ; update number of items variable
+	cp 1
+	jr nz, .skipSettingMaxMenuItemID
+	ld [wMaxMenuItem], a ; if the number of items is only one now, update the max menu item ID
 .skipSettingMaxMenuItemID
 	dec de
-	ld h,d
-	ld l,e
+	ld h, d
+	ld l, e
 	inc hl
 	inc hl ; hl = address of item after first item to swap
 .moveItemsUpLoop ; erase the first item slot and move up all the following item slots to fill the gap
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	inc a ; reached the $ff terminator?
-	jr z,.afterMovingItemsUp
-	ld a,[hli]
-	ld [de],a
+	jr z, .afterMovingItemsUp
+	ld a, [hli]
+	ld [de], a
 	inc de
 	jr .moveItemsUpLoop
 .afterMovingItemsUp
 	xor a
-	ld [wListScrollOffset],a
-	ld [wCurrentMenuItem],a
+	ld [wListScrollOffset], a
+	ld [wCurrentMenuItem], a
 .done
 	xor a
-	ld [wMenuItemToSwap],a ; 0 means no item is currently being swapped
+	ld [wMenuItemToSwap], a ; 0 means no item is currently being swapped
 	pop de
 	pop hl
 	jp DisplayListMenuIDLoop

--- a/engine/menu/text_box.asm
+++ b/engine/menu/text_box.asm
@@ -1,28 +1,28 @@
 ; function to draw various text boxes
 DisplayTextBoxID_:
-	ld a,[wTextBoxID]
-	cp a,TWO_OPTION_MENU
-	jp z,DisplayTwoOptionMenu
-	ld c,a
-	ld hl,TextBoxFunctionTable
-	ld de,3
+	ld a, [wTextBoxID]
+	cp TWO_OPTION_MENU
+	jp z, DisplayTwoOptionMenu
+	ld c, a
+	ld hl, TextBoxFunctionTable
+	ld de, 3
 	call SearchTextBoxTable
-	jr c,.functionTableMatch
-	ld hl,TextBoxCoordTable
-	ld de,5
+	jr c, .functionTableMatch
+	ld hl, TextBoxCoordTable
+	ld de, 5
 	call SearchTextBoxTable
-	jr c,.coordTableMatch
-	ld hl,TextBoxTextAndCoordTable
-	ld de,9
+	jr c, .coordTableMatch
+	ld hl, TextBoxTextAndCoordTable
+	ld de, 9
 	call SearchTextBoxTable
-	jr c,.textAndCoordTableMatch
+	jr c, .textAndCoordTableMatch
 .done
 	ret
 .functionTableMatch
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a ; hl = address of function
-	ld de,.done
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a ; hl = address of function
+	ld de, .done
 	push de
 	jp hl ; jump to the function
 .coordTableMatch
@@ -37,14 +37,14 @@ DisplayTextBoxID_:
 	call TextBoxBorder
 	pop hl
 	call GetTextBoxIDText
-	ld a,[wd730]
+	ld a, [wd730]
 	push af
-	ld a,[wd730]
-	set 6,a ; no pauses between printing each letter
-	ld [wd730],a
+	ld a, [wd730]
+	set 6, a ; no pauses between printing each letter
+	ld [wd730], a
 	call PlaceString
 	pop af
-	ld [wd730],a
+	ld [wd730], a
 	call UpdateSprites
 	ret
 
@@ -53,12 +53,12 @@ DisplayTextBoxID_:
 SearchTextBoxTable:
 	dec de
 .loop
-	ld a,[hli]
-	cp a,$ff
-	jr z,.notFound
+	ld a, [hli]
+	cp $ff
+	jr z, .notFound
 	cp c
-	jr z,.found
-	add hl,de
+	jr z, .found
+	add hl, de
 	jr .loop
 .found
 	scf
@@ -74,31 +74,31 @@ SearchTextBoxTable:
 ; d = row of upper left corner
 ; e = column of upper left corner
 GetTextBoxIDCoords:
-	ld a,[hli] ; column of upper left corner
-	ld e,a
-	ld a,[hli] ; row of upper left corner
-	ld d,a
-	ld a,[hli] ; column of lower right corner
+	ld a, [hli] ; column of upper left corner
+	ld e, a
+	ld a, [hli] ; row of upper left corner
+	ld d, a
+	ld a, [hli] ; column of lower right corner
 	sub e
 	dec a
-	ld c,a     ; c = width
-	ld a,[hli] ; row of lower right corner
+	ld c, a     ; c = width
+	ld a, [hli] ; row of lower right corner
 	sub d
 	dec a
-	ld b,a     ; b = height
+	ld b, a     ; b = height
 	ret
 
 ; function to load a text address and text coordinates from the TextBoxTextAndCoordTable
 GetTextBoxIDText:
-	ld a,[hli]
-	ld e,a
-	ld a,[hli]
-	ld d,a ; de = address of text
+	ld a, [hli]
+	ld e, a
+	ld a, [hli]
+	ld d, a ; de = address of text
 	push de ; save text address
-	ld a,[hli]
-	ld e,a ; column of upper left corner of text
-	ld a,[hl]
-	ld d,a ; row of upper left corner of text
+	ld a, [hli]
+	ld e, a ; column of upper left corner of text
+	ld a, [hl]
+	ld d, a ; row of upper left corner of text
 	call GetAddressOfScreenCoords
 	pop de ; restore text address
 	ret
@@ -112,17 +112,17 @@ GetTextBoxIDText:
 GetAddressOfScreenCoords:
 	push bc
 	coord hl, 0, 0
-	ld bc,20
+	ld bc, 20
 .loop ; loop to add d rows to the base address
-	ld a,d
+	ld a, d
 	and a
-	jr z,.addedRows
-	add hl,bc
+	jr z, .addedRows
+	add hl, bc
 	dec d
 	jr .loop
 .addedRows
 	pop bc
-	add hl,de
+	add hl, de
 	ret
 
 ; Format:

--- a/engine/oak_speech.asm
+++ b/engine/oak_speech.asm
@@ -32,123 +32,123 @@ SetDefaultNames:
 	jp CopyData
 
 OakSpeech:
-	ld a,$FF
+	ld a, $FF
 	call PlaySound ; stop music
 	ld a, BANK(Music_Routes2)
-	ld c,a
+	ld c, a
 	ld a, MUSIC_ROUTES2
 	call PlayMusic
 	call ClearScreen
 	call LoadTextBoxTilePatterns
 	call SetDefaultNames
 	predef InitPlayerData2
-	ld hl,wNumBoxItems
-	ld a,POTION
-	ld [wcf91],a
-	ld a,1
-	ld [wItemQuantity],a
+	ld hl, wNumBoxItems
+	ld a, POTION
+	ld [wcf91], a
+	ld a, 1
+	ld [wItemQuantity], a
 	call AddItemToInventory  ; give one potion
-	ld a,[wDefaultMap]
-	ld [wDestinationMap],a
+	ld a, [wDefaultMap]
+	ld [wDestinationMap], a
 	call SpecialWarpIn
 	xor a
-	ld [hTilesetType],a
-	ld a,[wd732]
-	bit 1,a ; possibly a debug mode bit
-	jp nz,.skipChoosingNames
-	ld de,ProfOakPic
+	ld [hTilesetType], a
+	ld a, [wd732]
+	bit 1, a ; possibly a debug mode bit
+	jp nz, .skipChoosingNames
+	ld de, ProfOakPic
 	lb bc, Bank(ProfOakPic), $00
 	call IntroDisplayPicCenteredOrUpperRight
 	call FadeInIntroPic
-	ld hl,OakSpeechText1
+	ld hl, OakSpeechText1
 	call PrintText
 	call GBFadeOutToWhite
 	call ClearScreen
-	ld a,NIDORINO
-	ld [wd0b5],a
-	ld [wcf91],a
+	ld a, NIDORINO
+	ld [wd0b5], a
+	ld [wcf91], a
 	call GetMonHeader
 	coord hl, 6, 4
 	call LoadFlippedFrontSpriteByMonIndex
 	call MovePicLeft
-	ld hl,OakSpeechText2
+	ld hl, OakSpeechText2
 	call PrintText
 	call GBFadeOutToWhite
 	call ClearScreen
-	ld de,RedPicFront
+	ld de, RedPicFront
 	lb bc, Bank(RedPicFront), $00
 	call IntroDisplayPicCenteredOrUpperRight
 	call MovePicLeft
-	ld hl,IntroducePlayerText
+	ld hl, IntroducePlayerText
 	call PrintText
 	call ChoosePlayerName
 	call GBFadeOutToWhite
 	call ClearScreen
-	ld de,Rival1Pic
+	ld de, Rival1Pic
 	lb bc, Bank(Rival1Pic), $00
 	call IntroDisplayPicCenteredOrUpperRight
 	call FadeInIntroPic
-	ld hl,IntroduceRivalText
+	ld hl, IntroduceRivalText
 	call PrintText
 	call ChooseRivalName
 .skipChoosingNames
 	call GBFadeOutToWhite
 	call ClearScreen
-	ld de,RedPicFront
+	ld de, RedPicFront
 	lb bc, Bank(RedPicFront), $00
 	call IntroDisplayPicCenteredOrUpperRight
 	call GBFadeInFromWhite
-	ld a,[wd72d]
+	ld a, [wd72d]
 	and a
-	jr nz,.next
-	ld hl,OakSpeechText3
+	jr nz, .next
+	ld hl, OakSpeechText3
 	call PrintText
 .next
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,SFX_SHRINK
+	ld a, SFX_SHRINK
 	call PlaySound
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
-	ld c,4
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
+	ld c, 4
 	call DelayFrames
-	ld de,RedSprite
-	ld hl,vSprites
+	ld de, RedSprite
+	ld hl, vSprites
 	lb bc, BANK(RedSprite), $0C
 	call CopyVideoData
-	ld de,ShrinkPic1
+	ld de, ShrinkPic1
 	lb bc, BANK(ShrinkPic1), $00
 	call IntroDisplayPicCenteredOrUpperRight
-	ld c,4
+	ld c, 4
 	call DelayFrames
-	ld de,ShrinkPic2
+	ld de, ShrinkPic2
 	lb bc, BANK(ShrinkPic2), $00
 	call IntroDisplayPicCenteredOrUpperRight
 	call ResetPlayerSpriteData
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
 	ld a, BANK(Music_PalletTown)
-	ld [wAudioROMBank],a
-	ld [wAudioSavedROMBank],a
+	ld [wAudioROMBank], a
+	ld [wAudioSavedROMBank], a
 	ld a, 10
-	ld [wAudioFadeOutControl],a
-	ld a,$FF
-	ld [wNewSoundID],a
+	ld [wAudioFadeOutControl], a
+	ld a, $FF
+	ld [wNewSoundID], a
 	call PlaySound ; stop music
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
-	ld c,20
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
+	ld c, 20
 	call DelayFrames
 	coord hl, 6, 5
-	ld b,7
-	ld c,7
+	ld b, 7
+	ld c, 7
 	call ClearScreenArea
 	call LoadTextBoxTilePatterns
-	ld a,1
-	ld [wUpdateSpritesEnabled],a
-	ld c,50
+	ld a, 1
+	ld [wUpdateSpritesEnabled], a
+	ld c, 50
 	call DelayFrames
 	call GBFadeOutToWhite
 	jp ClearScreen
@@ -171,15 +171,15 @@ OakSpeechText3:
 	db "@"
 
 FadeInIntroPic:
-	ld hl,IntroFadePalettes
-	ld b,6
+	ld hl, IntroFadePalettes
+	ld b, 6
 .next
-	ld a,[hli]
-	ld [rBGP],a
-	ld c,10
+	ld a, [hli]
+	ld [rBGP], a
+	ld c, 10
 	call DelayFrames
 	dec b
-	jr nz,.next
+	jr nz, .next
 	ret
 
 IntroFadePalettes:
@@ -191,19 +191,19 @@ IntroFadePalettes:
 	db %11100100
 
 MovePicLeft:
-	ld a,119
-	ld [rWX],a
+	ld a, 119
+	ld [rWX], a
 	call DelayFrame
 
-	ld a,%11100100
-	ld [rBGP],a
+	ld a, %11100100
+	ld [rBGP], a
 .next
 	call DelayFrame
-	ld a,[rWX]
+	ld a, [rWX]
 	sub 8
 	cp $FF
 	ret z
-	ld [rWX],a
+	ld [rWX], a
 	jr .next
 
 DisplayPicCenteredOrUpperRight:
@@ -213,21 +213,21 @@ IntroDisplayPicCenteredOrUpperRight:
 ; de = address of compressed pic
 ; c: 0 = centred, non-zero = upper-right
 	push bc
-	ld a,b
+	ld a, b
 	call UncompressSpriteFromDE
-	ld hl,sSpriteBuffer1
-	ld de,sSpriteBuffer0
-	ld bc,$310
+	ld hl, sSpriteBuffer1
+	ld de, sSpriteBuffer0
+	ld bc, $310
 	call CopyData
-	ld de,vFrontPic
+	ld de, vFrontPic
 	call InterlaceMergeSpriteBuffers
 	pop bc
-	ld a,c
+	ld a, c
 	and a
 	coord hl, 15, 1
-	jr nz,.next
+	jr nz, .next
 	coord hl, 6, 4
 .next
 	xor a
-	ld [hStartTileID],a
+	ld [hStartTileID], a
 	predef_jump CopyUncompressedPicToTilemap

--- a/engine/overworld/map_sprites.asm
+++ b/engine/overworld/map_sprites.asm
@@ -12,113 +12,113 @@ InitMapSprites:
 	call InitOutsideMapSprites
 	ret c ; return if the map is an outside map (already handled by above call)
 ; if the map is an inside map (i.e. mapID >= $25)
-	ld hl,wSpriteStateData1
-	ld de,wSpriteStateData2 + $0d
+	ld hl, wSpriteStateData1
+	ld de, wSpriteStateData2 + $0d
 ; Loop to copy picture ID's from $C1X0 to $C2XD for LoadMapSpriteTilePatterns.
 .copyPictureIDLoop
-	ld a,[hl] ; $C1X0 (picture ID)
-	ld [de],a ; $C2XD
-	ld a,$10
+	ld a, [hl] ; $C1X0 (picture ID)
+	ld [de], a ; $C2XD
+	ld a, $10
 	add e
-	ld e,a
-	ld a,$10
+	ld e, a
+	ld a, $10
 	add l
-	ld l,a
-	jr nz,.copyPictureIDLoop
+	ld l, a
+	jr nz, .copyPictureIDLoop
 
 ; This is used for both inside and outside maps, since it is called by
 ; InitOutsideMapSprites.
 ; Loads tile pattern data for sprites into VRAM.
 LoadMapSpriteTilePatterns:
-	ld a,[wNumSprites]
+	ld a, [wNumSprites]
 	and a ; are there any sprites?
-	jr nz,.spritesExist
+	jr nz, .spritesExist
 	ret
 .spritesExist
-	ld c,a ; c = [wNumSprites]
-	ld b,$10 ; number of sprite slots
-	ld hl,wSpriteStateData2 + $0d
+	ld c, a ; c = [wNumSprites]
+	ld b, $10 ; number of sprite slots
+	ld hl, wSpriteStateData2 + $0d
 	xor a
-	ld [hFourTileSpriteCount],a
+	ld [hFourTileSpriteCount], a
 .copyPictureIDLoop ; loop to copy picture ID from $C2XD to $C2XE
-	ld a,[hli] ; $C2XD (sprite picture ID)
-	ld [hld],a ; $C2XE
-	ld a,l
-	add a,$10
-	ld l,a
+	ld a, [hli] ; $C2XD (sprite picture ID)
+	ld [hld], a ; $C2XE
+	ld a, l
+	add $10
+	ld l, a
 	dec b
-	jr nz,.copyPictureIDLoop
-	ld hl,wSpriteStateData2 + $1e
+	jr nz, .copyPictureIDLoop
+	ld hl, wSpriteStateData2 + $1e
 .loadTilePatternLoop
-	ld de,wSpriteStateData2 + $1d
+	ld de, wSpriteStateData2 + $1d
 ; Check if the current picture ID has already had its tile patterns loaded.
 ; This done by looping through the previous sprite slots and seeing if any of
 ; their picture ID's match that of the current sprite slot.
 .checkIfAlreadyLoadedLoop
-	ld a,e
-	and a,$f0
-	ld b,a ; b = offset of the wSpriteStateData2 sprite slot being checked against
-	ld a,l
-	and a,$f0 ; a = offset of current wSpriteStateData2 sprite slot
+	ld a, e
+	and $f0
+	ld b, a ; b = offset of the wSpriteStateData2 sprite slot being checked against
+	ld a, l
+	and $f0 ; a = offset of current wSpriteStateData2 sprite slot
 	cp b ; done checking all previous sprite slots?
-	jr z,.notAlreadyLoaded
-	ld a,[de] ; picture ID of the wSpriteStateData2 sprite slot being checked against
+	jr z, .notAlreadyLoaded
+	ld a, [de] ; picture ID of the wSpriteStateData2 sprite slot being checked against
 	cp [hl] ; do the picture ID's match?
-	jp z,.alreadyLoaded
-	ld a,e
-	add a,$10
-	ld e,a
+	jp z, .alreadyLoaded
+	ld a, e
+	add $10
+	ld e, a
 	jr .checkIfAlreadyLoadedLoop
 .notAlreadyLoaded
-	ld de,wSpriteStateData2 + $0e
-	ld b,$01
+	ld de, wSpriteStateData2 + $0e
+	ld b, $01
 ; loop to find the highest tile pattern VRAM slot (among the first 10 slots) used by a previous sprite slot
 ; this is done in order to find the first free VRAM slot available
 .findNextVRAMSlotLoop
-	ld a,e
-	add a,$10
-	ld e,a
-	ld a,l
+	ld a, e
+	add $10
+	ld e, a
+	ld a, l
 	cp e ; reached current slot?
-	jr z,.foundNextVRAMSlot
-	ld a,[de] ; $C2YE (VRAM slot)
-	cp a,11 ; is it one of the first 10 slots?
-	jr nc,.findNextVRAMSlotLoop
+	jr z, .foundNextVRAMSlot
+	ld a, [de] ; $C2YE (VRAM slot)
+	cp 11 ; is it one of the first 10 slots?
+	jr nc, .findNextVRAMSlotLoop
 	cp b ; compare the slot being checked to the current max
-	jr c,.findNextVRAMSlotLoop ; if the slot being checked is less than the current max
+	jr c, .findNextVRAMSlotLoop ; if the slot being checked is less than the current max
 ; if the slot being checked is greater than or equal to the current max
-	ld b,a ; store new max VRAM slot
+	ld b, a ; store new max VRAM slot
 	jr .findNextVRAMSlotLoop
 .foundNextVRAMSlot
 	inc b ; increment previous max value to get next VRAM tile pattern slot
-	ld a,b ; a = next VRAM tile pattern slot
+	ld a, b ; a = next VRAM tile pattern slot
 	push af
-	ld a,[hl] ; $C2XE (sprite picture ID)
-	ld b,a ; b = current sprite picture ID
-	cp a,SPRITE_BALL ; is it a 4-tile sprite?
-	jr c,.notFourTileSprite
+	ld a, [hl] ; $C2XE (sprite picture ID)
+	ld b, a ; b = current sprite picture ID
+	cp SPRITE_BALL ; is it a 4-tile sprite?
+	jr c, .notFourTileSprite
 	pop af
-	ld a,[hFourTileSpriteCount]
-	add a,11
+	ld a, [hFourTileSpriteCount]
+	add 11
 	jr .storeVRAMSlot
 .notFourTileSprite
 	pop af
 .storeVRAMSlot
-	ld [hl],a ; store VRAM slot at $C2XE
-	ld [hVRAMSlot],a ; used to determine if it's 4-tile sprite later
-	ld a,b ; a = current sprite picture ID
+	ld [hl], a ; store VRAM slot at $C2XE
+	ld [hVRAMSlot], a ; used to determine if it's 4-tile sprite later
+	ld a, b ; a = current sprite picture ID
 	dec a
 	add a
 	add a
 	push bc
 	push hl
-	ld hl,SpriteSheetPointerTable
-	jr nc,.noCarry
+	ld hl, SpriteSheetPointerTable
+	jr nc, .noCarry
 	inc h
 .noCarry
 	add l
-	ld l,a
-	jr nc,.noCarry2
+	ld l, a
+	jr nc, .noCarry2
 	inc h
 .noCarry2
 	push hl
@@ -126,69 +126,69 @@ LoadMapSpriteTilePatterns:
 	push af
 	push de
 	push bc
-	ld hl,vNPCSprites ; VRAM base address
-	ld bc,$c0 ; number of bytes per VRAM slot
-	ld a,[hVRAMSlot]
-	cp a,11 ; is it a 4-tile sprite?
-	jr nc,.fourTileSpriteVRAMAddr
-	ld d,a
+	ld hl, vNPCSprites ; VRAM base address
+	ld bc, $c0 ; number of bytes per VRAM slot
+	ld a, [hVRAMSlot]
+	cp 11 ; is it a 4-tile sprite?
+	jr nc, .fourTileSpriteVRAMAddr
+	ld d, a
 	dec d
 ; Equivalent to multiplying $C0 (number of bytes in 12 tiles) times the VRAM
 ; slot and adding the result to $8000 (the VRAM base address).
 .calculateVRAMAddrLoop
-	add hl,bc
+	add hl, bc
 	dec d
-	jr nz,.calculateVRAMAddrLoop
+	jr nz, .calculateVRAMAddrLoop
 	jr .loadStillTilePattern
 .fourTileSpriteVRAMAddr
-	ld hl,vSprites + $7c0 ; address for second 4-tile sprite
-	ld a,[hFourTileSpriteCount]
+	ld hl, vSprites + $7c0 ; address for second 4-tile sprite
+	ld a, [hFourTileSpriteCount]
 	and a
-	jr nz,.loadStillTilePattern
+	jr nz, .loadStillTilePattern
 ; if it's the first 4-tile sprite
-	ld hl,vSprites + $780 ; address for first 4-tile sprite
+	ld hl, vSprites + $780 ; address for first 4-tile sprite
 	inc a
-	ld [hFourTileSpriteCount],a
+	ld [hFourTileSpriteCount], a
 .loadStillTilePattern
 	pop bc
 	pop de
 	pop af
 	push hl
 	push hl
-	ld h,d
-	ld l,e
+	ld h, d
+	ld l, e
 	pop de
-	ld b,a
-	ld a,[wFontLoaded]
-	bit 0,a ; reloading upper half of tile patterns after displaying text?
-	jr nz,.skipFirstLoad ; if so, skip loading data into the lower half
-	ld a,b
-	ld b,0
+	ld b, a
+	ld a, [wFontLoaded]
+	bit 0, a ; reloading upper half of tile patterns after displaying text?
+	jr nz, .skipFirstLoad ; if so, skip loading data into the lower half
+	ld a, b
+	ld b, 0
 	call FarCopyData2 ; load tile pattern data for sprite when standing still
 .skipFirstLoad
 	pop de
 	pop hl
-	ld a,[hVRAMSlot]
-	cp a,11 ; is it a 4-tile sprite?
-	jr nc,.skipSecondLoad ; if so, there is no second block
+	ld a, [hVRAMSlot]
+	cp 11 ; is it a 4-tile sprite?
+	jr nc, .skipSecondLoad ; if so, there is no second block
 	push de
 	call ReadSpriteSheetData
 	push af
-	ld a,$c0
+	ld a, $c0
 	add e
-	ld e,a
-	jr nc,.noCarry3
+	ld e, a
+	jr nc, .noCarry3
 	inc d
 .noCarry3
-	ld a,[wFontLoaded]
-	bit 0,a ; reloading upper half of tile patterns after displaying text?
-	jr nz,.loadWhileLCDOn
+	ld a, [wFontLoaded]
+	bit 0, a ; reloading upper half of tile patterns after displaying text?
+	jr nz, .loadWhileLCDOn
 	pop af
 	pop hl
-	set 3,h ; add $800 to hl
+	set 3, h ; add $800 to hl
 	push hl
-	ld h,d
-	ld l,e
+	ld h, d
+	ld l, e
 	pop de
 	call FarCopyData2 ; load tile pattern data for sprite when walking
 	jr .skipSecondLoad
@@ -198,8 +198,8 @@ LoadMapSpriteTilePatterns:
 .loadWhileLCDOn
 	pop af
 	pop hl
-	set 3,h ; add $800 to hl
-	ld b,a
+	set 3, h ; add $800 to hl
+	ld b, a
 	swap c
 	call CopyVideoData ; load tile pattern data for sprite when walking
 .skipSecondLoad
@@ -208,25 +208,25 @@ LoadMapSpriteTilePatterns:
 	jr .nextSpriteSlot
 .alreadyLoaded ; if the current picture ID has already had its tile patterns loaded
 	inc de
-	ld a,[de] ; a = VRAM slot for the current picture ID (from $C2YE)
-	ld [hl],a ; store VRAM slot in current wSpriteStateData2 sprite slot (at $C2XE)
+	ld a, [de] ; a = VRAM slot for the current picture ID (from $C2YE)
+	ld [hl], a ; store VRAM slot in current wSpriteStateData2 sprite slot (at $C2XE)
 .nextSpriteSlot
-	ld a,l
-	add a,$10
-	ld l,a
+	ld a, l
+	add $10
+	ld l, a
 	dec c
-	jp nz,.loadTilePatternLoop
-	ld hl,wSpriteStateData2 + $0d
-	ld b,$10
+	jp nz, .loadTilePatternLoop
+	ld hl, wSpriteStateData2 + $0d
+	ld b, $10
 ; the pictures ID's stored at $C2XD are no longer needed, so zero them
 .zeroStoredPictureIDLoop
 	xor a
-	ld [hl],a ; $C2XD
-	ld a,$10
+	ld [hl], a ; $C2XD
+	ld a, $10
 	add l
-	ld l,a
+	ld l, a
 	dec b
-	jr nz,.zeroStoredPictureIDLoop
+	jr nz, .zeroStoredPictureIDLoop
 	ret
 
 ; reads data from SpriteSheetPointerTable
@@ -237,108 +237,108 @@ LoadMapSpriteTilePatterns:
 ; bc = length in bytes
 ; a = ROM bank
 ReadSpriteSheetData:
-	ld a,[hli]
-	ld e,a
-	ld a,[hli]
-	ld d,a
-	ld a,[hli]
-	ld c,a
+	ld a, [hli]
+	ld e, a
+	ld a, [hli]
+	ld d, a
+	ld a, [hli]
+	ld c, a
 	xor a
-	ld b,a
-	ld a,[hli]
+	ld b, a
+	ld a, [hli]
 	ret
 
 ; Loads sprite set for outside maps (cities and routes) and sets VRAM slots.
 ; sets carry if the map is a city or route, unsets carry if not
 InitOutsideMapSprites:
-	ld a,[wCurMap]
-	cp a,REDS_HOUSE_1F ; is the map a city or a route (map ID less than $25)?
+	ld a, [wCurMap]
+	cp REDS_HOUSE_1F ; is the map a city or a route (map ID less than $25)?
 	ret nc ; if not, return
-	ld hl,MapSpriteSets
+	ld hl, MapSpriteSets
 	add l
-	ld l,a
-	jr nc,.noCarry
+	ld l, a
+	jr nc, .noCarry
 	inc h
 .noCarry
-	ld a,[hl] ; a = spriteSetID
-	cp a,$f0 ; does the map have 2 sprite sets?
-	call nc,GetSplitMapSpriteSetID ; if so, choose the appropriate one
-	ld b,a ; b = spriteSetID
-	ld a,[wFontLoaded]
-	bit 0,a ; reloading upper half of tile patterns after displaying text?
-	jr nz,.loadSpriteSet ; if so, forcibly reload the sprite set
-	ld a,[wSpriteSetID]
+	ld a, [hl] ; a = spriteSetID
+	cp $f0 ; does the map have 2 sprite sets?
+	call nc, GetSplitMapSpriteSetID ; if so, choose the appropriate one
+	ld b, a ; b = spriteSetID
+	ld a, [wFontLoaded]
+	bit 0, a ; reloading upper half of tile patterns after displaying text?
+	jr nz, .loadSpriteSet ; if so, forcibly reload the sprite set
+	ld a, [wSpriteSetID]
 	cp b ; has the sprite set ID changed?
-	jr z,.skipLoadingSpriteSet ; if not, don't load it again
+	jr z, .skipLoadingSpriteSet ; if not, don't load it again
 .loadSpriteSet
-	ld a,b
-	ld [wSpriteSetID],a
+	ld a, b
+	ld [wSpriteSetID], a
 	dec a
-	ld b,a
+	ld b, a
 	sla a
-	ld c,a
+	ld c, a
 	sla a
 	sla a
 	add c
 	add b ; a = (spriteSetID - 1) * 11
-	ld de,SpriteSets
+	ld de, SpriteSets
 ; add a to de to get offset of sprite set
 	add e
-	ld e,a
-	jr nc,.noCarry2
+	ld e, a
+	jr nc, .noCarry2
 	inc d
 .noCarry2
-	ld hl,wSpriteStateData2 + $0d
-	ld a,SPRITE_RED
-	ld [hl],a
-	ld bc,wSpriteSet
+	ld hl, wSpriteStateData2 + $0d
+	ld a, SPRITE_RED
+	ld [hl], a
+	ld bc, wSpriteSet
 ; Load the sprite set into RAM.
 ; This loop also fills $C2XD (sprite picture ID) where X is from $0 to $A
 ; with picture ID's. This is done so that LoadMapSpriteTilePatterns will
 ; load tile patterns for all sprite pictures in the sprite set.
 .loadSpriteSetLoop
-	ld a,$10
+	ld a, $10
 	add l
-	ld l,a
-	ld a,[de] ; sprite picture ID from sprite set
-	ld [hl],a ; $C2XD (sprite picture ID)
-	ld [bc],a
+	ld l, a
+	ld a, [de] ; sprite picture ID from sprite set
+	ld [hl], a ; $C2XD (sprite picture ID)
+	ld [bc], a
 	inc de
 	inc bc
-	ld a,l
-	cp a,$bd ; reached 11th sprite slot?
-	jr nz,.loadSpriteSetLoop
-	ld b,4 ; 4 remaining sprite slots
+	ld a, l
+	cp $bd ; reached 11th sprite slot?
+	jr nz, .loadSpriteSetLoop
+	ld b, 4 ; 4 remaining sprite slots
 .zeroRemainingSlotsLoop ; loop to zero the picture ID's of the remaining sprite slots
-	ld a,$10
+	ld a, $10
 	add l
-	ld l,a
+	ld l, a
 	xor a
-	ld [hl],a ; $C2XD (sprite picture ID)
+	ld [hl], a ; $C2XD (sprite picture ID)
 	dec b
-	jr nz,.zeroRemainingSlotsLoop
-	ld a,[wNumSprites]
+	jr nz, .zeroRemainingSlotsLoop
+	ld a, [wNumSprites]
 	push af ; save number of sprites
-	ld a,11 ; 11 sprites in sprite set
-	ld [wNumSprites],a
+	ld a, 11 ; 11 sprites in sprite set
+	ld [wNumSprites], a
 	call LoadMapSpriteTilePatterns
 	pop af
-	ld [wNumSprites],a ; restore number of sprites
-	ld hl,wSpriteStateData2 + $1e
-	ld b,$0f
+	ld [wNumSprites], a ; restore number of sprites
+	ld hl, wSpriteStateData2 + $1e
+	ld b, $0f
 ; The VRAM tile pattern slots that LoadMapSpriteTilePatterns set are in the
 ; order of the map's sprite set, not the order of the actual sprites loaded
 ; for the current map. So, they are not needed and are zeroed by this loop.
 .zeroVRAMSlotsLoop
 	xor a
-	ld [hl],a ; $C2XE (VRAM slot)
-	ld a,$10
+	ld [hl], a ; $C2XE (VRAM slot)
+	ld a, $10
 	add l
-	ld l,a
+	ld l, a
 	dec b
-	jr nz,.zeroVRAMSlotsLoop
+	jr nz, .zeroVRAMSlotsLoop
 .skipLoadingSpriteSet
-	ld hl,wSpriteStateData1 + $10
+	ld hl, wSpriteStateData1 + $10
 ; This loop stores the correct VRAM tile pattern slots according the sprite
 ; data from the map's header. Since the VRAM tile pattern slots are filled in
 ; the order of the sprite set, in order to find the VRAM tile pattern slot
@@ -347,94 +347,94 @@ InitOutsideMapSprites:
 ; (since the Red sprite always has the first VRAM tile pattern slot) is the
 ; VRAM tile pattern slot.
 .storeVRAMSlotsLoop
-	ld c,0
-	ld a,[hl] ; $C1X0 (picture ID) (zero if sprite slot is not used)
+	ld c, 0
+	ld a, [hl] ; $C1X0 (picture ID) (zero if sprite slot is not used)
 	and a ; is the sprite slot used?
-	jr z,.skipGettingPictureIndex ; if the sprite slot is not used
-	ld b,a ; b = picture ID
-	ld de,wSpriteSet
+	jr z, .skipGettingPictureIndex ; if the sprite slot is not used
+	ld b, a ; b = picture ID
+	ld de, wSpriteSet
 ; Loop to find the index of the sprite's picture ID within the sprite set.
 .getPictureIndexLoop
 	inc c
-	ld a,[de]
+	ld a, [de]
 	inc de
 	cp b ; does the picture ID match?
-	jr nz,.getPictureIndexLoop
+	jr nz, .getPictureIndexLoop
 	inc c
 .skipGettingPictureIndex
 	push hl
 	inc h
-	ld a,$0e
+	ld a, $0e
 	add l
-	ld l,a
-	ld a,c ; a = VRAM slot (zero if sprite slot is not used)
-	ld [hl],a ; $C2XE (VRAM slot)
+	ld l, a
+	ld a, c ; a = VRAM slot (zero if sprite slot is not used)
+	ld [hl], a ; $C2XE (VRAM slot)
 	pop hl
-	ld a,$10
+	ld a, $10
 	add l
-	ld l,a
+	ld l, a
 	and a
-	jr nz,.storeVRAMSlotsLoop
+	jr nz, .storeVRAMSlotsLoop
 	scf
 	ret
 
 ; Chooses the correct sprite set ID depending on the player's position within
 ; the map for maps with two sprite sets.
 GetSplitMapSpriteSetID:
-	cp a,$f8
-	jr z,.route20
-	ld hl,SplitMapSpriteSets
-	and a,$0f
+	cp $f8
+	jr z, .route20
+	ld hl, SplitMapSpriteSets
+	and $0f
 	dec a
 	sla a
 	sla a
 	add l
-	ld l,a
-	jr nc,.noCarry
+	ld l, a
+	jr nc, .noCarry
 	inc h
 .noCarry
-	ld a,[hli] ; determines whether the map is split East/West or North/South
-	cp a,$01
-	ld a,[hli] ; position of dividing line
-	ld b,a
-	jr z,.eastWestDivide
+	ld a, [hli] ; determines whether the map is split East/West or North/South
+	cp $01
+	ld a, [hli] ; position of dividing line
+	ld b, a
+	jr z, .eastWestDivide
 .northSouthDivide
-	ld a,[wYCoord]
+	ld a, [wYCoord]
 	jr .compareCoord
 .eastWestDivide
-	ld a,[wXCoord]
+	ld a, [wXCoord]
 .compareCoord
 	cp b
-	jr c,.loadSpriteSetID
+	jr c, .loadSpriteSetID
 ; if in the East side or South side
 	inc hl
 .loadSpriteSetID
-	ld a,[hl]
+	ld a, [hl]
 	ret
 ; Uses sprite set $01 for West side and $0A for East side.
 ; Route 20 is a special case because the two map sections have a more complex
 ; shape instead of the map simply being split horizontally or vertically.
 .route20
-	ld hl,wXCoord
-	ld a,[hl]
-	cp a,$2b
-	ld a,$01
+	ld hl, wXCoord
+	ld a, [hl]
+	cp $2b
+	ld a, $01
 	ret c
-	ld a,[hl]
-	cp a,$3e
-	ld a,$0a
+	ld a, [hl]
+	cp $3e
+	ld a, $0a
 	ret nc
-	ld a,[hl]
-	cp a,$37
-	ld b,$08
-	jr nc,.next
-	ld b,$0d
+	ld a, [hl]
+	cp $37
+	ld b, $08
+	jr nc, .next
+	ld b, $0d
 .next
-	ld a,[wYCoord]
+	ld a, [wYCoord]
 	cp b
-	ld a,$0a
+	ld a, $0a
 	ret c
-	ld a,$01
+	ld a, $01
 	ret
 
 INCLUDE "data/sprite_sets.asm"

--- a/engine/overworld/pokemart.asm
+++ b/engine/overworld/pokemart.asm
@@ -1,230 +1,230 @@
 DisplayPokemartDialogue_:
-	ld a,[wListScrollOffset]
-	ld [wSavedListScrollOffset],a
+	ld a, [wListScrollOffset]
+	ld [wSavedListScrollOffset], a
 	call UpdateSprites
 	xor a
-	ld [wBoughtOrSoldItemInMart],a
+	ld [wBoughtOrSoldItemInMart], a
 .loop
 	xor a
-	ld [wListScrollOffset],a
-	ld [wCurrentMenuItem],a
-	ld [wPlayerMonNumber],a
+	ld [wListScrollOffset], a
+	ld [wCurrentMenuItem], a
+	ld [wPlayerMonNumber], a
 	inc a
-	ld [wPrintItemPrices],a
-	ld a,MONEY_BOX
-	ld [wTextBoxID],a
+	ld [wPrintItemPrices], a
+	ld a, MONEY_BOX
+	ld [wTextBoxID], a
 	call DisplayTextBoxID
-	ld a,BUY_SELL_QUIT_MENU
-	ld [wTextBoxID],a
+	ld a, BUY_SELL_QUIT_MENU
+	ld [wTextBoxID], a
 	call DisplayTextBoxID
 
 ; This code is useless. It copies the address of the pokemart's inventory to hl,
 ; but the address is never used.
-	ld hl,wItemListPointer
-	ld a,[hli]
-	ld l,[hl]
-	ld h,a
+	ld hl, wItemListPointer
+	ld a, [hli]
+	ld l, [hl]
+	ld h, a
 
-	ld a,[wMenuExitMethod]
-	cp a,CANCELLED_MENU
-	jp z,.done
-	ld a,[wChosenMenuItem]
+	ld a, [wMenuExitMethod]
+	cp CANCELLED_MENU
+	jp z, .done
+	ld a, [wChosenMenuItem]
 	and a ; buying?
-	jp z,.buyMenu
+	jp z, .buyMenu
 	dec a ; selling?
-	jp z,.sellMenu
+	jp z, .sellMenu
 	dec a ; quitting?
-	jp z,.done
+	jp z, .done
 .sellMenu
 
 ; the same variables are set again below, so this code has no effect
 	xor a
-	ld [wPrintItemPrices],a
-	ld a,INIT_BAG_ITEM_LIST
-	ld [wInitListType],a
+	ld [wPrintItemPrices], a
+	ld a, INIT_BAG_ITEM_LIST
+	ld [wInitListType], a
 	callab InitList
 
-	ld a,[wNumBagItems]
+	ld a, [wNumBagItems]
 	and a
-	jp z,.bagEmpty
-	ld hl,PokemonSellingGreetingText
+	jp z, .bagEmpty
+	ld hl, PokemonSellingGreetingText
 	call PrintText
 	call SaveScreenTilesToBuffer1 ; save screen
 .sellMenuLoop
 	call LoadScreenTilesFromBuffer1 ; restore saved screen
-	ld a,MONEY_BOX
-	ld [wTextBoxID],a
+	ld a, MONEY_BOX
+	ld [wTextBoxID], a
 	call DisplayTextBoxID ; draw money text box
-	ld hl,wNumBagItems
-	ld a,l
-	ld [wListPointer],a
-	ld a,h
-	ld [wListPointer + 1],a
+	ld hl, wNumBagItems
+	ld a, l
+	ld [wListPointer], a
+	ld a, h
+	ld [wListPointer + 1], a
 	xor a
-	ld [wPrintItemPrices],a
-	ld [wCurrentMenuItem],a
-	ld a,ITEMLISTMENU
-	ld [wListMenuID],a
+	ld [wPrintItemPrices], a
+	ld [wCurrentMenuItem], a
+	ld a, ITEMLISTMENU
+	ld [wListMenuID], a
 	call DisplayListMenuID
-	jp c,.returnToMainPokemartMenu ; if the player closed the menu
+	jp c, .returnToMainPokemartMenu ; if the player closed the menu
 .confirmItemSale ; if the player is trying to sell a specific item
 	call IsKeyItem
-	ld a,[wIsKeyItem]
+	ld a, [wIsKeyItem]
 	and a
-	jr nz,.unsellableItem
-	ld a,[wcf91]
+	jr nz, .unsellableItem
+	ld a, [wcf91]
 	call IsItemHM
-	jr c,.unsellableItem
-	ld a,PRICEDITEMLISTMENU
-	ld [wListMenuID],a
-	ld [hHalveItemPrices],a ; halve prices when selling
+	jr c, .unsellableItem
+	ld a, PRICEDITEMLISTMENU
+	ld [wListMenuID], a
+	ld [hHalveItemPrices], a ; halve prices when selling
 	call DisplayChooseQuantityMenu
 	inc a
-	jr z,.sellMenuLoop ; if the player closed the choose quantity menu with the B button
-	ld hl,PokemartTellSellPriceText
+	jr z, .sellMenuLoop ; if the player closed the choose quantity menu with the B button
+	ld hl, PokemartTellSellPriceText
 	lb bc, 14, 1 ; location that PrintText always prints to, this is useless
 	call PrintText
 	coord hl, 14, 7
 	lb bc, 8, 15
-	ld a,TWO_OPTION_MENU
-	ld [wTextBoxID],a
+	ld a, TWO_OPTION_MENU
+	ld [wTextBoxID], a
 	call DisplayTextBoxID ; yes/no menu
-	ld a,[wMenuExitMethod]
-	cp a,CHOSE_SECOND_ITEM
-	jr z,.sellMenuLoop ; if the player chose No or pressed the B button
+	ld a, [wMenuExitMethod]
+	cp CHOSE_SECOND_ITEM
+	jr z, .sellMenuLoop ; if the player chose No or pressed the B button
 
 ; The following code is supposed to check if the player chose No, but the above
 ; check already catches it.
-	ld a,[wChosenMenuItem]
+	ld a, [wChosenMenuItem]
 	dec a
-	jr z,.sellMenuLoop
+	jr z, .sellMenuLoop
 
 .sellItem
-	ld a,[wBoughtOrSoldItemInMart]
+	ld a, [wBoughtOrSoldItemInMart]
 	and a
-	jr nz,.skipSettingFlag1
+	jr nz, .skipSettingFlag1
 	inc a
-	ld [wBoughtOrSoldItemInMart],a
+	ld [wBoughtOrSoldItemInMart], a
 .skipSettingFlag1
 	call AddAmountSoldToMoney
-	ld hl,wNumBagItems
+	ld hl, wNumBagItems
 	call RemoveItemFromInventory
 	jp .sellMenuLoop
 .unsellableItem
-	ld hl,PokemartUnsellableItemText
+	ld hl, PokemartUnsellableItemText
 	call PrintText
 	jp .returnToMainPokemartMenu
 .bagEmpty
-	ld hl,PokemartItemBagEmptyText
+	ld hl, PokemartItemBagEmptyText
 	call PrintText
 	call SaveScreenTilesToBuffer1
 	jp .returnToMainPokemartMenu
 .buyMenu
 
 ; the same variables are set again below, so this code has no effect
-	ld a,1
-	ld [wPrintItemPrices],a
-	ld a,INIT_OTHER_ITEM_LIST
-	ld [wInitListType],a
+	ld a, 1
+	ld [wPrintItemPrices], a
+	ld a, INIT_OTHER_ITEM_LIST
+	ld [wInitListType], a
 	callab InitList
 
-	ld hl,PokemartBuyingGreetingText
+	ld hl, PokemartBuyingGreetingText
 	call PrintText
 	call SaveScreenTilesToBuffer1
 .buyMenuLoop
 	call LoadScreenTilesFromBuffer1
-	ld a,MONEY_BOX
-	ld [wTextBoxID],a
+	ld a, MONEY_BOX
+	ld [wTextBoxID], a
 	call DisplayTextBoxID
-	ld hl,wItemList
-	ld a,l
-	ld [wListPointer],a
-	ld a,h
-	ld [wListPointer + 1],a
+	ld hl, wItemList
+	ld a, l
+	ld [wListPointer], a
+	ld a, h
+	ld [wListPointer + 1], a
 	xor a
-	ld [wCurrentMenuItem],a
+	ld [wCurrentMenuItem], a
 	inc a
-	ld [wPrintItemPrices],a
+	ld [wPrintItemPrices], a
 	inc a ; a = 2 (PRICEDITEMLISTMENU)
-	ld [wListMenuID],a
+	ld [wListMenuID], a
 	call DisplayListMenuID
-	jr c,.returnToMainPokemartMenu ; if the player closed the menu
-	ld a,99
-	ld [wMaxItemQuantity],a
+	jr c, .returnToMainPokemartMenu ; if the player closed the menu
+	ld a, 99
+	ld [wMaxItemQuantity], a
 	xor a
-	ld [hHalveItemPrices],a ; don't halve item prices when buying
+	ld [hHalveItemPrices], a ; don't halve item prices when buying
 	call DisplayChooseQuantityMenu
 	inc a
-	jr z,.buyMenuLoop ; if the player closed the choose quantity menu with the B button
-	ld a,[wcf91] ; item ID
-	ld [wd11e],a ; store item ID for GetItemName
+	jr z, .buyMenuLoop ; if the player closed the choose quantity menu with the B button
+	ld a, [wcf91] ; item ID
+	ld [wd11e], a ; store item ID for GetItemName
 	call GetItemName
 	call CopyStringToCF4B ; copy name to wcf4b
-	ld hl,PokemartTellBuyPriceText
+	ld hl, PokemartTellBuyPriceText
 	call PrintText
 	coord hl, 14, 7
 	lb bc, 8, 15
-	ld a,TWO_OPTION_MENU
-	ld [wTextBoxID],a
+	ld a, TWO_OPTION_MENU
+	ld [wTextBoxID], a
 	call DisplayTextBoxID ; yes/no menu
-	ld a,[wMenuExitMethod]
-	cp a,CHOSE_SECOND_ITEM
-	jp z,.buyMenuLoop ; if the player chose No or pressed the B button
+	ld a, [wMenuExitMethod]
+	cp CHOSE_SECOND_ITEM
+	jp z, .buyMenuLoop ; if the player chose No or pressed the B button
 
 ; The following code is supposed to check if the player chose No, but the above
 ; check already catches it.
-	ld a,[wChosenMenuItem]
+	ld a, [wChosenMenuItem]
 	dec a
-	jr z,.buyMenuLoop
+	jr z, .buyMenuLoop
 
 .buyItem
 	call .isThereEnoughMoney
-	jr c,.notEnoughMoney
-	ld hl,wNumBagItems
+	jr c, .notEnoughMoney
+	ld hl, wNumBagItems
 	call AddItemToInventory
-	jr nc,.bagFull
+	jr nc, .bagFull
 	call SubtractAmountPaidFromMoney
-	ld a,[wBoughtOrSoldItemInMart]
+	ld a, [wBoughtOrSoldItemInMart]
 	and a
-	jr nz,.skipSettingFlag2
-	ld a,1
-	ld [wBoughtOrSoldItemInMart],a
+	jr nz, .skipSettingFlag2
+	ld a, 1
+	ld [wBoughtOrSoldItemInMart], a
 .skipSettingFlag2
-	ld a,SFX_PURCHASE
+	ld a, SFX_PURCHASE
 	call PlaySoundWaitForCurrent
 	call WaitForSoundToFinish
-	ld hl,PokemartBoughtItemText
+	ld hl, PokemartBoughtItemText
 	call PrintText
 	jp .buyMenuLoop
 .returnToMainPokemartMenu
 	call LoadScreenTilesFromBuffer1
-	ld a,MONEY_BOX
-	ld [wTextBoxID],a
+	ld a, MONEY_BOX
+	ld [wTextBoxID], a
 	call DisplayTextBoxID
-	ld hl,PokemartAnythingElseText
+	ld hl, PokemartAnythingElseText
 	call PrintText
 	jp .loop
 .isThereEnoughMoney
-	ld de,wPlayerMoney
-	ld hl,hMoney
-	ld c,3 ; length of money in bytes
+	ld de, wPlayerMoney
+	ld hl, hMoney
+	ld c, 3 ; length of money in bytes
 	jp StringCmp
 .notEnoughMoney
-	ld hl,PokemartNotEnoughMoneyText
+	ld hl, PokemartNotEnoughMoneyText
 	call PrintText
 	jr .returnToMainPokemartMenu
 .bagFull
-	ld hl,PokemartItemBagFullText
+	ld hl, PokemartItemBagFullText
 	call PrintText
 	jr .returnToMainPokemartMenu
 .done
-	ld hl,PokemartThankYouText
+	ld hl, PokemartThankYouText
 	call PrintText
-	ld a,1
-	ld [wUpdateSpritesEnabled],a
+	ld a, 1
+	ld [wUpdateSpritesEnabled], a
 	call UpdateSprites
-	ld a,[wSavedListScrollOffset]
-	ld [wListScrollOffset],a
+	ld a, [wSavedListScrollOffset]
+	ld [wListScrollOffset], a
 	ret
 
 PokemartBuyingGreetingText:

--- a/engine/overworld/wild_mons.asm
+++ b/engine/overworld/wild_mons.asm
@@ -1,33 +1,33 @@
 LoadWildData:
-	ld hl,WildDataPointers
-	ld a,[wCurMap]
+	ld hl, WildDataPointers
+	ld a, [wCurMap]
 
 	; get wild data for current map
-	ld c,a
-	ld b,0
-	add hl,bc
-	add hl,bc
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a       ; hl now points to wild data for current map
-	ld a,[hli]
-	ld [wGrassRate],a
+	ld c, a
+	ld b, 0
+	add hl, bc
+	add hl, bc
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a       ; hl now points to wild data for current map
+	ld a, [hli]
+	ld [wGrassRate], a
 	and a
-	jr z,.NoGrassData ; if no grass data, skip to surfing data
+	jr z, .NoGrassData ; if no grass data, skip to surfing data
 	push hl
-	ld de,wGrassMons ; otherwise, load grass data
-	ld bc,$0014
+	ld de, wGrassMons ; otherwise, load grass data
+	ld bc, $0014
 	call CopyData
 	pop hl
-	ld bc,$0014
-	add hl,bc
+	ld bc, $0014
+	add hl, bc
 .NoGrassData
-	ld a,[hli]
-	ld [wWaterRate],a
+	ld a, [hli]
+	ld [wWaterRate], a
 	and a
 	ret z        ; if no water data, we're done
-	ld de,wWaterMons  ; otherwise, load surfing data
-	ld bc,$0014
+	ld de, wWaterMons  ; otherwise, load surfing data
+	ld bc, $0014
 	jp CopyData
 
 INCLUDE "data/wild_mons.asm"

--- a/engine/palettes.asm
+++ b/engine/palettes.asm
@@ -325,11 +325,11 @@ UpdatePartyMenuBlkPacket:
 
 SendSGBPacket:
 ;check number of packets
-	ld a,[hl]
-	and a,$07
+	ld a, [hl]
+	and $07
 	ret z
 ; store number of packets in B
-	ld b,a
+	ld b, a
 .loop2
 ; save B for later use
 	push bc
@@ -338,46 +338,46 @@ SendSGBPacket:
 	ld [hDisableJoypadPolling], a
 ; send RESET signal (P14=LOW, P15=LOW)
 	xor a
-	ld [rJOYP],a
+	ld [rJOYP], a
 ; set P14=HIGH, P15=HIGH
-	ld a,$30
-	ld [rJOYP],a
+	ld a, $30
+	ld [rJOYP], a
 ;load length of packets (16 bytes)
-	ld b,$10
+	ld b, $10
 .nextByte
 ;set bit counter (8 bits per byte)
-	ld e,$08
+	ld e, $08
 ; get next byte in the packet
-	ld a,[hli]
-	ld d,a
+	ld a, [hli]
+	ld d, a
 .nextBit0
-	bit 0,d
+	bit 0, d
 ; if 0th bit is not zero set P14=HIGH,P15=LOW (send bit 1)
-	ld a,$10
-	jr nz,.next0
+	ld a, $10
+	jr nz, .next0
 ; else (if 0th bit is zero) set P14=LOW,P15=HIGH (send bit 0)
-	ld a,$20
+	ld a, $20
 .next0
-	ld [rJOYP],a
+	ld [rJOYP], a
 ; must set P14=HIGH,P15=HIGH between each "pulse"
-	ld a,$30
-	ld [rJOYP],a
+	ld a, $30
+	ld [rJOYP], a
 ; rotation will put next bit in 0th position (so  we can always use command
 ; "bit 0,d" to fetch the bit that has to be sent)
 	rr d
 ; decrease bit counter so we know when we have sent all 8 bits of current byte
 	dec e
-	jr nz,.nextBit0
+	jr nz, .nextBit0
 	dec b
-	jr nz,.nextByte
+	jr nz, .nextByte
 ; send bit 1 as a "stop bit" (end of parameter data)
-	ld a,$20
-	ld [rJOYP],a
+	ld a, $20
+	ld [rJOYP], a
 ; set P14=HIGH,P15=HIGH
-	ld a,$30
-	ld [rJOYP],a
+	ld a, $30
+	ld [rJOYP], a
 	xor a
-	ld [hDisableJoypadPolling],a
+	ld [hDisableJoypadPolling], a
 ; wait for about 70000 cycles
 	call Wait7000
 ; restore (previously pushed) number of packets

--- a/engine/palettes.asm
+++ b/engine/palettes.asm
@@ -269,7 +269,7 @@ BadgeBlkDataLengths:
 	db 6     ; Earth Badge
 
 DeterminePaletteID:
-	bit Transformed, a ; a is battle status 3
+	bit TRANSFORMED, a ; a is battle status 3
 	ld a, PAL_GREYMON  ; if the mon has used Transform, use Ditto's palette
 	ret nz
 	ld a, [hl]

--- a/engine/pokedex_rating.asm
+++ b/engine/pokedex_rating.asm
@@ -42,7 +42,7 @@ DisplayDexRating:
 	inc de
 .copyRatingTextLoop
 	ld a, [hli]
-	cp a, "@"
+	cp "@"
 	jr z, .doneCopying
 	ld [de], a
 	inc de

--- a/engine/predefs.asm
+++ b/engine/predefs.asm
@@ -4,48 +4,48 @@ GetPredefPointer:
 ; Then put the bank and address of predef
 ; wPredefID in [wPredefBank] and hl.
 
-	ld a,h
-	ld [wPredefRegisters],a
-	ld a,l
-	ld [wPredefRegisters + 1],a
+	ld a, h
+	ld [wPredefRegisters], a
+	ld a, l
+	ld [wPredefRegisters + 1], a
 
-	ld hl,wPredefRegisters + 2
-	ld a,d
-	ld [hli],a
-	ld a,e
-	ld [hli],a
+	ld hl, wPredefRegisters + 2
+	ld a, d
+	ld [hli], a
+	ld a, e
+	ld [hli], a
 
-	ld a,b
-	ld [hli],a
-	ld [hl],c
+	ld a, b
+	ld [hli], a
+	ld [hl], c
 
-	ld hl,PredefPointers
-	ld de,0
+	ld hl, PredefPointers
+	ld de, 0
 
-	ld a,[wPredefID]
-	ld e,a
+	ld a, [wPredefID]
+	ld e, a
 	add a
 	add e
-	ld e,a
+	ld e, a
 	jr nc, .nocarry
 	inc d
 
 .nocarry
-	add hl,de
-	ld d,h
-	ld e,l
+	add hl, de
+	ld d, h
+	ld e, l
 
 	; get bank of predef routine
-	ld a,[de]
-	ld [wPredefBank],a
+	ld a, [de]
+	ld [wPredefBank], a
 
 	; get pointer
 	inc de
-	ld a,[de]
-	ld l,a
+	ld a, [de]
+	ld l, a
 	inc de
-	ld a,[de]
-	ld h,a
+	ld a, [de]
+	ld h, a
 
 	ret
 

--- a/engine/save.asm
+++ b/engine/save.asm
@@ -139,16 +139,16 @@ LoadSAVIgnoreBadCheckSum:
 
 SaveSAV:
 	callba PrintSaveScreenText
-	ld hl,WouldYouLikeToSaveText
+	ld hl, WouldYouLikeToSaveText
 	call SaveSAVConfirm
 	and a   ;|0 = Yes|1 = No|
 	ret nz
-	ld a,[wSaveFileStatus]
+	ld a, [wSaveFileStatus]
 	dec a
-	jr z,.save
+	jr z, .save
 	call SAVCheckRandomID
-	jr z,.save
-	ld hl,OlderFileWillBeErasedText
+	jr z, .save
+	ld hl, OlderFileWillBeErasedText
 	call SaveSAVConfirm
 	and a
 	ret nz
@@ -158,16 +158,16 @@ SaveSAV:
 	lb bc, 4, 18
 	call ClearScreenArea
 	coord hl, 1, 14
-	ld de,NowSavingString
+	ld de, NowSavingString
 	call PlaceString
-	ld c,120
+	ld c, 120
 	call DelayFrames
-	ld hl,GameSavedText
+	ld hl, GameSavedText
 	call PrintText
 	ld a, SFX_SAVE
 	call PlaySoundWaitForCurrent
 	call WaitForSoundToFinish
-	ld c,30
+	ld c, 30
 	jp DelayFrames
 
 NowSavingString:
@@ -177,10 +177,10 @@ SaveSAVConfirm:
 	call PrintText
 	coord hl, 0, 7
 	lb bc, 8, 1
-	ld a,TWO_OPTION_MENU
-	ld [wTextBoxID],a
+	ld a, TWO_OPTION_MENU
+	ld [wTextBoxID], a
 	call DisplayTextBoxID ; yes/no menu
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	ret
 
 WouldYouLikeToSaveText:
@@ -604,34 +604,34 @@ SAVCheckRandomID:
 ;checks if Sav file is the same by checking player's name 1st letter ($a598)
 ; and the two random numbers generated at game beginning
 ;(which are stored at wPlayerID)s
-	ld a,$0a
-	ld [MBC1SRamEnable],a
-	ld a,$01
-	ld [MBC1SRamBankingMode],a
-	ld [MBC1SRamBank],a
-	ld a,[sPlayerName]
+	ld a, $0a
+	ld [MBC1SRamEnable], a
+	ld a, $01
+	ld [MBC1SRamBankingMode], a
+	ld [MBC1SRamBank], a
+	ld a, [sPlayerName]
 	and a
-	jr z,.next
-	ld hl,sPlayerName
+	jr z, .next
+	ld hl, sPlayerName
 	ld bc, sMainDataCheckSum - sPlayerName
 	call SAVCheckSum
-	ld c,a
-	ld a,[sMainDataCheckSum]
+	ld c, a
+	ld a, [sMainDataCheckSum]
 	cp c
-	jr nz,.next
-	ld hl,sMainData + (wPlayerID - wMainDataStart) ; player ID
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
-	ld a,[wPlayerID]
+	jr nz, .next
+	ld hl, sMainData + (wPlayerID - wMainDataStart) ; player ID
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
+	ld a, [wPlayerID]
 	cp l
-	jr nz,.next
-	ld a,[wPlayerID + 1]
+	jr nz, .next
+	ld a, [wPlayerID + 1]
 	cp h
 .next
-	ld a,$00
-	ld [MBC1SRamBankingMode],a
-	ld [MBC1SRamEnable],a
+	ld a, $00
+	ld [MBC1SRamBankingMode], a
+	ld [MBC1SRamEnable], a
 	ret
 
 SaveHallOfFameTeams:

--- a/engine/special_warps.asm
+++ b/engine/special_warps.asm
@@ -1,31 +1,31 @@
 SpecialWarpIn:
 	call LoadSpecialWarpData
 	predef LoadTilesetHeader
-	ld hl,wd732
-	bit 2,[hl] ; dungeon warp or fly warp?
-	res 2,[hl]
-	jr z,.next
+	ld hl, wd732
+	bit 2, [hl] ; dungeon warp or fly warp?
+	res 2, [hl]
+	jr z, .next
 ; if dungeon warp or fly warp
-	ld a,[wDestinationMap]
+	ld a, [wDestinationMap]
 	jr .next2
 .next
-	bit 1,[hl]
-	jr z,.next3
+	bit 1, [hl]
+	jr z, .next3
 	call EmptyFunc
 .next3
-	ld a,0
+	ld a, 0
 .next2
-	ld b,a
-	ld a,[wd72d]
+	ld b, a
+	ld a, [wd72d]
 	and a
-	jr nz,.next4
-	ld a,b
+	jr nz, .next4
+	ld a, b
 .next4
-	ld hl,wd732
-	bit 4,[hl] ; dungeon warp?
+	ld hl, wd732
+	bit 4, [hl] ; dungeon warp?
 	ret nz
 ; if not dungeon warp
-	ld [wLastMap],a
+	ld [wLastMap], a
 	ret
 
 ; gets the map ID, tile block map view pointer, tileset, and coordinates

--- a/engine/subtract_paid_money.asm
+++ b/engine/subtract_paid_money.asm
@@ -1,17 +1,17 @@
 ; subtracts the amount the player paid from their money
 ; sets carry flag if there is enough money and unsets carry flag if not
 SubtractAmountPaidFromMoney_:
-	ld de,wPlayerMoney
-	ld hl,hMoney ; total price of items
-	ld c,3 ; length of money in bytes
+	ld de, wPlayerMoney
+	ld hl, hMoney ; total price of items
+	ld c, 3 ; length of money in bytes
 	call StringCmp
 	ret c
-	ld de,wPlayerMoney + 2
-	ld hl,hMoney + 2 ; total price of items
-	ld c,3 ; length of money in bytes
+	ld de, wPlayerMoney + 2
+	ld hl, hMoney + 2 ; total price of items
+	ld c, 3 ; length of money in bytes
 	predef SubBCDPredef ; subtract total price from money
-	ld a,MONEY_BOX
-	ld [wTextBoxID],a
+	ld a, MONEY_BOX
+	ld [wTextBoxID], a
 	call DisplayTextBoxID ; redraw money text box
 	and a
 	ret

--- a/engine/titlescreen.asm
+++ b/engine/titlescreen.asm
@@ -56,7 +56,7 @@ DisplayTitleScreen:
 	ld a, BANK(PokemonLogoGraphics)
 	call FarCopyData2          ; second chunk
 	ld hl, Version_GFX
-	ld de,vChars2 + $600 - (Version_GFXEnd - Version_GFX - $50)
+	ld de, vChars2 + $600 - (Version_GFXEnd - Version_GFX - $50)
 	ld bc, Version_GFXEnd - Version_GFX
 	ld a, BANK(Version_GFX)
 	call FarCopyDataDouble
@@ -118,10 +118,10 @@ DisplayTitleScreen:
 	call LoadScreenTilesFromBuffer2
 	call EnableLCD
 IF DEF(_RED)
-	ld a,CHARMANDER ; which Pokemon to show first on the title screen
+	ld a, CHARMANDER ; which Pokemon to show first on the title screen
 ENDC
 IF DEF(_BLUE)
-	ld a,SQUIRTLE ; which Pokemon to show first on the title screen
+	ld a, SQUIRTLE ; which Pokemon to show first on the title screen
 ENDC
 
 	ld [wTitleMonSpecies], a

--- a/engine/trade2.asm
+++ b/engine/trade2.asm
@@ -1,44 +1,44 @@
 Trade_PrintPlayerMonInfoText:
 	coord hl, 5, 0
-	ld de,Trade_MonInfoText
+	ld de, Trade_MonInfoText
 	call PlaceString
-	ld a,[wTradedPlayerMonSpecies]
-	ld [wd11e],a
+	ld a, [wTradedPlayerMonSpecies]
+	ld [wd11e], a
 	predef IndexToPokedex
 	coord hl, 9, 0
-	ld de,wd11e
+	ld de, wd11e
 	lb bc, LEADING_ZEROES | 1, 3
 	call PrintNumber
 	coord hl, 5, 2
-	ld de,wcf4b
+	ld de, wcf4b
 	call PlaceString
 	coord hl, 8, 4
-	ld de,wTradedPlayerMonOT
+	ld de, wTradedPlayerMonOT
 	call PlaceString
 	coord hl, 8, 6
-	ld de,wTradedPlayerMonOTID
+	ld de, wTradedPlayerMonOTID
 	lb bc, LEADING_ZEROES | 2, 5
 	jp PrintNumber
 
 Trade_PrintEnemyMonInfoText:
 	coord hl, 5, 10
-	ld de,Trade_MonInfoText
+	ld de, Trade_MonInfoText
 	call PlaceString
-	ld a,[wTradedEnemyMonSpecies]
-	ld [wd11e],a
+	ld a, [wTradedEnemyMonSpecies]
+	ld [wd11e], a
 	predef IndexToPokedex
 	coord hl, 9, 10
-	ld de,wd11e
+	ld de, wd11e
 	lb bc, LEADING_ZEROES | 1, 3
 	call PrintNumber
 	coord hl, 5, 12
-	ld de,wcd6d
+	ld de, wcd6d
 	call PlaceString
 	coord hl, 8, 14
-	ld de,wTradedEnemyMonOT
+	ld de, wTradedEnemyMonOT
 	call PlaceString
 	coord hl, 8, 16
-	ld de,wTradedEnemyMonOTID
+	ld de, wTradedEnemyMonOTID
 	lb bc, LEADING_ZEROES | 2, 5
 	jp PrintNumber
 

--- a/home.asm
+++ b/home.asm
@@ -148,24 +148,24 @@ CheckForUserInterruption::
 ; INPUT:
 ; a = ID of destination warp within destination map
 LoadDestinationWarpPosition::
-	ld b,a
-	ld a,[H_LOADEDROMBANK]
+	ld b, a
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,[wPredefParentBank]
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
-	ld a,b
+	ld a, [wPredefParentBank]
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
+	ld a, b
 	add a
 	add a
-	ld c,a
-	ld b,0
-	add hl,bc
-	ld bc,4
-	ld de,wCurrentTileBlockMapViewPointer
+	ld c, a
+	ld b, 0
+	add hl, bc
+	ld bc, 4
+	ld de, wCurrentTileBlockMapViewPointer
 	call CopyData
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 
@@ -189,18 +189,18 @@ DrawHPBar::
 	; Middle
 	ld a, $63 ; empty
 .draw
-	ld [hli],a
+	ld [hli], a
 	dec d
 	jr nz, .draw
 
 	; Right
-	ld a,[wHPBarType]
+	ld a, [wHPBarType]
 	dec a
 	ld a, $6d ; status screen and battle
 	jr z, .ok
 	dec a ; pokemon menu
 .ok
-	ld [hl],a
+	ld [hl], a
 
 	pop hl
 
@@ -346,10 +346,10 @@ GetCryData::
 	ret
 
 DisplayPartyMenu::
-	ld a,[hTilesetType]
+	ld a, [hTilesetType]
 	push af
 	xor a
-	ld [hTilesetType],a
+	ld [hTilesetType], a
 	call GBPalWhiteOutWithDelay3
 	call ClearSprites
 	call PartyMenuInit
@@ -357,10 +357,10 @@ DisplayPartyMenu::
 	jp HandlePartyMenuInput
 
 GoBackToPartyMenu::
-	ld a,[hTilesetType]
+	ld a, [hTilesetType]
 	push af
 	xor a
-	ld [hTilesetType],a
+	ld [hTilesetType], a
 	call PartyMenuInit
 	call RedrawPartyMenu
 	jp HandlePartyMenuInput
@@ -405,38 +405,38 @@ PartyMenuInit::
 	ret
 
 HandlePartyMenuInput::
-	ld a,1
-	ld [wMenuWrappingEnabled],a
-	ld a,$40
-	ld [wPartyMenuAnimMonEnabled],a
+	ld a, 1
+	ld [wMenuWrappingEnabled], a
+	ld a, $40
+	ld [wPartyMenuAnimMonEnabled], a
 	call HandleMenuInput_
 	call PlaceUnfilledArrowMenuCursor
-	ld b,a
+	ld b, a
 	xor a
-	ld [wPartyMenuAnimMonEnabled],a
-	ld a,[wCurrentMenuItem]
-	ld [wPartyAndBillsPCSavedMenuItem],a
-	ld hl,wd730
-	res 6,[hl] ; turn on letter printing delay
-	ld a,[wMenuItemToSwap]
+	ld [wPartyMenuAnimMonEnabled], a
+	ld a, [wCurrentMenuItem]
+	ld [wPartyAndBillsPCSavedMenuItem], a
+	ld hl, wd730
+	res 6, [hl] ; turn on letter printing delay
+	ld a, [wMenuItemToSwap]
 	and a
-	jp nz,.swappingPokemon
+	jp nz, .swappingPokemon
 	pop af
-	ld [hTilesetType],a
-	bit 1,b
-	jr nz,.noPokemonChosen
-	ld a,[wPartyCount]
+	ld [hTilesetType], a
+	bit 1, b
+	jr nz, .noPokemonChosen
+	ld a, [wPartyCount]
 	and a
-	jr z,.noPokemonChosen
-	ld a,[wCurrentMenuItem]
-	ld [wWhichPokemon],a
-	ld hl,wPartySpecies
-	ld b,0
-	ld c,a
-	add hl,bc
-	ld a,[hl]
-	ld [wcf91],a
-	ld [wBattleMonSpecies2],a
+	jr z, .noPokemonChosen
+	ld a, [wCurrentMenuItem]
+	ld [wWhichPokemon], a
+	ld hl, wPartySpecies
+	ld b, 0
+	ld c, a
+	add hl, bc
+	ld a, [hl]
+	ld [wcf91], a
+	ld [wBattleMonSpecies2], a
 	call BankswitchBack
 	and a
 	ret
@@ -445,18 +445,18 @@ HandlePartyMenuInput::
 	scf
 	ret
 .swappingPokemon
-	bit 1,b ; was the B button pressed?
-	jr z,.handleSwap ; if not, handle swapping the pokemon
+	bit 1, b ; was the B button pressed?
+	jr z, .handleSwap ; if not, handle swapping the pokemon
 .cancelSwap ; if the B button was pressed
 	callba ErasePartyMenuCursors
 	xor a
-	ld [wMenuItemToSwap],a
-	ld [wPartyMenuTypeOrMessageID],a
+	ld [wMenuItemToSwap], a
+	ld [wPartyMenuTypeOrMessageID], a
 	call RedrawPartyMenu
 	jr HandlePartyMenuInput
 .handleSwap
-	ld a,[wCurrentMenuItem]
-	ld [wWhichPokemon],a
+	ld a, [wCurrentMenuItem]
+	ld [wWhichPokemon], a
 	callba SwitchPartyMon
 	jr HandlePartyMenuInput
 
@@ -479,33 +479,33 @@ PrintStatusCondition::
 	push de
 	dec de
 	dec de ; de = address of current HP
-	ld a,[de]
-	ld b,a
+	ld a, [de]
+	ld b, a
 	dec de
-	ld a,[de]
+	ld a, [de]
 	or b ; is the pokemon's HP zero?
 	pop de
-	jr nz,PrintStatusConditionNotFainted
+	jr nz, PrintStatusConditionNotFainted
 ; if the pokemon's HP is 0, print "FNT"
-	ld a,"F"
-	ld [hli],a
-	ld a,"N"
-	ld [hli],a
-	ld [hl],"T"
+	ld a, "F"
+	ld [hli], a
+	ld a, "N"
+	ld [hli], a
+	ld [hl], "T"
 	and a
 	ret
 
 PrintStatusConditionNotFainted:
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,BANK(PrintStatusAilment)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, BANK(PrintStatusAilment)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	call PrintStatusAilment ; print status condition
 	pop bc
-	ld a,b
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, b
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 ; function to print pokemon level, leaving off the ":L" if the level is at least 100
@@ -513,12 +513,12 @@ PrintStatusConditionNotFainted:
 ; hl = destination address
 ; [wLoadedMonLevel] = level
 PrintLevel::
-	ld a,$6e ; ":L" tile ID
-	ld [hli],a
-	ld c,2 ; number of digits
-	ld a,[wLoadedMonLevel] ; level
+	ld a, $6e ; ":L" tile ID
+	ld [hli], a
+	ld c, 2 ; number of digits
+	ld a, [wLoadedMonLevel] ; level
 	cp 100
-	jr c,PrintLevelCommon
+	jr c, PrintLevelCommon
 ; if level at least 100, write over the ":L" tile
 	dec hl
 	inc c ; increment number of digits to 3
@@ -529,105 +529,105 @@ PrintLevel::
 ; hl = destination address
 ; [wLoadedMonLevel] = level
 PrintLevelFull::
-	ld a,$6e ; ":L" tile ID
-	ld [hli],a
-	ld c,3 ; number of digits
-	ld a,[wLoadedMonLevel] ; level
+	ld a, $6e ; ":L" tile ID
+	ld [hli], a
+	ld c, 3 ; number of digits
+	ld a, [wLoadedMonLevel] ; level
 
 PrintLevelCommon::
-	ld [wd11e],a
-	ld de,wd11e
-	ld b,LEFT_ALIGN | 1 ; 1 byte
+	ld [wd11e], a
+	ld de, wd11e
+	ld b, LEFT_ALIGN | 1 ; 1 byte
 	jp PrintNumber
 
 GetwMoves::
 ; Unused. Returns the move at index a from wMoves in a
-	ld hl,wMoves
-	ld c,a
-	ld b,0
-	add hl,bc
-	ld a,[hl]
+	ld hl, wMoves
+	ld c, a
+	ld b, 0
+	add hl, bc
+	ld a, [hl]
 	ret
 
 ; copies the base stat data of a pokemon to wMonHeader
 ; INPUT:
 ; [wd0b5] = pokemon ID
 GetMonHeader::
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,BANK(BaseStats)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, BANK(BaseStats)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	push bc
 	push de
 	push hl
-	ld a,[wd11e]
+	ld a, [wd11e]
 	push af
-	ld a,[wd0b5]
-	ld [wd11e],a
-	ld de,FossilKabutopsPic
-	ld b,$66 ; size of Kabutops fossil and Ghost sprites
+	ld a, [wd0b5]
+	ld [wd11e], a
+	ld de, FossilKabutopsPic
+	ld b, $66 ; size of Kabutops fossil and Ghost sprites
 	cp FOSSIL_KABUTOPS ; Kabutops fossil
-	jr z,.specialID
-	ld de,GhostPic
+	jr z, .specialID
+	ld de, GhostPic
 	cp MON_GHOST ; Ghost
-	jr z,.specialID
-	ld de,FossilAerodactylPic
-	ld b,$77 ; size of Aerodactyl fossil sprite
+	jr z, .specialID
+	ld de, FossilAerodactylPic
+	ld b, $77 ; size of Aerodactyl fossil sprite
 	cp FOSSIL_AERODACTYL ; Aerodactyl fossil
-	jr z,.specialID
-	cp a,MEW
-	jr z,.mew
+	jr z, .specialID
+	cp MEW
+	jr z, .mew
 	predef IndexToPokedex   ; convert pokemon ID in [wd11e] to pokedex number
-	ld a,[wd11e]
+	ld a, [wd11e]
 	dec a
 	ld bc, MonBaseStatsEnd - MonBaseStats
-	ld hl,BaseStats
+	ld hl, BaseStats
 	call AddNTimes
-	ld de,wMonHeader
+	ld de, wMonHeader
 	ld bc, MonBaseStatsEnd - MonBaseStats
 	call CopyData
 	jr .done
 .specialID
-	ld hl,wMonHSpriteDim
-	ld [hl],b ; write sprite dimensions
+	ld hl, wMonHSpriteDim
+	ld [hl], b ; write sprite dimensions
 	inc hl
-	ld [hl],e ; write front sprite pointer
+	ld [hl], e ; write front sprite pointer
 	inc hl
-	ld [hl],d
+	ld [hl], d
 	jr .done
 .mew
-	ld hl,MewBaseStats
-	ld de,wMonHeader
-	ld bc,MonBaseStatsEnd - MonBaseStats
-	ld a,BANK(MewBaseStats)
+	ld hl, MewBaseStats
+	ld de, wMonHeader
+	ld bc, MonBaseStatsEnd - MonBaseStats
+	ld a, BANK(MewBaseStats)
 	call FarCopyData
 .done
-	ld a,[wd0b5]
-	ld [wMonHIndex],a
+	ld a, [wd0b5]
+	ld [wMonHIndex], a
 	pop af
-	ld [wd11e],a
+	ld [wd11e], a
 	pop hl
 	pop de
 	pop bc
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 ; copy party pokemon's name to wcd6d
 GetPartyMonName2::
-	ld a,[wWhichPokemon] ; index within party
-	ld hl,wPartyMonNicks
+	ld a, [wWhichPokemon] ; index within party
+	ld hl, wPartyMonNicks
 
 ; this is called more often
 GetPartyMonName::
 	push hl
 	push bc
 	call SkipFixedLengthTextEntries ; add NAME_LENGTH to hl, a times
-	ld de,wcd6d
+	ld de, wcd6d
 	push de
-	ld bc,NAME_LENGTH
+	ld bc, NAME_LENGTH
 	call CopyData
 	pop de
 	pop bc
@@ -648,38 +648,38 @@ GetPartyMonName::
 ; Note that bits 5 and 7 are modified during execution. The above reflects
 ; their meaning at the beginning of the functions's execution.
 PrintBCDNumber::
-	ld b,c ; save flags in b
-	res 7,c
-	res 6,c
-	res 5,c ; c now holds the length
-	bit 5,b
-	jr z,.loop
-	bit 7,b
-	jr nz,.loop
-	ld [hl],"¥"
+	ld b, c ; save flags in b
+	res 7, c
+	res 6, c
+	res 5, c ; c now holds the length
+	bit 5, b
+	jr z, .loop
+	bit 7, b
+	jr nz, .loop
+	ld [hl], "¥"
 	inc hl
 .loop
-	ld a,[de]
+	ld a, [de]
 	swap a
 	call PrintBCDDigit ; print upper digit
-	ld a,[de]
+	ld a, [de]
 	call PrintBCDDigit ; print lower digit
 	inc de
 	dec c
-	jr nz,.loop
-	bit 7,b ; were any non-zero digits printed?
-	jr z,.done ; if so, we are done
+	jr nz, .loop
+	bit 7, b ; were any non-zero digits printed?
+	jr z, .done ; if so, we are done
 .numberEqualsZero ; if every digit of the BCD number is zero
-	bit 6,b ; left or right alignment?
-	jr nz,.skipRightAlignmentAdjustment
+	bit 6, b ; left or right alignment?
+	jr nz, .skipRightAlignmentAdjustment
 	dec hl ; if the string is right-aligned, it needs to be moved back one space
 .skipRightAlignmentAdjustment
-	bit 5,b
-	jr z,.skipCurrencySymbol
-	ld [hl],"¥"
+	bit 5, b
+	jr z, .skipCurrencySymbol
+	ld [hl], "¥"
 	inc hl
 .skipCurrencySymbol
-	ld [hl],"0"
+	ld [hl], "0"
 	call PrintLetterDelay
 	inc hl
 .done
@@ -688,26 +688,26 @@ PrintBCDNumber::
 PrintBCDDigit::
 	and $f
 	and a
-	jr z,.zeroDigit
+	jr z, .zeroDigit
 .nonzeroDigit
-	bit 7,b ; have any non-space characters been printed?
-	jr z,.outputDigit
+	bit 7, b ; have any non-space characters been printed?
+	jr z, .outputDigit
 ; if bit 7 is set, then no numbers have been printed yet
-	bit 5,b ; print the currency symbol?
-	jr z,.skipCurrencySymbol
-	ld [hl],"¥"
+	bit 5, b ; print the currency symbol?
+	jr z, .skipCurrencySymbol
+	ld [hl], "¥"
 	inc hl
-	res 5,b
+	res 5, b
 .skipCurrencySymbol
-	res 7,b ; unset 7 to indicate that a nonzero digit has been reached
+	res 7, b ; unset 7 to indicate that a nonzero digit has been reached
 .outputDigit
 	add "0"
-	ld [hli],a
+	ld [hli], a
 	jp PrintLetterDelay
 .zeroDigit
-	bit 7,b ; either printing leading zeroes or already reached a nonzero digit?
-	jr z,.outputDigit ; if so, print a zero digit
-	bit 6,b ; left or right alignment?
+	bit 7, b ; either printing leading zeroes or already reached a nonzero digit?
+	jr z, .outputDigit ; if so, print a zero digit
+	bit 6, b ; left or right alignment?
 	ret nz
 	inc hl ; if right-aligned, "print" a space by advancing the pointer
 	ret
@@ -716,12 +716,12 @@ PrintBCDDigit::
 ; assumes the corresponding mon header is already loaded
 ; hl contains offset to sprite pointer ($b for front or $d for back)
 UncompressMonSprite::
-	ld bc,wMonHeader
-	add hl,bc
-	ld a,[hli]
-	ld [wSpriteInputPtr],a    ; fetch sprite input pointer
-	ld a,[hl]
-	ld [wSpriteInputPtr+1],a
+	ld bc, wMonHeader
+	add hl, bc
+	ld a, [hli]
+	ld [wSpriteInputPtr], a    ; fetch sprite input pointer
+	ld a, [hl]
+	ld [wSpriteInputPtr+1], a
 ; define (by index number) the bank that a pokemon's image is in
 ; index = Mew, bank 1
 ; index = Kabutops fossil, bank $B
@@ -730,32 +730,32 @@ UncompressMonSprite::
 ; $4A ≤ index < $74, bank $B
 ; $74 ≤ index < $99, bank $C
 ; $99 ≤ index,       bank $D
-	ld a,[wcf91] ; XXX name for this ram location
-	ld b,a
+	ld a, [wcf91] ; XXX name for this ram location
+	ld b, a
 	cp MEW
-	ld a,BANK(MewPicFront)
-	jr z,.GotBank
-	ld a,b
+	ld a, BANK(MewPicFront)
+	jr z, .GotBank
+	ld a, b
 	cp FOSSIL_KABUTOPS
-	ld a,BANK(FossilKabutopsPic)
-	jr z,.GotBank
-	ld a,b
+	ld a, BANK(FossilKabutopsPic)
+	jr z, .GotBank
+	ld a, b
 	cp TANGELA + 1
-	ld a,BANK(TangelaPicFront)
-	jr c,.GotBank
-	ld a,b
+	ld a, BANK(TangelaPicFront)
+	jr c, .GotBank
+	ld a, b
 	cp MOLTRES + 1
-	ld a,BANK(MoltresPicFront)
-	jr c,.GotBank
-	ld a,b
+	ld a, BANK(MoltresPicFront)
+	jr c, .GotBank
+	ld a, b
 	cp BEEDRILL + 2
-	ld a,BANK(BeedrillPicFront)
-	jr c,.GotBank
-	ld a,b
+	ld a, BANK(BeedrillPicFront)
+	jr c, .GotBank
+	ld a, b
 	cp STARMIE + 1
-	ld a,BANK(StarmiePicFront)
-	jr c,.GotBank
-	ld a,BANK(VictreebelPicFront)
+	ld a, BANK(StarmiePicFront)
+	jr c, .GotBank
+	ld a, BANK(VictreebelPicFront)
 .GotBank
 	jp UncompressSpriteData
 
@@ -942,7 +942,7 @@ INCLUDE "data/mart_inventories.asm"
 TextScriptEndingChar::
 	db "@"
 TextScriptEnd::
-	ld hl,TextScriptEndingChar
+	ld hl, TextScriptEndingChar
 	ret
 
 ExclamationText::
@@ -1047,41 +1047,41 @@ FadeOutAudio::
 ; this function is used to display sign messages, sprite dialog, etc.
 ; INPUT: [hSpriteIndexOrTextID] = sprite ID or text ID
 DisplayTextID::
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
 	callba DisplayTextIDInit ; initialization
-	ld hl,wTextPredefFlag
-	bit 0,[hl]
-	res 0,[hl]
-	jr nz,.skipSwitchToMapBank
-	ld a,[wCurMap]
+	ld hl, wTextPredefFlag
+	bit 0, [hl]
+	res 0, [hl]
+	jr nz, .skipSwitchToMapBank
+	ld a, [wCurMap]
 	call SwitchToMapRomBank
 .skipSwitchToMapBank
-	ld a,30 ; half a second
-	ld [H_FRAMECOUNTER],a ; used as joypad poll timer
-	ld hl,wMapTextPtr
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a ; hl = map text pointer
-	ld d,$00
-	ld a,[hSpriteIndexOrTextID] ; text ID
-	ld [wSpriteIndex],a
+	ld a, 30 ; half a second
+	ld [H_FRAMECOUNTER], a ; used as joypad poll timer
+	ld hl, wMapTextPtr
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a ; hl = map text pointer
+	ld d, $00
+	ld a, [hSpriteIndexOrTextID] ; text ID
+	ld [wSpriteIndex], a
 	and a
-	jp z,DisplayStartMenu
+	jp z, DisplayStartMenu
 	cp TEXT_SAFARI_GAME_OVER
-	jp z,DisplaySafariGameOverText
+	jp z, DisplaySafariGameOverText
 	cp TEXT_MON_FAINTED
-	jp z,DisplayPokemonFaintedText
+	jp z, DisplayPokemonFaintedText
 	cp TEXT_BLACKED_OUT
-	jp z,DisplayPlayerBlackedOutText
+	jp z, DisplayPlayerBlackedOutText
 	cp TEXT_REPEL_WORE_OFF
-	jp z,DisplayRepelWoreOffText
-	ld a,[wNumSprites]
-	ld e,a
-	ld a,[hSpriteIndexOrTextID] ; sprite ID
+	jp z, DisplayRepelWoreOffText
+	ld a, [wNumSprites]
+	ld e, a
+	ld a, [hSpriteIndexOrTextID] ; sprite ID
 	cp e
-	jr z,.spriteHandling
-	jr nc,.skipSpriteHandling
+	jr z, .spriteHandling
+	jr nc, .skipSpriteHandling
 .spriteHandling
 ; get the text ID of the sprite
 	push hl
@@ -1090,123 +1090,123 @@ DisplayTextID::
 	callba UpdateSpriteFacingOffsetAndDelayMovement ; update the graphics of the sprite the player is talking to (to face the right direction)
 	pop bc
 	pop de
-	ld hl,wMapSpriteData ; NPC text entries
-	ld a,[hSpriteIndexOrTextID]
+	ld hl, wMapSpriteData ; NPC text entries
+	ld a, [hSpriteIndexOrTextID]
 	dec a
 	add a
 	add l
-	ld l,a
-	jr nc,.noCarry
+	ld l, a
+	jr nc, .noCarry
 	inc h
 .noCarry
 	inc hl
-	ld a,[hl] ; a = text ID of the sprite
+	ld a, [hl] ; a = text ID of the sprite
 	pop hl
 .skipSpriteHandling
 ; look up the address of the text in the map's text entries
 	dec a
-	ld e,a
+	ld e, a
 	sla e
-	add hl,de
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a ; hl = address of the text
-	ld a,[hl] ; a = first byte of text
+	add hl, de
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a ; hl = address of the text
+	ld a, [hl] ; a = first byte of text
 ; check first byte of text for special cases
 	cp $fe   ; Pokemart NPC
-	jp z,DisplayPokemartDialogue
+	jp z, DisplayPokemartDialogue
 	cp $ff   ; Pokemon Center NPC
-	jp z,DisplayPokemonCenterDialogue
+	jp z, DisplayPokemonCenterDialogue
 	cp $fc   ; Item Storage PC
-	jp z,FuncTX_ItemStoragePC
+	jp z, FuncTX_ItemStoragePC
 	cp $fd   ; Bill's PC
-	jp z,FuncTX_BillsPC
+	jp z, FuncTX_BillsPC
 	cp $f9   ; Pokemon Center PC
-	jp z,FuncTX_PokemonCenterPC
+	jp z, FuncTX_PokemonCenterPC
 	cp $f5   ; Vending Machine
-	jr nz,.notVendingMachine
+	jr nz, .notVendingMachine
 	callba VendingMachineMenu ; jump banks to vending machine routine
 	jr AfterDisplayingTextID
 .notVendingMachine
 	cp $f7   ; prize menu
 	jp z, FuncTX_GameCornerPrizeMenu
 	cp $f6   ; cable connection NPC in Pokemon Center
-	jr nz,.notSpecialCase
+	jr nz, .notSpecialCase
 	callab CableClubNPC
 	jr AfterDisplayingTextID
 .notSpecialCase
 	call PrintText_NoCreatingTextBox ; display the text
-	ld a,[wDoNotWaitForButtonPressAfterDisplayingText]
+	ld a, [wDoNotWaitForButtonPressAfterDisplayingText]
 	and a
-	jr nz,HoldTextDisplayOpen
+	jr nz, HoldTextDisplayOpen
 
 AfterDisplayingTextID::
-	ld a,[wEnteringCableClub]
+	ld a, [wEnteringCableClub]
 	and a
-	jr nz,HoldTextDisplayOpen
+	jr nz, HoldTextDisplayOpen
 	call WaitForTextScrollButtonPress ; wait for a button press after displaying all the text
 
 ; loop to hold the dialogue box open as long as the player keeps holding down the A button
 HoldTextDisplayOpen::
 	call Joypad
-	ld a,[hJoyHeld]
-	bit 0,a ; is the A button being pressed?
-	jr nz,HoldTextDisplayOpen
+	ld a, [hJoyHeld]
+	bit 0, a ; is the A button being pressed?
+	jr nz, HoldTextDisplayOpen
 
 CloseTextDisplay::
-	ld a,[wCurMap]
+	ld a, [wCurMap]
 	call SwitchToMapRomBank
-	ld a,$90
-	ld [hWY],a ; move the window off the screen
+	ld a, $90
+	ld [hWY], a ; move the window off the screen
 	call DelayFrame
 	call LoadGBPal
 	xor a
-	ld [H_AUTOBGTRANSFERENABLED],a ; disable continuous WRAM to VRAM transfer each V-blank
+	ld [H_AUTOBGTRANSFERENABLED], a ; disable continuous WRAM to VRAM transfer each V-blank
 ; loop to make sprites face the directions they originally faced before the dialogue
-	ld hl,wSpriteStateData2 + $19
-	ld c,$0f
-	ld de,$0010
+	ld hl, wSpriteStateData2 + $19
+	ld c, $0f
+	ld de, $0010
 .restoreSpriteFacingDirectionLoop
-	ld a,[hl]
+	ld a, [hl]
 	dec h
-	ld [hl],a
+	ld [hl], a
 	inc h
-	add hl,de
+	add hl, de
 	dec c
-	jr nz,.restoreSpriteFacingDirectionLoop
-	ld a,BANK(InitMapSprites)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	jr nz, .restoreSpriteFacingDirectionLoop
+	ld a, BANK(InitMapSprites)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	call InitMapSprites ; reload sprite tile pattern data (since it was partially overwritten by text tile patterns)
-	ld hl,wFontLoaded
-	res 0,[hl]
-	ld a,[wd732]
-	bit 3,a ; used fly warp
-	call z,LoadPlayerSpriteGraphics
+	ld hl, wFontLoaded
+	res 0, [hl]
+	ld a, [wd732]
+	bit 3, a ; used fly warp
+	call z, LoadPlayerSpriteGraphics
 	call LoadCurrentMapView
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	jp UpdateSprites
 
 DisplayPokemartDialogue::
 	push hl
-	ld hl,PokemartGreetingText
+	ld hl, PokemartGreetingText
 	call PrintText
 	pop hl
 	inc hl
 	call LoadItemList
-	ld a,PRICEDITEMLISTMENU
-	ld [wListMenuID],a
-	ld a,[H_LOADEDROMBANK]
+	ld a, PRICEDITEMLISTMENU
+	ld [wListMenuID], a
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,Bank(DisplayPokemartDialogue_)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, Bank(DisplayPokemartDialogue_)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	call DisplayPokemartDialogue_
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	jp AfterDisplayingTextID
 
 PokemartGreetingText::
@@ -1214,38 +1214,38 @@ PokemartGreetingText::
 	db "@"
 
 LoadItemList::
-	ld a,1
-	ld [wUpdateSpritesEnabled],a
-	ld a,h
-	ld [wItemListPointer],a
-	ld a,l
-	ld [wItemListPointer + 1],a
-	ld de,wItemList
+	ld a, 1
+	ld [wUpdateSpritesEnabled], a
+	ld a, h
+	ld [wItemListPointer], a
+	ld a, l
+	ld [wItemListPointer + 1], a
+	ld de, wItemList
 .loop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	cp $ff
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 DisplayPokemonCenterDialogue::
 ; zeroing these doesn't appear to serve any purpose
 	xor a
-	ld [$ff8b],a
-	ld [$ff8c],a
-	ld [$ff8d],a
+	ld [$ff8b], a
+	ld [$ff8c], a
+	ld [$ff8d], a
 
 	inc hl
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,Bank(DisplayPokemonCenterDialogue_)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, Bank(DisplayPokemonCenterDialogue_)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	call DisplayPokemonCenterDialogue_
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	jp AfterDisplayingTextID
 
 DisplaySafariGameOverText::
@@ -1253,7 +1253,7 @@ DisplaySafariGameOverText::
 	jp AfterDisplayingTextID
 
 DisplayPokemonFaintedText::
-	ld hl,PokemonFaintedText
+	ld hl, PokemonFaintedText
 	call PrintText
 	jp AfterDisplayingTextID
 
@@ -1262,11 +1262,11 @@ PokemonFaintedText::
 	db "@"
 
 DisplayPlayerBlackedOutText::
-	ld hl,PlayerBlackedOutText
+	ld hl, PlayerBlackedOutText
 	call PrintText
-	ld a,[wd732]
-	res 5,a ; reset forced to use bike bit
-	ld [wd732],a
+	ld a, [wd732]
+	res 5, a ; reset forced to use bike bit
+	ld [wd732], a
 	jp HoldTextDisplayOpen
 
 PlayerBlackedOutText::
@@ -1274,7 +1274,7 @@ PlayerBlackedOutText::
 	db "@"
 
 DisplayRepelWoreOffText::
-	ld hl,RepelWoreOffText
+	ld hl, RepelWoreOffText
 	call PrintText
 	jp AfterDisplayingTextID
 
@@ -1291,22 +1291,22 @@ INCLUDE "engine/menu/start_menu.asm"
 ; OUTPUT:
 ; [wNumSetBits] = number of set bits
 CountSetBits::
-	ld c,0
+	ld c, 0
 .loop
-	ld a,[hli]
-	ld e,a
-	ld d,8
+	ld a, [hli]
+	ld e, a
+	ld d, 8
 .innerLoop ; count how many bits are set in the current byte
 	srl e
-	ld a,0
+	ld a, 0
 	adc c
-	ld c,a
+	ld c, a
 	dec d
-	jr nz,.innerLoop
+	jr nz, .innerLoop
 	dec b
-	jr nz,.loop
-	ld a,c
-	ld [wNumSetBits],a
+	jr nz, .loop
+	ld a, c
+	ld [wNumSetBits], a
 	ret
 
 ; subtracts the amount the player paid from their money
@@ -1316,12 +1316,12 @@ SubtractAmountPaidFromMoney::
 
 ; adds the amount the player sold to their money
 AddAmountSoldToMoney::
-	ld de,wPlayerMoney + 2
-	ld hl,$ffa1 ; total price of items
-	ld c,3 ; length of money in bytes
+	ld de, wPlayerMoney + 2
+	ld hl, $ffa1 ; total price of items
+	ld c, 3 ; length of money in bytes
 	predef AddBCDPredef ; add total price to money
-	ld a,MONEY_BOX
-	ld [wTextBoxID],a
+	ld a, MONEY_BOX
+	ld [wTextBoxID], a
 	call DisplayTextBoxID ; redraw money text box
 	ld a, SFX_PURCHASE
 	call PlaySoundWaitForCurrent
@@ -1333,15 +1333,15 @@ AddAmountSoldToMoney::
 ; [wWhichPokemon] = index (within the inventory) of the item to remove
 ; [wItemQuantity] = quantity to remove
 RemoveItemFromInventory::
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,BANK(RemoveItemFromInventory_)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, BANK(RemoveItemFromInventory_)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	call RemoveItemFromInventory_
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 ; function to add an item (in varying quantities) to the player's bag or PC box
@@ -1352,16 +1352,16 @@ RemoveItemFromInventory::
 ; sets carry flag if successful, unsets carry flag if unsuccessful
 AddItemToInventory::
 	push bc
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,BANK(AddItemToInventory_)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, BANK(AddItemToInventory_)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	call AddItemToInventory_
 	pop bc
-	ld a,b
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, b
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	pop bc
 	ret
 
@@ -1370,80 +1370,80 @@ AddItemToInventory::
 ; [wListPointer] = address of the list (2 bytes)
 DisplayListMenuID::
 	xor a
-	ld [H_AUTOBGTRANSFERENABLED],a ; disable auto-transfer
-	ld a,1
-	ld [hJoy7],a ; joypad state update flag
-	ld a,[wBattleType]
+	ld [H_AUTOBGTRANSFERENABLED], a ; disable auto-transfer
+	ld a, 1
+	ld [hJoy7], a ; joypad state update flag
+	ld a, [wBattleType]
 	and a ; is it the Old Man battle?
-	jr nz,.specialBattleType
-	ld a,$01 ; hardcoded bank
+	jr nz, .specialBattleType
+	ld a, $01 ; hardcoded bank
 	jr .bankswitch
 .specialBattleType ; Old Man battle
 	ld a, BANK(DisplayBattleMenu)
 .bankswitch
 	call BankswitchHome
-	ld hl,wd730
-	set 6,[hl] ; turn off letter printing delay
+	ld hl, wd730
+	set 6, [hl] ; turn off letter printing delay
 	xor a
-	ld [wMenuItemToSwap],a ; 0 means no item is currently being swapped
-	ld [wListCount],a
-	ld a,[wListPointer]
-	ld l,a
-	ld a,[wListPointer + 1]
-	ld h,a ; hl = address of the list
-	ld a,[hl] ; the first byte is the number of entries in the list
-	ld [wListCount],a
-	ld a,LIST_MENU_BOX
-	ld [wTextBoxID],a
+	ld [wMenuItemToSwap], a ; 0 means no item is currently being swapped
+	ld [wListCount], a
+	ld a, [wListPointer]
+	ld l, a
+	ld a, [wListPointer + 1]
+	ld h, a ; hl = address of the list
+	ld a, [hl] ; the first byte is the number of entries in the list
+	ld [wListCount], a
+	ld a, LIST_MENU_BOX
+	ld [wTextBoxID], a
 	call DisplayTextBoxID ; draw the menu text box
 	call UpdateSprites ; disable sprites behind the text box
 ; the code up to .skipMovingSprites appears to be useless
 	coord hl, 4, 2 ; coordinates of upper left corner of menu text box
 	lb de, 9, 14 ; height and width of menu text box
-	ld a,[wListMenuID]
+	ld a, [wListMenuID]
 	and a ; is it a PC pokemon list?
-	jr nz,.skipMovingSprites
+	jr nz, .skipMovingSprites
 	call UpdateSprites
 .skipMovingSprites
-	ld a,1 ; max menu item ID is 1 if the list has less than 2 entries
-	ld [wMenuWatchMovingOutOfBounds],a
-	ld a,[wListCount]
+	ld a, 1 ; max menu item ID is 1 if the list has less than 2 entries
+	ld [wMenuWatchMovingOutOfBounds], a
+	ld a, [wListCount]
 	cp 2 ; does the list have less than 2 entries?
-	jr c,.setMenuVariables
-	ld a,2 ; max menu item ID is 2 if the list has at least 2 entries
+	jr c, .setMenuVariables
+	ld a, 2 ; max menu item ID is 2 if the list has at least 2 entries
 .setMenuVariables
-	ld [wMaxMenuItem],a
-	ld a,4
-	ld [wTopMenuItemY],a
-	ld a,5
-	ld [wTopMenuItemX],a
-	ld a,A_BUTTON | B_BUTTON | SELECT
-	ld [wMenuWatchedKeys],a
-	ld c,10
+	ld [wMaxMenuItem], a
+	ld a, 4
+	ld [wTopMenuItemY], a
+	ld a, 5
+	ld [wTopMenuItemX], a
+	ld a, A_BUTTON | B_BUTTON | SELECT
+	ld [wMenuWatchedKeys], a
+	ld c, 10
 	call DelayFrames
 
 DisplayListMenuIDLoop::
 	xor a
-	ld [H_AUTOBGTRANSFERENABLED],a ; disable transfer
+	ld [H_AUTOBGTRANSFERENABLED], a ; disable transfer
 	call PrintListMenuEntries
-	ld a,1
-	ld [H_AUTOBGTRANSFERENABLED],a ; enable transfer
+	ld a, 1
+	ld [H_AUTOBGTRANSFERENABLED], a ; enable transfer
 	call Delay3
-	ld a,[wBattleType]
+	ld a, [wBattleType]
 	and a ; is it the Old Man battle?
-	jr z,.notOldManBattle
+	jr z, .notOldManBattle
 .oldManBattle
-	ld a,"▶"
+	ld a, "▶"
 	Coorda 5, 4 ; place menu cursor in front of first menu entry
-	ld c,80
+	ld c, 80
 	call DelayFrames
 	xor a
-	ld [wCurrentMenuItem],a
+	ld [wCurrentMenuItem], a
 	coord hl, 5, 4
-	ld a,l
-	ld [wMenuCursorLocation],a
-	ld a,h
-	ld [wMenuCursorLocation + 1],a
+	ld a, l
+	ld [wMenuCursorLocation], a
+	ld a, h
+	ld [wMenuCursorLocation + 1], a
 	jr .buttonAPressed
 .notOldManBattle
 	call LoadGBPal
@@ -1451,231 +1451,231 @@ DisplayListMenuIDLoop::
 	push af
 	call PlaceMenuCursor
 	pop af
-	bit 0,a ; was the A button pressed?
-	jp z,.checkOtherKeys
+	bit 0, a ; was the A button pressed?
+	jp z, .checkOtherKeys
 .buttonAPressed
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	call PlaceUnfilledArrowMenuCursor
 
 ; pointless because both values are overwritten before they are read
-	ld a,$01
-	ld [wMenuExitMethod],a
-	ld [wChosenMenuItem],a
+	ld a, $01
+	ld [wMenuExitMethod], a
+	ld [wChosenMenuItem], a
 
 	xor a
-	ld [wMenuWatchMovingOutOfBounds],a
-	ld a,[wCurrentMenuItem]
-	ld c,a
-	ld a,[wListScrollOffset]
+	ld [wMenuWatchMovingOutOfBounds], a
+	ld a, [wCurrentMenuItem]
+	ld c, a
+	ld a, [wListScrollOffset]
 	add c
-	ld c,a
-	ld a,[wListCount]
+	ld c, a
+	ld a, [wListCount]
 	and a ; is the list empty?
-	jp z,ExitListMenu ; if so, exit the menu
+	jp z, ExitListMenu ; if so, exit the menu
 	dec a
 	cp c ; did the player select Cancel?
-	jp c,ExitListMenu ; if so, exit the menu
-	ld a,c
-	ld [wWhichPokemon],a
-	ld a,[wListMenuID]
+	jp c, ExitListMenu ; if so, exit the menu
+	ld a, c
+	ld [wWhichPokemon], a
+	ld a, [wListMenuID]
 	cp ITEMLISTMENU
-	jr nz,.skipMultiplying
+	jr nz, .skipMultiplying
 ; if it's an item menu
 	sla c ; item entries are 2 bytes long, so multiply by 2
 .skipMultiplying
-	ld a,[wListPointer]
-	ld l,a
-	ld a,[wListPointer + 1]
-	ld h,a
+	ld a, [wListPointer]
+	ld l, a
+	ld a, [wListPointer + 1]
+	ld h, a
 	inc hl ; hl = beginning of list entries
-	ld b,0
-	add hl,bc
-	ld a,[hl]
-	ld [wcf91],a
-	ld a,[wListMenuID]
+	ld b, 0
+	add hl, bc
+	ld a, [hl]
+	ld [wcf91], a
+	ld a, [wListMenuID]
 	and a ; is it a PC pokemon list?
-	jr z,.pokemonList
+	jr z, .pokemonList
 	push hl
 	call GetItemPrice
 	pop hl
-	ld a,[wListMenuID]
+	ld a, [wListMenuID]
 	cp ITEMLISTMENU
-	jr nz,.skipGettingQuantity
+	jr nz, .skipGettingQuantity
 ; if it's an item menu
 	inc hl
-	ld a,[hl] ; a = item quantity
-	ld [wMaxItemQuantity],a
+	ld a, [hl] ; a = item quantity
+	ld [wMaxItemQuantity], a
 .skipGettingQuantity
-	ld a,[wcf91]
-	ld [wd0b5],a
-	ld a,BANK(ItemNames)
-	ld [wPredefBank],a
+	ld a, [wcf91]
+	ld [wd0b5], a
+	ld a, BANK(ItemNames)
+	ld [wPredefBank], a
 	call GetName
 	jr .storeChosenEntry
 .pokemonList
-	ld hl,wPartyCount
-	ld a,[wListPointer]
+	ld hl, wPartyCount
+	ld a, [wListPointer]
 	cp l ; is it a list of party pokemon or box pokemon?
-	ld hl,wPartyMonNicks
-	jr z,.getPokemonName
+	ld hl, wPartyMonNicks
+	jr z, .getPokemonName
 	ld hl, wBoxMonNicks ; box pokemon names
 .getPokemonName
-	ld a,[wWhichPokemon]
+	ld a, [wWhichPokemon]
 	call GetPartyMonName
 .storeChosenEntry ; store the menu entry that the player chose and return
-	ld de,wcd6d
+	ld de, wcd6d
 	call CopyStringToCF4B ; copy name to wcf4b
-	ld a,CHOSE_MENU_ITEM
-	ld [wMenuExitMethod],a
-	ld a,[wCurrentMenuItem]
-	ld [wChosenMenuItem],a
+	ld a, CHOSE_MENU_ITEM
+	ld [wMenuExitMethod], a
+	ld a, [wCurrentMenuItem]
+	ld [wChosenMenuItem], a
 	xor a
-	ld [hJoy7],a ; joypad state update flag
-	ld hl,wd730
-	res 6,[hl] ; turn on letter printing delay
+	ld [hJoy7], a ; joypad state update flag
+	ld hl, wd730
+	res 6, [hl] ; turn on letter printing delay
 	jp BankswitchBack
 .checkOtherKeys ; check B, SELECT, Up, and Down keys
-	bit 1,a ; was the B button pressed?
-	jp nz,ExitListMenu ; if so, exit the menu
-	bit 2,a ; was the select button pressed?
-	jp nz,HandleItemListSwapping ; if so, allow the player to swap menu entries
-	ld b,a
-	bit 7,b ; was Down pressed?
-	ld hl,wListScrollOffset
-	jr z,.upPressed
+	bit 1, a ; was the B button pressed?
+	jp nz, ExitListMenu ; if so, exit the menu
+	bit 2, a ; was the select button pressed?
+	jp nz, HandleItemListSwapping ; if so, allow the player to swap menu entries
+	ld b, a
+	bit 7, b ; was Down pressed?
+	ld hl, wListScrollOffset
+	jr z, .upPressed
 .downPressed
-	ld a,[hl]
+	ld a, [hl]
 	add 3
-	ld b,a
-	ld a,[wListCount]
+	ld b, a
+	ld a, [wListCount]
 	cp b ; will going down scroll past the Cancel button?
-	jp c,DisplayListMenuIDLoop
+	jp c, DisplayListMenuIDLoop
 	inc [hl] ; if not, go down
 	jp DisplayListMenuIDLoop
 .upPressed
-	ld a,[hl]
+	ld a, [hl]
 	and a
-	jp z,DisplayListMenuIDLoop
+	jp z, DisplayListMenuIDLoop
 	dec [hl]
 	jp DisplayListMenuIDLoop
 
 DisplayChooseQuantityMenu::
 ; text box dimensions/coordinates for just quantity
 	coord hl, 15, 9
-	ld b,1 ; height
-	ld c,3 ; width
-	ld a,[wListMenuID]
+	ld b, 1 ; height
+	ld c, 3 ; width
+	ld a, [wListMenuID]
 	cp PRICEDITEMLISTMENU
-	jr nz,.drawTextBox
+	jr nz, .drawTextBox
 ; text box dimensions/coordinates for quantity and price
 	coord hl, 7, 9
-	ld b,1  ; height
-	ld c,11 ; width
+	ld b, 1  ; height
+	ld c, 11 ; width
 .drawTextBox
 	call TextBoxBorder
 	coord hl, 16, 10
-	ld a,[wListMenuID]
+	ld a, [wListMenuID]
 	cp PRICEDITEMLISTMENU
-	jr nz,.printInitialQuantity
+	jr nz, .printInitialQuantity
 	coord hl, 8, 10
 .printInitialQuantity
-	ld de,InitialQuantityText
+	ld de, InitialQuantityText
 	call PlaceString
 	xor a
-	ld [wItemQuantity],a ; initialize current quantity to 0
+	ld [wItemQuantity], a ; initialize current quantity to 0
 	jp .incrementQuantity
 .waitForKeyPressLoop
 	call JoypadLowSensitivity
-	ld a,[hJoyPressed] ; newly pressed buttons
-	bit 0,a ; was the A button pressed?
-	jp nz,.buttonAPressed
-	bit 1,a ; was the B button pressed?
-	jp nz,.buttonBPressed
-	bit 6,a ; was Up pressed?
-	jr nz,.incrementQuantity
-	bit 7,a ; was Down pressed?
-	jr nz,.decrementQuantity
+	ld a, [hJoyPressed] ; newly pressed buttons
+	bit 0, a ; was the A button pressed?
+	jp nz, .buttonAPressed
+	bit 1, a ; was the B button pressed?
+	jp nz, .buttonBPressed
+	bit 6, a ; was Up pressed?
+	jr nz, .incrementQuantity
+	bit 7, a ; was Down pressed?
+	jr nz, .decrementQuantity
 	jr .waitForKeyPressLoop
 .incrementQuantity
-	ld a,[wMaxItemQuantity]
+	ld a, [wMaxItemQuantity]
 	inc a
-	ld b,a
-	ld hl,wItemQuantity ; current quantity
+	ld b, a
+	ld hl, wItemQuantity ; current quantity
 	inc [hl]
-	ld a,[hl]
+	ld a, [hl]
 	cp b
-	jr nz,.handleNewQuantity
+	jr nz, .handleNewQuantity
 ; wrap to 1 if the player goes above the max quantity
-	ld a,1
-	ld [hl],a
+	ld a, 1
+	ld [hl], a
 	jr .handleNewQuantity
 .decrementQuantity
-	ld hl,wItemQuantity ; current quantity
+	ld hl, wItemQuantity ; current quantity
 	dec [hl]
-	jr nz,.handleNewQuantity
+	jr nz, .handleNewQuantity
 ; wrap to the max quantity if the player goes below 1
-	ld a,[wMaxItemQuantity]
-	ld [hl],a
+	ld a, [wMaxItemQuantity]
+	ld [hl], a
 .handleNewQuantity
 	coord hl, 17, 10
-	ld a,[wListMenuID]
+	ld a, [wListMenuID]
 	cp PRICEDITEMLISTMENU
-	jr nz,.printQuantity
+	jr nz, .printQuantity
 .printPrice
-	ld c,$03
-	ld a,[wItemQuantity]
-	ld b,a
-	ld hl,hMoney ; total price
+	ld c, $03
+	ld a, [wItemQuantity]
+	ld b, a
+	ld hl, hMoney ; total price
 ; initialize total price to 0
 	xor a
-	ld [hli],a
-	ld [hli],a
-	ld [hl],a
+	ld [hli], a
+	ld [hli], a
+	ld [hl], a
 .addLoop ; loop to multiply the individual price by the quantity to get the total price
-	ld de,hMoney + 2
-	ld hl,hItemPrice + 2
+	ld de, hMoney + 2
+	ld hl, hItemPrice + 2
 	push bc
 	predef AddBCDPredef ; add the individual price to the current sum
 	pop bc
 	dec b
-	jr nz,.addLoop
-	ld a,[hHalveItemPrices]
+	jr nz, .addLoop
+	ld a, [hHalveItemPrices]
 	and a ; should the price be halved (for selling items)?
-	jr z,.skipHalvingPrice
+	jr z, .skipHalvingPrice
 	xor a
-	ld [hDivideBCDDivisor],a
-	ld [hDivideBCDDivisor + 1],a
-	ld a,$02
-	ld [hDivideBCDDivisor + 2],a
+	ld [hDivideBCDDivisor], a
+	ld [hDivideBCDDivisor + 1], a
+	ld a, $02
+	ld [hDivideBCDDivisor + 2], a
 	predef DivideBCDPredef3 ; halves the price
 ; store the halved price
-	ld a,[hDivideBCDQuotient]
-	ld [hMoney],a
-	ld a,[hDivideBCDQuotient + 1]
-	ld [hMoney + 1],a
-	ld a,[hDivideBCDQuotient + 2]
-	ld [hMoney + 2],a
+	ld a, [hDivideBCDQuotient]
+	ld [hMoney], a
+	ld a, [hDivideBCDQuotient + 1]
+	ld [hMoney + 1], a
+	ld a, [hDivideBCDQuotient + 2]
+	ld [hMoney + 2], a
 .skipHalvingPrice
 	coord hl, 12, 10
-	ld de,SpacesBetweenQuantityAndPriceText
+	ld de, SpacesBetweenQuantityAndPriceText
 	call PlaceString
-	ld de,hMoney ; total price
-	ld c,$a3
+	ld de, hMoney ; total price
+	ld c, $a3
 	call PrintBCDNumber
 	coord hl, 9, 10
 .printQuantity
-	ld de,wItemQuantity ; current quantity
+	ld de, wItemQuantity ; current quantity
 	lb bc, LEADING_ZEROES | 1, 2 ; 1 byte, 2 digits
 	call PrintNumber
 	jp .waitForKeyPressLoop
 .buttonAPressed ; the player chose to make the transaction
 	xor a
-	ld [wMenuItemToSwap],a ; 0 means no item is currently being swapped
+	ld [wMenuItemToSwap], a ; 0 means no item is currently being swapped
 	ret
 .buttonBPressed ; the player chose to cancel the transaction
 	xor a
-	ld [wMenuItemToSwap],a ; 0 means no item is currently being swapped
-	ld a,$ff
+	ld [wMenuItemToSwap], a ; 0 means no item is currently being swapped
+	ld a, $ff
 	ret
 
 InitialQuantityText::
@@ -1685,84 +1685,84 @@ SpacesBetweenQuantityAndPriceText::
 	db "      @"
 
 ExitListMenu::
-	ld a,[wCurrentMenuItem]
-	ld [wChosenMenuItem],a
-	ld a,CANCELLED_MENU
-	ld [wMenuExitMethod],a
-	ld [wMenuWatchMovingOutOfBounds],a
+	ld a, [wCurrentMenuItem]
+	ld [wChosenMenuItem], a
+	ld a, CANCELLED_MENU
+	ld [wMenuExitMethod], a
+	ld [wMenuWatchMovingOutOfBounds], a
 	xor a
-	ld [hJoy7],a
-	ld hl,wd730
-	res 6,[hl]
+	ld [hJoy7], a
+	ld hl, wd730
+	res 6, [hl]
 	call BankswitchBack
 	xor a
-	ld [wMenuItemToSwap],a ; 0 means no item is currently being swapped
+	ld [wMenuItemToSwap], a ; 0 means no item is currently being swapped
 	scf
 	ret
 
 PrintListMenuEntries::
 	coord hl, 5, 3
-	ld b,9
-	ld c,14
+	ld b, 9
+	ld c, 14
 	call ClearScreenArea
-	ld a,[wListPointer]
-	ld e,a
-	ld a,[wListPointer + 1]
-	ld d,a
+	ld a, [wListPointer]
+	ld e, a
+	ld a, [wListPointer + 1]
+	ld d, a
 	inc de ; de = beginning of list entries
-	ld a,[wListScrollOffset]
-	ld c,a
-	ld a,[wListMenuID]
+	ld a, [wListScrollOffset]
+	ld c, a
+	ld a, [wListMenuID]
 	cp ITEMLISTMENU
-	ld a,c
-	jr nz,.skipMultiplying
+	ld a, c
+	jr nz, .skipMultiplying
 ; if it's an item menu
 ; item entries are 2 bytes long, so multiply by 2
 	sla a
 	sla c
 .skipMultiplying
 	add e
-	ld e,a
-	jr nc,.noCarry
+	ld e, a
+	jr nc, .noCarry
 	inc d
 .noCarry
 	coord hl, 6, 4 ; coordinates of first list entry name
-	ld b,4 ; print 4 names
+	ld b, 4 ; print 4 names
 .loop
-	ld a,b
-	ld [wWhichPokemon],a
-	ld a,[de]
-	ld [wd11e],a
+	ld a, b
+	ld [wWhichPokemon], a
+	ld a, [de]
+	ld [wd11e], a
 	cp $ff
-	jp z,.printCancelMenuItem
+	jp z, .printCancelMenuItem
 	push bc
 	push de
 	push hl
 	push hl
 	push de
-	ld a,[wListMenuID]
+	ld a, [wListMenuID]
 	and a
-	jr z,.pokemonPCMenu
+	jr z, .pokemonPCMenu
 	cp MOVESLISTMENU
-	jr z,.movesMenu
+	jr z, .movesMenu
 .itemMenu
 	call GetItemName
 	jr .placeNameString
 .pokemonPCMenu
 	push hl
-	ld hl,wPartyCount
-	ld a,[wListPointer]
+	ld hl, wPartyCount
+	ld a, [wListPointer]
 	cp l ; is it a list of party pokemon or box pokemon?
-	ld hl,wPartyMonNicks
-	jr z,.getPokemonName
+	ld hl, wPartyMonNicks
+	jr z, .getPokemonName
 	ld hl, wBoxMonNicks ; box pokemon names
 .getPokemonName
-	ld a,[wWhichPokemon]
-	ld b,a
-	ld a,4
+	ld a, [wWhichPokemon]
+	ld b, a
+	ld a, 4
 	sub b
-	ld b,a
-	ld a,[wListScrollOffset]
+	ld b, a
+	ld a, [wListScrollOffset]
 	add b
 	call GetPartyMonName
 	pop hl
@@ -1773,90 +1773,90 @@ PrintListMenuEntries::
 	call PlaceString
 	pop de
 	pop hl
-	ld a,[wPrintItemPrices]
+	ld a, [wPrintItemPrices]
 	and a ; should prices be printed?
-	jr z,.skipPrintingItemPrice
+	jr z, .skipPrintingItemPrice
 .printItemPrice
 	push hl
-	ld a,[de]
-	ld de,ItemPrices
-	ld [wcf91],a
+	ld a, [de]
+	ld de, ItemPrices
+	ld [wcf91], a
 	call GetItemPrice ; get price
 	pop hl
 	ld bc, SCREEN_WIDTH + 5 ; 1 row down and 5 columns right
-	add hl,bc
-	ld c,$a3 ; no leading zeroes, right-aligned, print currency symbol, 3 bytes
+	add hl, bc
+	ld c, $a3 ; no leading zeroes, right-aligned, print currency symbol, 3 bytes
 	call PrintBCDNumber
 .skipPrintingItemPrice
-	ld a,[wListMenuID]
+	ld a, [wListMenuID]
 	and a
-	jr nz,.skipPrintingPokemonLevel
+	jr nz, .skipPrintingPokemonLevel
 .printPokemonLevel
-	ld a,[wd11e]
+	ld a, [wd11e]
 	push af
 	push hl
-	ld hl,wPartyCount
-	ld a,[wListPointer]
+	ld hl, wPartyCount
+	ld a, [wListPointer]
 	cp l ; is it a list of party pokemon or box pokemon?
-	ld a,PLAYER_PARTY_DATA
-	jr z,.next
-	ld a,BOX_DATA
+	ld a, PLAYER_PARTY_DATA
+	jr z, .next
+	ld a, BOX_DATA
 .next
-	ld [wMonDataLocation],a
-	ld hl,wWhichPokemon
-	ld a,[hl]
-	ld b,a
-	ld a,$04
+	ld [wMonDataLocation], a
+	ld hl, wWhichPokemon
+	ld a, [hl]
+	ld b, a
+	ld a, $04
 	sub b
-	ld b,a
-	ld a,[wListScrollOffset]
+	ld b, a
+	ld a, [wListScrollOffset]
 	add b
-	ld [hl],a
+	ld [hl], a
 	call LoadMonData
-	ld a,[wMonDataLocation]
+	ld a, [wMonDataLocation]
 	and a ; is it a list of party pokemon or box pokemon?
-	jr z,.skipCopyingLevel
+	jr z, .skipCopyingLevel
 .copyLevel
-	ld a,[wLoadedMonBoxLevel]
-	ld [wLoadedMonLevel],a
+	ld a, [wLoadedMonBoxLevel]
+	ld [wLoadedMonLevel], a
 .skipCopyingLevel
 	pop hl
-	ld bc,$001c
-	add hl,bc
+	ld bc, $001c
+	add hl, bc
 	call PrintLevel
 	pop af
-	ld [wd11e],a
+	ld [wd11e], a
 .skipPrintingPokemonLevel
 	pop hl
 	pop de
 	inc de
-	ld a,[wListMenuID]
+	ld a, [wListMenuID]
 	cp ITEMLISTMENU
-	jr nz,.nextListEntry
+	jr nz, .nextListEntry
 .printItemQuantity
-	ld a,[wd11e]
-	ld [wcf91],a
+	ld a, [wd11e]
+	ld [wcf91], a
 	call IsKeyItem ; check if item is unsellable
-	ld a,[wIsKeyItem]
+	ld a, [wIsKeyItem]
 	and a ; is the item unsellable?
-	jr nz,.skipPrintingItemQuantity ; if so, don't print the quantity
+	jr nz, .skipPrintingItemQuantity ; if so, don't print the quantity
 	push hl
 	ld bc, SCREEN_WIDTH + 8 ; 1 row down and 8 columns right
-	add hl,bc
-	ld a,"×"
-	ld [hli],a
-	ld a,[wd11e]
+	add hl, bc
+	ld a, "×"
+	ld [hli], a
+	ld a, [wd11e]
 	push af
-	ld a,[de]
-	ld [wMaxItemQuantity],a
+	ld a, [de]
+	ld [wMaxItemQuantity], a
 	push de
-	ld de,wd11e
-	ld [de],a
+	ld de, wd11e
+	ld [de], a
 	lb bc, 1, 2
 	call PrintNumber
 	pop de
 	pop af
-	ld [wd11e],a
+	ld [wd11e], a
 	pop hl
 .skipPrintingItemQuantity
 	inc de
@@ -1864,29 +1864,29 @@ PrintListMenuEntries::
 	inc c
 	push bc
 	inc c
-	ld a,[wMenuItemToSwap] ; ID of item chosen for swapping (counts from 1)
+	ld a, [wMenuItemToSwap] ; ID of item chosen for swapping (counts from 1)
 	and a ; is an item being swapped?
-	jr z,.nextListEntry
+	jr z, .nextListEntry
 	sla a
 	cp c ; is it this item?
-	jr nz,.nextListEntry
+	jr nz, .nextListEntry
 	dec hl
-	ld a,$ec ; unfilled right arrow menu cursor to indicate an item being swapped
-	ld [hli],a
+	ld a, $ec ; unfilled right arrow menu cursor to indicate an item being swapped
+	ld [hli], a
 .nextListEntry
-	ld bc,2 * SCREEN_WIDTH ; 2 rows
-	add hl,bc
+	ld bc, 2 * SCREEN_WIDTH ; 2 rows
+	add hl, bc
 	pop bc
 	inc c
 	dec b
-	jp nz,.loop
-	ld bc,-8
-	add hl,bc
-	ld a,"▼"
-	ld [hl],a
+	jp nz, .loop
+	ld bc, -8
+	add hl, bc
+	ld a, "▼"
+	ld [hl], a
 	ret
 .printCancelMenuItem
-	ld de,ListMenuCancelText
+	ld de, ListMenuCancelText
 	jp PlaceString
 
 ListMenuCancelText::
@@ -1894,27 +1894,27 @@ ListMenuCancelText::
 
 GetMonName::
 	push hl
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,BANK(MonsterNames)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
-	ld a,[wd11e]
+	ld a, BANK(MonsterNames)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
+	ld a, [wd11e]
 	dec a
-	ld hl,MonsterNames
-	ld c,10
-	ld b,0
+	ld hl, MonsterNames
+	ld c, 10
+	ld b, 0
 	call AddNTimes
-	ld de,wcd6d
+	ld de, wcd6d
 	push de
-	ld bc,10
+	ld bc, 10
 	call CopyData
-	ld hl,wcd6d + 10
+	ld hl, wcd6d + 10
 	ld [hl], "@"
 	pop de
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	pop hl
 	ret
 
@@ -1923,22 +1923,22 @@ GetItemName::
 ;     starting at wcd6d
 	push hl
 	push bc
-	ld a,[wd11e]
+	ld a, [wd11e]
 	cp HM_01 ; is this a TM/HM?
-	jr nc,.Machine
+	jr nc, .Machine
 
-	ld [wd0b5],a
-	ld a,ITEM_NAME
-	ld [wNameListType],a
-	ld a,BANK(ItemNames)
-	ld [wPredefBank],a
+	ld [wd0b5], a
+	ld a, ITEM_NAME
+	ld [wNameListType], a
+	ld a, BANK(ItemNames)
+	ld [wPredefBank], a
 	call GetName
 	jr .Finish
 
 .Machine
 	call GetMachineName
 .Finish
-	ld de,wcd6d ; pointer to where item name is stored in RAM
+	ld de, wcd6d ; pointer to where item name is stored in RAM
 	pop bc
 	pop hl
 	ret
@@ -1948,48 +1948,48 @@ GetMachineName::
 	push hl
 	push de
 	push bc
-	ld a,[wd11e]
+	ld a, [wd11e]
 	push af
 	cp TM_01 ; is this a TM? [not HM]
-	jr nc,.WriteTM
+	jr nc, .WriteTM
 ; if HM, then write "HM" and add 5 to the item ID, so we can reuse the
 ; TM printing code
 	add 5
-	ld [wd11e],a
-	ld hl,HiddenPrefix ; points to "HM"
-	ld bc,2
+	ld [wd11e], a
+	ld hl, HiddenPrefix ; points to "HM"
+	ld bc, 2
 	jr .WriteMachinePrefix
 .WriteTM
-	ld hl,TechnicalPrefix ; points to "TM"
-	ld bc,2
+	ld hl, TechnicalPrefix ; points to "TM"
+	ld bc, 2
 .WriteMachinePrefix
-	ld de,wcd6d
+	ld de, wcd6d
 	call CopyData
 
 ; now get the machine number and convert it to text
-	ld a,[wd11e]
+	ld a, [wd11e]
 	sub TM_01 - 1
 	ld b, "0"
 .FirstDigit
 	sub 10
-	jr c,.SecondDigit
+	jr c, .SecondDigit
 	inc b
 	jr .FirstDigit
 .SecondDigit
 	add 10
 	push af
-	ld a,b
-	ld [de],a
+	ld a, b
+	ld [de], a
 	inc de
 	pop af
 	ld b, "0"
 	add b
-	ld [de],a
+	ld [de], a
 	inc de
-	ld a,"@"
-	ld [de],a
+	ld a, "@"
+	ld [de], a
 	pop af
-	ld [wd11e],a
+	ld [wd11e], a
 	pop bc
 	pop de
 	pop hl
@@ -2004,7 +2004,7 @@ HiddenPrefix::
 ; Input: a = item ID
 IsItemHM::
 	cp HM_01
-	jr c,.notHM
+	jr c, .notHM
 	cp TM_01
 	ret
 .notHM
@@ -2014,8 +2014,8 @@ IsItemHM::
 ; sets carry if move is an HM, clears carry if move is not an HM
 ; Input: a = move ID
 IsMoveHM::
-	ld hl,HMMoves
-	ld de,1
+	ld hl, HMMoves
+	ld de, 1
 	jp IsInArray
 
 HMMoves::
@@ -2024,22 +2024,22 @@ HMMoves::
 
 GetMoveName::
 	push hl
-	ld a,MOVE_NAME
-	ld [wNameListType],a
-	ld a,[wd11e]
-	ld [wd0b5],a
-	ld a,BANK(MoveNames)
-	ld [wPredefBank],a
+	ld a, MOVE_NAME
+	ld [wNameListType], a
+	ld a, [wd11e]
+	ld [wd0b5], a
+	ld a, BANK(MoveNames)
+	ld [wPredefBank], a
 	call GetName
-	ld de,wcd6d ; pointer to where move name is stored in RAM
+	ld de, wcd6d ; pointer to where move name is stored in RAM
 	pop hl
 	ret
 
 ; reloads text box tile patterns, current map view, and tileset tile patterns
 ReloadMapData::
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,[wCurMap]
+	ld a, [wCurMap]
 	call SwitchToMapRomBank
 	call DisableLCD
 	call LoadTextBoxTilePatterns
@@ -2047,34 +2047,34 @@ ReloadMapData::
 	call LoadTilesetTilePatternData
 	call EnableLCD
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 ; reloads tileset tile patterns
 ReloadTilesetTilePatterns::
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,[wCurMap]
+	ld a, [wCurMap]
 	call SwitchToMapRomBank
 	call DisableLCD
 	call LoadTilesetTilePatternData
 	call EnableLCD
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 ; shows the town map and lets the player choose a destination to fly to
 ChooseFlyDestination::
-	ld hl,wd72e
-	res 4,[hl]
+	ld hl, wd72e
+	res 4, [hl]
 	jpba LoadTownMap_Fly
 
 ; causes the text box to close without waiting for a button press after displaying text
 DisableWaitingAfterTextDisplay::
-	ld a,$01
-	ld [wDoNotWaitForButtonPressAfterDisplayingText],a
+	ld a, $01
+	ld [wDoNotWaitForButtonPressAfterDisplayingText], a
 	ret
 
 ; uses an item
@@ -2098,16 +2098,16 @@ UseItem::
 ; OUTPUT:
 ; clears carry flag if the item is tossed, sets carry flag if not
 TossItem::
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,BANK(TossItem_)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, BANK(TossItem_)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	call TossItem_
 	pop de
-	ld a,d
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, d
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 ; checks if an item is a key item
@@ -2132,16 +2132,16 @@ IsKeyItem::
 ; [wTextBoxID] = text box ID
 ; b, c = y, x cursor position (TWO_OPTION_MENU only)
 DisplayTextBoxID::
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,BANK(DisplayTextBoxID_)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, BANK(DisplayTextBoxID_)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	call DisplayTextBoxID_
 	pop bc
-	ld a,b
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, b
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 ; not zero if an NPC movement script is running, the player character is
@@ -2679,8 +2679,8 @@ FuncTX_BillsPC::
 FuncTX_GameCornerPrizeMenu::
 ; XXX find a better name for this function
 ; special_F7
-	ld b,BANK(CeladonPrizeMenu)
-	ld hl,CeladonPrizeMenu
+	ld b, BANK(CeladonPrizeMenu)
+	ld hl, CeladonPrizeMenu
 bankswitchAndContinue::
 	call Bankswitch
 	jp HoldTextDisplayOpen        ; continue to main text-engine function
@@ -2704,7 +2704,7 @@ IsItemInBag::
 ; else reset zero flag
 ; related to Pokémon Tower and ghosts
 	predef GetQuantityOfItemInBag
-	ld a,b
+	ld a, b
 	and a
 	ret
 
@@ -2738,32 +2738,32 @@ SetSpriteImageIndexAfterSettingFacingDirection::
 ; [wCoordIndex] = if there is match, the matching array index
 ; sets carry if the coordinates are in the array, clears carry if not
 ArePlayerCoordsInArray::
-	ld a,[wYCoord]
-	ld b,a
-	ld a,[wXCoord]
-	ld c,a
+	ld a, [wYCoord]
+	ld b, a
+	ld a, [wXCoord]
+	ld c, a
 	; fallthrough
 
 CheckCoords::
 	xor a
-	ld [wCoordIndex],a
+	ld [wCoordIndex], a
 .loop
-	ld a,[hli]
+	ld a, [hli]
 	cp $ff ; reached terminator?
-	jr z,.notInArray
+	jr z, .notInArray
 	push hl
-	ld hl,wCoordIndex
+	ld hl, wCoordIndex
 	inc [hl]
 	pop hl
 .compareYCoord
 	cp b
-	jr z,.compareXCoord
+	jr z, .compareXCoord
 	inc hl
 	jr .loop
 .compareXCoord
-	ld a,[hli]
+	ld a, [hli]
 	cp c
-	jr nz,.loop
+	jr nz, .loop
 .inArray
 	scf
 	ret
@@ -2857,31 +2857,31 @@ SetSpriteMovementBytesToFE::
 SetSpriteMovementBytesToFF::
 	push hl
 	call GetSpriteMovementByte1Pointer
-	ld [hl],$FF
+	ld [hl], $FF
 	call GetSpriteMovementByte2Pointer
-	ld [hl],$FF ; prevent person from walking?
+	ld [hl], $FF ; prevent person from walking?
 	pop hl
 	ret
 
 ; returns the sprite movement byte 1 pointer for sprite [H_SPRITEINDEX] in hl
 GetSpriteMovementByte1Pointer::
-	ld h,$C2
-	ld a,[H_SPRITEINDEX]
+	ld h, $C2
+	ld a, [H_SPRITEINDEX]
 	swap a
 	add 6
-	ld l,a
+	ld l, a
 	ret
 
 ; returns the sprite movement byte 2 pointer for sprite [H_SPRITEINDEX] in hl
 GetSpriteMovementByte2Pointer::
 	push de
-	ld hl,wMapSpriteData
-	ld a,[H_SPRITEINDEX]
+	ld hl, wMapSpriteData
+	ld a, [H_SPRITEINDEX]
 	dec a
 	add a
-	ld d,0
-	ld e,a
-	add hl,de
+	ld d, 0
+	ld e, a
+	add hl, de
 	pop de
 	ret
 
@@ -2941,37 +2941,37 @@ HasEnoughCoins::
 BankswitchHome::
 ; switches to bank # in a
 ; Only use this when in the home bank!
-	ld [wBankswitchHomeTemp],a
-	ld a,[H_LOADEDROMBANK]
-	ld [wBankswitchHomeSavedROMBank],a
-	ld a,[wBankswitchHomeTemp]
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [wBankswitchHomeTemp], a
+	ld a, [H_LOADEDROMBANK]
+	ld [wBankswitchHomeSavedROMBank], a
+	ld a, [wBankswitchHomeTemp]
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 BankswitchBack::
 ; returns from BankswitchHome
-	ld a,[wBankswitchHomeSavedROMBank]
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, [wBankswitchHomeSavedROMBank]
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 Bankswitch::
 ; self-contained bankswitch, use this when not in the home bank
 ; switches to the bank in b
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,b
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
-	ld bc,.Return
+	ld a, b
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
+	ld bc, .Return
 	push bc
 	jp hl
 .Return
 	pop bc
-	ld a,b
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, b
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 ; displays yes/no choice
@@ -3033,31 +3033,31 @@ MoveSprite_::
 	push bc
 	call GetSpriteMovementByte1Pointer
 	xor a
-	ld [hl],a
-	ld hl,wNPCMovementDirections
-	ld c,0
+	ld [hl], a
+	ld hl, wNPCMovementDirections
+	ld c, 0
 
 .loop
-	ld a,[de]
-	ld [hli],a
+	ld a, [de]
+	ld [hli], a
 	inc de
 	inc c
 	cp $FF ; have we reached the end of the movement data?
-	jr nz,.loop
+	jr nz, .loop
 
-	ld a,c
-	ld [wNPCNumScriptedSteps],a ; number of steps taken
+	ld a, c
+	ld [wNPCNumScriptedSteps], a ; number of steps taken
 
 	pop bc
-	ld hl,wd730
-	set 0,[hl]
+	ld hl, wd730
+	set 0, [hl]
 	pop hl
 	xor a
-	ld [wOverrideSimulatedJoypadStatesMask],a
-	ld [wSimulatedJoypadStatesEnd],a
+	ld [wOverrideSimulatedJoypadStatesMask], a
+	ld [wSimulatedJoypadStatesEnd], a
 	dec a
-	ld [wJoyIgnore],a
-	ld [wWastedByteCD3A],a
+	ld [wJoyIgnore], a
+	ld [wWastedByteCD3A], a
 	ret
 
 ; divides [hDividend2] by [hDivisor2] and stores the quotient in [hQuotient2]
@@ -3198,7 +3198,7 @@ DelayFrames::
 ; wait c frames
 	call DelayFrame
 	dec c
-	jr nz,DelayFrames
+	jr nz, DelayFrames
 	ret
 
 PlaySoundWaitForCurrent::
@@ -3242,82 +3242,82 @@ GetName::
 ; [wPredefBank] = bank of list
 ;
 ; returns pointer to name in de
-	ld a,[wd0b5]
-	ld [wd11e],a
+	ld a, [wd0b5]
+	ld [wd11e], a
 
 	; TM names are separate from item names.
 	; BUG: This applies to all names instead of just items.
 	cp HM_01
 	jp nc, GetMachineName
 
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
 	push hl
 	push bc
 	push de
-	ld a,[wNameListType]    ;List3759_entrySelector
+	ld a, [wNameListType]    ;List3759_entrySelector
 	dec a
-	jr nz,.otherEntries
+	jr nz, .otherEntries
 	;1 = MON_NAMES
 	call GetMonName
-	ld hl,NAME_LENGTH
-	add hl,de
-	ld e,l
-	ld d,h
+	ld hl, NAME_LENGTH
+	add hl, de
+	ld e, l
+	ld d, h
 	jr .gotPtr
 .otherEntries
 	;2-7 = OTHER ENTRIES
-	ld a,[wPredefBank]
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
-	ld a,[wNameListType]    ;VariousNames' entryID
+	ld a, [wPredefBank]
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
+	ld a, [wNameListType]    ;VariousNames' entryID
 	dec a
 	add a
-	ld d,0
-	ld e,a
-	jr nc,.skip
+	ld d, 0
+	ld e, a
+	jr nc, .skip
 	inc d
 .skip
-	ld hl,NamePointers
-	add hl,de
-	ld a,[hli]
-	ld [$ff96],a
-	ld a,[hl]
-	ld [$ff95],a
-	ld a,[$ff95]
-	ld h,a
-	ld a,[$ff96]
-	ld l,a
-	ld a,[wd0b5]
-	ld b,a
-	ld c,0
+	ld hl, NamePointers
+	add hl, de
+	ld a, [hli]
+	ld [$ff96], a
+	ld a, [hl]
+	ld [$ff95], a
+	ld a, [$ff95]
+	ld h, a
+	ld a, [$ff96]
+	ld l, a
+	ld a, [wd0b5]
+	ld b, a
+	ld c, 0
 .nextName
-	ld d,h
-	ld e,l
+	ld d, h
+	ld e, l
 .nextChar
-	ld a,[hli]
+	ld a, [hli]
 	cp "@"
-	jr nz,.nextChar
+	jr nz, .nextChar
 	inc c           ;entry counter
-	ld a,b          ;wanted entry
+	ld a, b          ;wanted entry
 	cp c
-	jr nz,.nextName
-	ld h,d
-	ld l,e
-	ld de,wcd6d
-	ld bc,$0014
+	jr nz, .nextName
+	ld h, d
+	ld l, e
+	ld de, wcd6d
+	ld bc, $0014
 	call CopyData
 .gotPtr
-	ld a,e
-	ld [wUnusedCF8D],a
-	ld a,d
-	ld [wUnusedCF8D + 1],a
+	ld a, e
+	ld [wUnusedCF8D], a
+	ld a, d
+	ld [wUnusedCF8D + 1], a
 	pop de
 	pop bc
 	pop hl
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 GetItemPrice::
@@ -3396,41 +3396,41 @@ CopyString::
 ;    ([hJoy7] == 1, [hJoy6] == 0)
 JoypadLowSensitivity::
 	call Joypad
-	ld a,[hJoy7] ; flag
+	ld a, [hJoy7] ; flag
 	and a ; get all currently pressed buttons or only newly pressed buttons?
-	ld a,[hJoyPressed] ; newly pressed buttons
-	jr z,.storeButtonState
-	ld a,[hJoyHeld] ; all currently pressed buttons
+	ld a, [hJoyPressed] ; newly pressed buttons
+	jr z, .storeButtonState
+	ld a, [hJoyHeld] ; all currently pressed buttons
 .storeButtonState
-	ld [hJoy5],a
-	ld a,[hJoyPressed] ; newly pressed buttons
+	ld [hJoy5], a
+	ld a, [hJoyPressed] ; newly pressed buttons
 	and a ; have any buttons been newly pressed since last check?
-	jr z,.noNewlyPressedButtons
+	jr z, .noNewlyPressedButtons
 .newlyPressedButtons
-	ld a,30 ; half a second delay
-	ld [H_FRAMECOUNTER],a
+	ld a, 30 ; half a second delay
+	ld [H_FRAMECOUNTER], a
 	ret
 .noNewlyPressedButtons
-	ld a,[H_FRAMECOUNTER]
+	ld a, [H_FRAMECOUNTER]
 	and a ; is the delay over?
-	jr z,.delayOver
+	jr z, .delayOver
 .delayNotOver
 	xor a
-	ld [hJoy5],a ; report no buttons as pressed
+	ld [hJoy5], a ; report no buttons as pressed
 	ret
 .delayOver
 ; if [hJoy6] = 0 and A or B is pressed, report no buttons as pressed
-	ld a,[hJoyHeld]
+	ld a, [hJoyHeld]
 	and A_BUTTON | B_BUTTON
-	jr z,.setShortDelay
-	ld a,[hJoy6] ; flag
+	jr z, .setShortDelay
+	ld a, [hJoy6] ; flag
 	and a
-	jr nz,.setShortDelay
+	jr nz, .setShortDelay
 	xor a
-	ld [hJoy5],a
+	ld [hJoy5], a
 .setShortDelay
-	ld a,5 ; 1/12 of a second delay
-	ld [H_FRAMECOUNTER],a
+	ld a, 5 ; 1/12 of a second delay
+	ld [H_FRAMECOUNTER], a
 	ret
 
 WaitForTextScrollButtonPress::
@@ -3503,15 +3503,15 @@ Divide::
 	push hl
 	push de
 	push bc
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,Bank(_Divide)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, Bank(_Divide)
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	call _Divide
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	pop bc
 	pop de
 	pop hl
@@ -3521,42 +3521,42 @@ Divide::
 ; screen unless the player presses the A/B button or the delay is turned off
 ; through the [wd730] or [wLetterPrintingDelayFlags] flags.
 PrintLetterDelay::
-	ld a,[wd730]
-	bit 6,a
+	ld a, [wd730]
+	bit 6, a
 	ret nz
-	ld a,[wLetterPrintingDelayFlags]
-	bit 1,a
+	ld a, [wLetterPrintingDelayFlags]
+	bit 1, a
 	ret z
 	push hl
 	push de
 	push bc
-	ld a,[wLetterPrintingDelayFlags]
-	bit 0,a
-	jr z,.waitOneFrame
-	ld a,[wOptions]
+	ld a, [wLetterPrintingDelayFlags]
+	bit 0, a
+	jr z, .waitOneFrame
+	ld a, [wOptions]
 	and $f
-	ld [H_FRAMECOUNTER],a
+	ld [H_FRAMECOUNTER], a
 	jr .checkButtons
 .waitOneFrame
-	ld a,1
-	ld [H_FRAMECOUNTER],a
+	ld a, 1
+	ld [H_FRAMECOUNTER], a
 .checkButtons
 	call Joypad
-	ld a,[hJoyHeld]
+	ld a, [hJoyHeld]
 .checkAButton
-	bit 0,a ; is the A button pressed?
-	jr z,.checkBButton
+	bit 0, a ; is the A button pressed?
+	jr z, .checkBButton
 	jr .endWait
 .checkBButton
-	bit 1,a ; is the B button pressed?
-	jr z,.buttonsNotPressed
+	bit 1, a ; is the B button pressed?
+	jr z, .buttonsNotPressed
 .endWait
 	call DelayFrame
 	jr .done
 .buttonsNotPressed ; if neither A nor B is pressed
-	ld a,[H_FRAMECOUNTER]
+	ld a, [H_FRAMECOUNTER]
 	and a
-	jr nz,.checkButtons
+	jr nz, .checkButtons
 .done
 	pop bc
 	pop de
@@ -3567,15 +3567,15 @@ PrintLetterDelay::
 ; In other words, the source data is from hl up to but not including bc,
 ; and the destination is de.
 CopyDataUntil::
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
-	ld a,h
+	ld a, h
 	cp b
-	jr nz,CopyDataUntil
-	ld a,l
+	jr nz, CopyDataUntil
+	ld a, l
 	cp c
-	jr nz,CopyDataUntil
+	jr nz, CopyDataUntil
 	ret
 
 ; Function to remove a pokemon from the party or the current box.
@@ -3838,21 +3838,21 @@ AddNTimes::
 	and a
 	ret z
 .loop
-	add hl,bc
+	add hl, bc
 	dec a
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 ; Compare strings, c bytes in length, at de and hl.
 ; Often used to compare big endian numbers in battle calculations.
 StringCmp::
-	ld a,[de]
+	ld a, [de]
 	cp [hl]
 	ret nz
 	inc de
 	inc hl
 	dec c
-	jr nz,StringCmp
+	jr nz, StringCmp
 	ret
 
 ; INPUT:
@@ -3861,228 +3861,228 @@ StringCmp::
 ; c = X coordinate of upper left corner of sprite
 ; de = base address of 4 tile number and attribute pairs
 WriteOAMBlock::
-	ld h,wOAMBuffer / $100
+	ld h, wOAMBuffer / $100
 	swap a ; multiply by 16
-	ld l,a
+	ld l, a
 	call .writeOneEntry ; upper left
 	push bc
-	ld a,8
+	ld a, 8
 	add c
-	ld c,a
+	ld c, a
 	call .writeOneEntry ; upper right
 	pop bc
-	ld a,8
+	ld a, 8
 	add b
-	ld b,a
+	ld b, a
 	call .writeOneEntry ; lower left
-	ld a,8
+	ld a, 8
 	add c
-	ld c,a
+	ld c, a
 	                      ; lower right
 .writeOneEntry
-	ld [hl],b ; Y coordinate
+	ld [hl], b ; Y coordinate
 	inc hl
-	ld [hl],c ; X coordinate
+	ld [hl], c ; X coordinate
 	inc hl
-	ld a,[de] ; tile number
+	ld a, [de] ; tile number
 	inc de
-	ld [hli],a
-	ld a,[de] ; attribute
+	ld [hli], a
+	ld a, [de] ; attribute
 	inc de
-	ld [hli],a
+	ld [hli], a
 	ret
 
 HandleMenuInput::
 	xor a
-	ld [wPartyMenuAnimMonEnabled],a
+	ld [wPartyMenuAnimMonEnabled], a
 
 HandleMenuInput_::
-	ld a,[H_DOWNARROWBLINKCNT1]
+	ld a, [H_DOWNARROWBLINKCNT1]
 	push af
-	ld a,[H_DOWNARROWBLINKCNT2]
+	ld a, [H_DOWNARROWBLINKCNT2]
 	push af ; save existing values on stack
 	xor a
-	ld [H_DOWNARROWBLINKCNT1],a ; blinking down arrow timing value 1
-	ld a,6
-	ld [H_DOWNARROWBLINKCNT2],a ; blinking down arrow timing value 2
+	ld [H_DOWNARROWBLINKCNT1], a ; blinking down arrow timing value 1
+	ld a, 6
+	ld [H_DOWNARROWBLINKCNT2], a ; blinking down arrow timing value 2
 .loop1
 	xor a
-	ld [wAnimCounter],a ; counter for pokemon shaking animation
+	ld [wAnimCounter], a ; counter for pokemon shaking animation
 	call PlaceMenuCursor
 	call Delay3
 .loop2
 	push hl
-	ld a,[wPartyMenuAnimMonEnabled]
+	ld a, [wPartyMenuAnimMonEnabled]
 	and a ; is it a pokemon selection menu?
-	jr z,.getJoypadState
+	jr z, .getJoypadState
 	callba AnimatePartyMon ; shake mini sprite of selected pokemon
 .getJoypadState
 	pop hl
 	call JoypadLowSensitivity
-	ld a,[hJoy5]
+	ld a, [hJoy5]
 	and a ; was a key pressed?
-	jr nz,.keyPressed
+	jr nz, .keyPressed
 	push hl
 	coord hl, 18, 11 ; coordinates of blinking down arrow in some menus
 	call HandleDownArrowBlinkTiming ; blink down arrow (if any)
 	pop hl
-	ld a,[wMenuJoypadPollCount]
+	ld a, [wMenuJoypadPollCount]
 	dec a
-	jr z,.giveUpWaiting
+	jr z, .giveUpWaiting
 	jr .loop2
 .giveUpWaiting
 ; if a key wasn't pressed within the specified number of checks
 	pop af
-	ld [H_DOWNARROWBLINKCNT2],a
+	ld [H_DOWNARROWBLINKCNT2], a
 	pop af
-	ld [H_DOWNARROWBLINKCNT1],a ; restore previous values
+	ld [H_DOWNARROWBLINKCNT1], a ; restore previous values
 	xor a
-	ld [wMenuWrappingEnabled],a ; disable menu wrapping
+	ld [wMenuWrappingEnabled], a ; disable menu wrapping
 	ret
 .keyPressed
 	xor a
-	ld [wCheckFor180DegreeTurn],a
-	ld a,[hJoy5]
-	ld b,a
-	bit 6,a ; pressed Up key?
-	jr z,.checkIfDownPressed
+	ld [wCheckFor180DegreeTurn], a
+	ld a, [hJoy5]
+	ld b, a
+	bit 6, a ; pressed Up key?
+	jr z, .checkIfDownPressed
 .upPressed
-	ld a,[wCurrentMenuItem] ; selected menu item
+	ld a, [wCurrentMenuItem] ; selected menu item
 	and a ; already at the top of the menu?
-	jr z,.alreadyAtTop
+	jr z, .alreadyAtTop
 .notAtTop
 	dec a
-	ld [wCurrentMenuItem],a ; move selected menu item up one space
+	ld [wCurrentMenuItem], a ; move selected menu item up one space
 	jr .checkOtherKeys
 .alreadyAtTop
-	ld a,[wMenuWrappingEnabled]
+	ld a, [wMenuWrappingEnabled]
 	and a ; is wrapping around enabled?
-	jr z,.noWrappingAround
-	ld a,[wMaxMenuItem]
-	ld [wCurrentMenuItem],a ; wrap to the bottom of the menu
+	jr z, .noWrappingAround
+	ld a, [wMaxMenuItem]
+	ld [wCurrentMenuItem], a ; wrap to the bottom of the menu
 	jr .checkOtherKeys
 .checkIfDownPressed
-	bit 7,a
-	jr z,.checkOtherKeys
+	bit 7, a
+	jr z, .checkOtherKeys
 .downPressed
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	inc a
-	ld c,a
-	ld a,[wMaxMenuItem]
+	ld c, a
+	ld a, [wMaxMenuItem]
 	cp c
-	jr nc,.notAtBottom
+	jr nc, .notAtBottom
 .alreadyAtBottom
-	ld a,[wMenuWrappingEnabled]
+	ld a, [wMenuWrappingEnabled]
 	and a ; is wrapping around enabled?
-	jr z,.noWrappingAround
-	ld c,$00 ; wrap from bottom to top
+	jr z, .noWrappingAround
+	ld c, $00 ; wrap from bottom to top
 .notAtBottom
-	ld a,c
-	ld [wCurrentMenuItem],a
+	ld a, c
+	ld [wCurrentMenuItem], a
 .checkOtherKeys
-	ld a,[wMenuWatchedKeys]
+	ld a, [wMenuWatchedKeys]
 	and b ; does the menu care about any of the pressed keys?
-	jp z,.loop1
+	jp z, .loop1
 .checkIfAButtonOrBButtonPressed
-	ld a,[hJoy5]
+	ld a, [hJoy5]
 	and A_BUTTON | B_BUTTON
-	jr z,.skipPlayingSound
+	jr z, .skipPlayingSound
 .AButtonOrBButtonPressed
 	push hl
-	ld hl,wFlags_0xcd60
-	bit 5,[hl]
+	ld hl, wFlags_0xcd60
+	bit 5, [hl]
 	pop hl
-	jr nz,.skipPlayingSound
-	ld a,SFX_PRESS_AB
+	jr nz, .skipPlayingSound
+	ld a, SFX_PRESS_AB
 	call PlaySound
 .skipPlayingSound
 	pop af
-	ld [H_DOWNARROWBLINKCNT2],a
+	ld [H_DOWNARROWBLINKCNT2], a
 	pop af
-	ld [H_DOWNARROWBLINKCNT1],a ; restore previous values
+	ld [H_DOWNARROWBLINKCNT1], a ; restore previous values
 	xor a
-	ld [wMenuWrappingEnabled],a ; disable menu wrapping
-	ld a,[hJoy5]
+	ld [wMenuWrappingEnabled], a ; disable menu wrapping
+	ld a, [hJoy5]
 	ret
 .noWrappingAround
-	ld a,[wMenuWatchMovingOutOfBounds]
+	ld a, [wMenuWatchMovingOutOfBounds]
 	and a ; should we return if the user tried to go past the top or bottom?
-	jr z,.checkOtherKeys
+	jr z, .checkOtherKeys
 	jr .checkIfAButtonOrBButtonPressed
 
 PlaceMenuCursor::
-	ld a,[wTopMenuItemY]
+	ld a, [wTopMenuItemY]
 	and a ; is the y coordinate 0?
-	jr z,.adjustForXCoord
+	jr z, .adjustForXCoord
 	coord hl, 0, 0
-	ld bc,SCREEN_WIDTH
+	ld bc, SCREEN_WIDTH
 .topMenuItemLoop
-	add hl,bc
+	add hl, bc
 	dec a
-	jr nz,.topMenuItemLoop
+	jr nz, .topMenuItemLoop
 .adjustForXCoord
-	ld a,[wTopMenuItemX]
-	ld b,0
-	ld c,a
-	add hl,bc
+	ld a, [wTopMenuItemX]
+	ld b, 0
+	ld c, a
+	add hl, bc
 	push hl
-	ld a,[wLastMenuItem]
+	ld a, [wLastMenuItem]
 	and a ; was the previous menu id 0?
-	jr z,.checkForArrow1
+	jr z, .checkForArrow1
 	push af
-	ld a,[hFlags_0xFFF6]
-	bit 1,a ; is the menu double spaced?
-	jr z,.doubleSpaced1
-	ld bc,20
+	ld a, [hFlags_0xFFF6]
+	bit 1, a ; is the menu double spaced?
+	jr z, .doubleSpaced1
+	ld bc, 20
 	jr .getOldMenuItemScreenPosition
 .doubleSpaced1
-	ld bc,40
+	ld bc, 40
 .getOldMenuItemScreenPosition
 	pop af
 .oldMenuItemLoop
-	add hl,bc
+	add hl, bc
 	dec a
-	jr nz,.oldMenuItemLoop
+	jr nz, .oldMenuItemLoop
 .checkForArrow1
-	ld a,[hl]
-	cp a,"▶" ; was an arrow next to the previously selected menu item?
-	jr nz,.skipClearingArrow
+	ld a, [hl]
+	cp "▶" ; was an arrow next to the previously selected menu item?
+	jr nz, .skipClearingArrow
 .clearArrow
-	ld a,[wTileBehindCursor]
-	ld [hl],a
+	ld a, [wTileBehindCursor]
+	ld [hl], a
 .skipClearingArrow
 	pop hl
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	and a
-	jr z,.checkForArrow2
+	jr z, .checkForArrow2
 	push af
-	ld a,[hFlags_0xFFF6]
-	bit 1,a ; is the menu double spaced?
-	jr z,.doubleSpaced2
-	ld bc,20
+	ld a, [hFlags_0xFFF6]
+	bit 1, a ; is the menu double spaced?
+	jr z, .doubleSpaced2
+	ld bc, 20
 	jr .getCurrentMenuItemScreenPosition
 .doubleSpaced2
-	ld bc,40
+	ld bc, 40
 .getCurrentMenuItemScreenPosition
 	pop af
 .currentMenuItemLoop
-	add hl,bc
+	add hl, bc
 	dec a
-	jr nz,.currentMenuItemLoop
+	jr nz, .currentMenuItemLoop
 .checkForArrow2
-	ld a,[hl]
+	ld a, [hl]
 	cp "▶" ; has the right arrow already been placed?
-	jr z,.skipSavingTile ; if so, don't lose the saved tile
-	ld [wTileBehindCursor],a ; save tile before overwriting with right arrow
+	jr z, .skipSavingTile ; if so, don't lose the saved tile
+	ld [wTileBehindCursor], a ; save tile before overwriting with right arrow
 .skipSavingTile
-	ld a,"▶" ; place right arrow
-	ld [hl],a
-	ld a,l
-	ld [wMenuCursorLocation],a
-	ld a,h
-	ld [wMenuCursorLocation + 1],a
-	ld a,[wCurrentMenuItem]
-	ld [wLastMenuItem],a
+	ld a, "▶" ; place right arrow
+	ld [hl], a
+	ld a, l
+	ld [wMenuCursorLocation], a
+	ld a, h
+	ld [wMenuCursorLocation + 1], a
+	ld a, [wCurrentMenuItem]
+	ld [wLastMenuItem], a
 	ret
 
 ; This is used to mark a menu cursor other than the one currently being
@@ -4090,22 +4090,22 @@ PlaceMenuCursor::
 ; the menu cursor in the parent menu. In the case of swapping items in list,
 ; this is used to mark the item that was first chosen to be swapped.
 PlaceUnfilledArrowMenuCursor::
-	ld b,a
-	ld a,[wMenuCursorLocation]
-	ld l,a
-	ld a,[wMenuCursorLocation + 1]
-	ld h,a
-	ld [hl],$ec ; outline of right arrow
-	ld a,b
+	ld b, a
+	ld a, [wMenuCursorLocation]
+	ld l, a
+	ld a, [wMenuCursorLocation + 1]
+	ld h, a
+	ld [hl], $ec ; outline of right arrow
+	ld a, b
 	ret
 
 ; Replaces the menu cursor with a blank space.
 EraseMenuCursor::
-	ld a,[wMenuCursorLocation]
-	ld l,a
-	ld a,[wMenuCursorLocation + 1]
-	ld h,a
-	ld [hl]," "
+	ld a, [wMenuCursorLocation]
+	ld l, a
+	ld a, [wMenuCursorLocation + 1]
+	ld h, a
+	ld [hl], " "
 	ret
 
 ; This toggles a blinking down arrow at hl on and off after a delay has passed.
@@ -4117,44 +4117,44 @@ EraseMenuCursor::
 ; That allows this to be called without worrying about if a down arrow should
 ; be blinking.
 HandleDownArrowBlinkTiming::
-	ld a,[hl]
-	ld b,a
-	ld a,"▼"
+	ld a, [hl]
+	ld b, a
+	ld a, "▼"
 	cp b
-	jr nz,.downArrowOff
+	jr nz, .downArrowOff
 .downArrowOn
-	ld a,[H_DOWNARROWBLINKCNT1]
+	ld a, [H_DOWNARROWBLINKCNT1]
 	dec a
-	ld [H_DOWNARROWBLINKCNT1],a
+	ld [H_DOWNARROWBLINKCNT1], a
 	ret nz
-	ld a,[H_DOWNARROWBLINKCNT2]
+	ld a, [H_DOWNARROWBLINKCNT2]
 	dec a
-	ld [H_DOWNARROWBLINKCNT2],a
+	ld [H_DOWNARROWBLINKCNT2], a
 	ret nz
-	ld a," "
-	ld [hl],a
-	ld a,$ff
-	ld [H_DOWNARROWBLINKCNT1],a
-	ld a,$06
-	ld [H_DOWNARROWBLINKCNT2],a
+	ld a, " "
+	ld [hl], a
+	ld a, $ff
+	ld [H_DOWNARROWBLINKCNT1], a
+	ld a, $06
+	ld [H_DOWNARROWBLINKCNT2], a
 	ret
 .downArrowOff
-	ld a,[H_DOWNARROWBLINKCNT1]
+	ld a, [H_DOWNARROWBLINKCNT1]
 	and a
 	ret z
 	dec a
-	ld [H_DOWNARROWBLINKCNT1],a
+	ld [H_DOWNARROWBLINKCNT1], a
 	ret nz
 	dec a
-	ld [H_DOWNARROWBLINKCNT1],a
-	ld a,[H_DOWNARROWBLINKCNT2]
+	ld [H_DOWNARROWBLINKCNT1], a
+	ld a, [H_DOWNARROWBLINKCNT2]
 	dec a
-	ld [H_DOWNARROWBLINKCNT2],a
+	ld [H_DOWNARROWBLINKCNT2], a
 	ret nz
-	ld a,$06
-	ld [H_DOWNARROWBLINKCNT2],a
-	ld a,"▼"
-	ld [hl],a
+	ld a, $06
+	ld [H_DOWNARROWBLINKCNT2], a
+	ld a, "▼"
+	ld [hl], a
 	ret
 
 ; The following code either enables or disables the automatic drawing of
@@ -4166,19 +4166,19 @@ EnableAutoTextBoxDrawing::
 	jr AutoTextBoxDrawingCommon
 
 DisableAutoTextBoxDrawing::
-	ld a,$01
+	ld a, $01
 
 AutoTextBoxDrawingCommon::
-	ld [wAutoTextBoxDrawingControl],a
+	ld [wAutoTextBoxDrawingControl], a
 	xor a
-	ld [wDoNotWaitForButtonPressAfterDisplayingText],a ; make DisplayTextID wait for button press
+	ld [wDoNotWaitForButtonPressAfterDisplayingText], a ; make DisplayTextID wait for button press
 	ret
 
 PrintText::
 ; Print text hl at (1, 14).
 	push hl
-	ld a,MESSAGE_BOX
-	ld [wTextBoxID],a
+	ld a, MESSAGE_BOX
+	ld [wTextBoxID], a
 	call DisplayTextBoxID
 	call UpdateSprites
 	call Delay3
@@ -4488,16 +4488,16 @@ GBPalNormal::
 GBPalWhiteOut::
 ; White out all palettes.
 	xor a
-	ld [rBGP],a
-	ld [rOBP0],a
-	ld [rOBP1],a
+	ld [rBGP], a
+	ld [rOBP0], a
+	ld [rOBP1], a
 	ret
 
 
 RunDefaultPaletteCommand::
-	ld b,$ff
+	ld b, $ff
 RunPaletteCommand::
-	ld a,[wOnSGB]
+	ld a, [wOnSGB]
 	and a
 	ret z
 	predef_jump _RunPaletteCommand
@@ -4547,7 +4547,7 @@ GiveItem::
 	ld [wcf91], a
 	ld a, c
 	ld [wItemQuantity], a
-	ld hl,wNumBagItems
+	ld hl, wNumBagItems
 	call AddItemToInventory
 	ret nc
 	call GetItemName

--- a/home/copy2.asm
+++ b/home/copy2.asm
@@ -1,62 +1,62 @@
 FarCopyData2::
 ; Identical to FarCopyData, but uses hROMBankTemp
 ; as temp space instead of wBuffer.
-	ld [hROMBankTemp],a
-	ld a,[H_LOADEDROMBANK]
+	ld [hROMBankTemp], a
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,[hROMBankTemp]
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, [hROMBankTemp]
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	call CopyData
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 FarCopyData3::
 ; Copy bc bytes from a:de to hl.
-	ld [hROMBankTemp],a
-	ld a,[H_LOADEDROMBANK]
+	ld [hROMBankTemp], a
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,[hROMBankTemp]
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, [hROMBankTemp]
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	push hl
 	push de
 	push de
-	ld d,h
-	ld e,l
+	ld d, h
+	ld e, l
 	pop hl
 	call CopyData
 	pop de
 	pop hl
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 FarCopyDataDouble::
 ; Expand bc bytes of 1bpp image data
 ; from a:hl to 2bpp data at de.
-	ld [hROMBankTemp],a
-	ld a,[H_LOADEDROMBANK]
+	ld [hROMBankTemp], a
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,[hROMBankTemp]
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, [hROMBankTemp]
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 .loop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
-	ld [de],a
+	ld [de], a
 	inc de
 	dec bc
-	ld a,c
+	ld a, c
 	or b
-	jr nz,.loop
+	jr nz, .loop
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 CopyVideoData::

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -43,152 +43,152 @@ OverworldLoop::
 OverworldLoopLessDelay::
 	call DelayFrame
 	call LoadGBPal
-	ld a,[wd736]
-	bit 6,a ; jumping down a ledge?
+	ld a, [wd736]
+	bit 6, a ; jumping down a ledge?
 	call nz, HandleMidJump
-	ld a,[wWalkCounter]
+	ld a, [wWalkCounter]
 	and a
-	jp nz,.moveAhead ; if the player sprite has not yet completed the walking animation
+	jp nz, .moveAhead ; if the player sprite has not yet completed the walking animation
 	call JoypadOverworld ; get joypad state (which is possibly simulated)
 	callba SafariZoneCheck
-	ld a,[wSafariZoneGameOver]
+	ld a, [wSafariZoneGameOver]
 	and a
-	jp nz,WarpFound2
-	ld hl,wd72d
-	bit 3,[hl]
-	res 3,[hl]
-	jp nz,WarpFound2
-	ld a,[wd732]
+	jp nz, WarpFound2
+	ld hl, wd72d
+	bit 3, [hl]
+	res 3, [hl]
+	jp nz, WarpFound2
+	ld a, [wd732]
 	and 1 << 4 | 1 << 3 ; fly warp or dungeon warp
-	jp nz,HandleFlyWarpOrDungeonWarp
-	ld a,[wCurOpponent]
+	jp nz, HandleFlyWarpOrDungeonWarp
+	ld a, [wCurOpponent]
 	and a
-	jp nz,.newBattle
-	ld a,[wd730]
-	bit 7,a ; are we simulating button presses?
-	jr z,.notSimulating
-	ld a,[hJoyHeld]
+	jp nz, .newBattle
+	ld a, [wd730]
+	bit 7, a ; are we simulating button presses?
+	jr z, .notSimulating
+	ld a, [hJoyHeld]
 	jr .checkIfStartIsPressed
 .notSimulating
-	ld a,[hJoyPressed]
+	ld a, [hJoyPressed]
 .checkIfStartIsPressed
-	bit 3,a ; start button
-	jr z,.startButtonNotPressed
+	bit 3, a ; start button
+	jr z, .startButtonNotPressed
 ; if START is pressed
 	xor a
-	ld [hSpriteIndexOrTextID],a ; start menu text ID
+	ld [hSpriteIndexOrTextID], a ; start menu text ID
 	jp .displayDialogue
 .startButtonNotPressed
-	bit 0,a ; A button
-	jp z,.checkIfDownButtonIsPressed
+	bit 0, a ; A button
+	jp z, .checkIfDownButtonIsPressed
 ; if A is pressed
-	ld a,[wd730]
-	bit 2,a
-	jp nz,.noDirectionButtonsPressed
+	ld a, [wd730]
+	bit 2, a
+	jp nz, .noDirectionButtonsPressed
 	call IsPlayerCharacterBeingControlledByGame
-	jr nz,.checkForOpponent
+	jr nz, .checkForOpponent
 	call CheckForHiddenObjectOrBookshelfOrCardKeyDoor
-	ld a,[$ffeb]
+	ld a, [$ffeb]
 	and a
-	jp z,OverworldLoop ; jump if a hidden object or bookshelf was found, but not if a card key door was found
+	jp z, OverworldLoop ; jump if a hidden object or bookshelf was found, but not if a card key door was found
 	call IsSpriteOrSignInFrontOfPlayer
-	ld a,[hSpriteIndexOrTextID]
+	ld a, [hSpriteIndexOrTextID]
 	and a
-	jp z,OverworldLoop
+	jp z, OverworldLoop
 .displayDialogue
 	predef GetTileAndCoordsInFrontOfPlayer
 	call UpdateSprites
-	ld a,[wFlags_0xcd60]
-	bit 2,a
-	jr nz,.checkForOpponent
-	bit 0,a
-	jr nz,.checkForOpponent
+	ld a, [wFlags_0xcd60]
+	bit 2, a
+	jr nz, .checkForOpponent
+	bit 0, a
+	jr nz, .checkForOpponent
 	aCoord 8, 9
-	ld [wTilePlayerStandingOn],a ; unused?
+	ld [wTilePlayerStandingOn], a ; unused?
 	call DisplayTextID ; display either the start menu or the NPC/sign text
-	ld a,[wEnteringCableClub]
+	ld a, [wEnteringCableClub]
 	and a
-	jr z,.checkForOpponent
+	jr z, .checkForOpponent
 	dec a
-	ld a,0
-	ld [wEnteringCableClub],a
-	jr z,.changeMap
+	ld a, 0
+	ld [wEnteringCableClub], a
+	jr z, .changeMap
 ; XXX can this code be reached?
 	predef LoadSAV
-	ld a,[wCurMap]
-	ld [wDestinationMap],a
+	ld a, [wCurMap]
+	ld [wDestinationMap], a
 	call SpecialWarpIn
-	ld a,[wCurMap]
+	ld a, [wCurMap]
 	call SwitchToMapRomBank ; switch to the ROM bank of the current map
-	ld hl,wCurMapTileset
-	set 7,[hl]
+	ld hl, wCurMapTileset
+	set 7, [hl]
 .changeMap
 	jp EnterMap
 .checkForOpponent
-	ld a,[wCurOpponent]
+	ld a, [wCurOpponent]
 	and a
-	jp nz,.newBattle
+	jp nz, .newBattle
 	jp OverworldLoop
 .noDirectionButtonsPressed
-	ld hl,wFlags_0xcd60
-	res 2,[hl]
+	ld hl, wFlags_0xcd60
+	res 2, [hl]
 	call UpdateSprites
 	ld a, 1
-	ld [wCheckFor180DegreeTurn],a
-	ld a,[wPlayerMovingDirection] ; the direction that was pressed last time
+	ld [wCheckFor180DegreeTurn], a
+	ld a, [wPlayerMovingDirection] ; the direction that was pressed last time
 	and a
-	jp z,OverworldLoop
+	jp z, OverworldLoop
 ; if a direction was pressed last time
-	ld [wPlayerLastStopDirection],a ; save the last direction
+	ld [wPlayerLastStopDirection], a ; save the last direction
 	xor a
-	ld [wPlayerMovingDirection],a ; zero the direction
+	ld [wPlayerMovingDirection], a ; zero the direction
 	jp OverworldLoop
 
 .checkIfDownButtonIsPressed
-	ld a,[hJoyHeld] ; current joypad state
-	bit 7,a ; down button
-	jr z,.checkIfUpButtonIsPressed
-	ld a,1
-	ld [wSpriteStateData1 + 3],a ; delta Y
-	ld a,PLAYER_DIR_DOWN
+	ld a, [hJoyHeld] ; current joypad state
+	bit 7, a ; down button
+	jr z, .checkIfUpButtonIsPressed
+	ld a, 1
+	ld [wSpriteStateData1 + 3], a ; delta Y
+	ld a, PLAYER_DIR_DOWN
 	jr .handleDirectionButtonPress
 
 .checkIfUpButtonIsPressed
-	bit 6,a ; up button
-	jr z,.checkIfLeftButtonIsPressed
-	ld a,-1
-	ld [wSpriteStateData1 + 3],a ; delta Y
-	ld a,PLAYER_DIR_UP
+	bit 6, a ; up button
+	jr z, .checkIfLeftButtonIsPressed
+	ld a, -1
+	ld [wSpriteStateData1 + 3], a ; delta Y
+	ld a, PLAYER_DIR_UP
 	jr .handleDirectionButtonPress
 
 .checkIfLeftButtonIsPressed
-	bit 5,a ; left button
-	jr z,.checkIfRightButtonIsPressed
-	ld a,-1
-	ld [wSpriteStateData1 + 5],a ; delta X
-	ld a,PLAYER_DIR_LEFT
+	bit 5, a ; left button
+	jr z, .checkIfRightButtonIsPressed
+	ld a, -1
+	ld [wSpriteStateData1 + 5], a ; delta X
+	ld a, PLAYER_DIR_LEFT
 	jr .handleDirectionButtonPress
 
 .checkIfRightButtonIsPressed
-	bit 4,a ; right button
-	jr z,.noDirectionButtonsPressed
+	bit 4, a ; right button
+	jr z, .noDirectionButtonsPressed
 	ld a, 1
-	ld [wSpriteStateData1 + 5],a ; delta X
+	ld [wSpriteStateData1 + 5], a ; delta X
 
 
 .handleDirectionButtonPress
-	ld [wPlayerDirection],a ; new direction
-	ld a,[wd730]
-	bit 7,a ; are we simulating button presses?
-	jr nz,.noDirectionChange ; ignore direction changes if we are
-	ld a,[wCheckFor180DegreeTurn]
+	ld [wPlayerDirection], a ; new direction
+	ld a, [wd730]
+	bit 7, a ; are we simulating button presses?
+	jr nz, .noDirectionChange ; ignore direction changes if we are
+	ld a, [wCheckFor180DegreeTurn]
 	and a
-	jr z,.noDirectionChange
-	ld a,[wPlayerDirection] ; new direction
-	ld b,a
-	ld a,[wPlayerLastStopDirection] ; old direction
+	jr z, .noDirectionChange
+	ld a, [wPlayerDirection] ; new direction
+	ld b, a
+	ld a, [wPlayerLastStopDirection] ; old direction
 	cp b
-	jr z,.noDirectionChange
+	jr z, .noDirectionChange
 ; Check whether the player did a 180-degree turn.
 ; It appears that this code was supposed to show the player rotate by having
 ; the player's sprite face an intermediate direction before facing the opposite
@@ -199,175 +199,175 @@ OverworldLoopLessDelay::
 ; direction is set for V-blank to occur while the direction is still set.
 	swap a ; put old direction in upper half
 	or b ; put new direction in lower half
-	cp a,(PLAYER_DIR_DOWN << 4) | PLAYER_DIR_UP ; change dir from down to up
-	jr nz,.notDownToUp
-	ld a,PLAYER_DIR_LEFT
-	ld [wPlayerMovingDirection],a
+	cp (PLAYER_DIR_DOWN << 4) | PLAYER_DIR_UP ; change dir from down to up
+	jr nz, .notDownToUp
+	ld a, PLAYER_DIR_LEFT
+	ld [wPlayerMovingDirection], a
 	jr .holdIntermediateDirectionLoop
 .notDownToUp
-	cp a,(PLAYER_DIR_UP << 4) | PLAYER_DIR_DOWN ; change dir from up to down
-	jr nz,.notUpToDown
-	ld a,PLAYER_DIR_RIGHT
-	ld [wPlayerMovingDirection],a
+	cp (PLAYER_DIR_UP << 4) | PLAYER_DIR_DOWN ; change dir from up to down
+	jr nz, .notUpToDown
+	ld a, PLAYER_DIR_RIGHT
+	ld [wPlayerMovingDirection], a
 	jr .holdIntermediateDirectionLoop
 .notUpToDown
-	cp a,(PLAYER_DIR_RIGHT << 4) | PLAYER_DIR_LEFT ; change dir from right to left
-	jr nz,.notRightToLeft
-	ld a,PLAYER_DIR_DOWN
-	ld [wPlayerMovingDirection],a
+	cp (PLAYER_DIR_RIGHT << 4) | PLAYER_DIR_LEFT ; change dir from right to left
+	jr nz, .notRightToLeft
+	ld a, PLAYER_DIR_DOWN
+	ld [wPlayerMovingDirection], a
 	jr .holdIntermediateDirectionLoop
 .notRightToLeft
-	cp a,(PLAYER_DIR_LEFT << 4) | PLAYER_DIR_RIGHT ; change dir from left to right
-	jr nz,.holdIntermediateDirectionLoop
-	ld a,PLAYER_DIR_UP
-	ld [wPlayerMovingDirection],a
+	cp (PLAYER_DIR_LEFT << 4) | PLAYER_DIR_RIGHT ; change dir from left to right
+	jr nz, .holdIntermediateDirectionLoop
+	ld a, PLAYER_DIR_UP
+	ld [wPlayerMovingDirection], a
 .holdIntermediateDirectionLoop
-	ld hl,wFlags_0xcd60
-	set 2,[hl]
-	ld hl,wCheckFor180DegreeTurn
+	ld hl, wFlags_0xcd60
+	set 2, [hl]
+	ld hl, wCheckFor180DegreeTurn
 	dec [hl]
-	jr nz,.holdIntermediateDirectionLoop
-	ld a,[wPlayerDirection]
-	ld [wPlayerMovingDirection],a
+	jr nz, .holdIntermediateDirectionLoop
+	ld a, [wPlayerDirection]
+	ld [wPlayerMovingDirection], a
 	call NewBattle
-	jp c,.battleOccurred
+	jp c, .battleOccurred
 	jp OverworldLoop
 
 .noDirectionChange
-	ld a,[wPlayerDirection] ; current direction
-	ld [wPlayerMovingDirection],a ; save direction
+	ld a, [wPlayerDirection] ; current direction
+	ld [wPlayerMovingDirection], a ; save direction
 	call UpdateSprites
-	ld a,[wWalkBikeSurfState]
+	ld a, [wWalkBikeSurfState]
 	cp $02 ; surfing
-	jr z,.surfing
+	jr z, .surfing
 ; not surfing
 	call CollisionCheckOnLand
-	jr nc,.noCollision
+	jr nc, .noCollision
 ; collision occurred
 	push hl
-	ld hl,wd736
-	bit 2,[hl] ; standing on warp flag
+	ld hl, wd736
+	bit 2, [hl] ; standing on warp flag
 	pop hl
-	jp z,OverworldLoop
+	jp z, OverworldLoop
 ; collision occurred while standing on a warp
 	push hl
 	call ExtraWarpCheck ; sets carry if there is a potential to warp
 	pop hl
-	jp c,CheckWarpsCollision
+	jp c, CheckWarpsCollision
 	jp OverworldLoop
 
 .surfing
 	call CollisionCheckOnWater
-	jp c,OverworldLoop
+	jp c, OverworldLoop
 
 .noCollision
-	ld a,$08
-	ld [wWalkCounter],a
+	ld a, $08
+	ld [wWalkCounter], a
 	jr .moveAhead2
 
 .moveAhead
-	ld a,[wd736]
-	bit 7,a
-	jr z,.noSpinning
+	ld a, [wd736]
+	bit 7, a
+	jr z, .noSpinning
 	callba LoadSpinnerArrowTiles
 .noSpinning
 	call UpdateSprites
 
 .moveAhead2
-	ld hl,wFlags_0xcd60
-	res 2,[hl]
-	ld a,[wWalkBikeSurfState]
+	ld hl, wFlags_0xcd60
+	res 2, [hl]
+	ld a, [wWalkBikeSurfState]
 	dec a ; riding a bike?
-	jr nz,.normalPlayerSpriteAdvancement
-	ld a,[wd736]
-	bit 6,a ; jumping a ledge?
-	jr nz,.normalPlayerSpriteAdvancement
+	jr nz, .normalPlayerSpriteAdvancement
+	ld a, [wd736]
+	bit 6, a ; jumping a ledge?
+	jr nz, .normalPlayerSpriteAdvancement
 	call DoBikeSpeedup
 .normalPlayerSpriteAdvancement
 	call AdvancePlayerSprite
-	ld a,[wWalkCounter]
+	ld a, [wWalkCounter]
 	and a
-	jp nz,CheckMapConnections ; it seems like this check will never succeed (the other place where CheckMapConnections is run works)
+	jp nz, CheckMapConnections ; it seems like this check will never succeed (the other place where CheckMapConnections is run works)
 ; walking animation finished
-	ld a,[wd730]
-	bit 7,a
-	jr nz,.doneStepCounting ; if button presses are being simulated, don't count steps
+	ld a, [wd730]
+	bit 7, a
+	jr nz, .doneStepCounting ; if button presses are being simulated, don't count steps
 ; step counting
-	ld hl,wStepCounter
+	ld hl, wStepCounter
 	dec [hl]
-	ld a,[wd72c]
-	bit 0,a
-	jr z,.doneStepCounting
-	ld hl,wNumberOfNoRandomBattleStepsLeft
+	ld a, [wd72c]
+	bit 0, a
+	jr z, .doneStepCounting
+	ld hl, wNumberOfNoRandomBattleStepsLeft
 	dec [hl]
-	jr nz,.doneStepCounting
-	ld hl,wd72c
-	res 0,[hl] ; indicate that the player has stepped thrice since the last battle
+	jr nz, .doneStepCounting
+	ld hl, wd72c
+	res 0, [hl] ; indicate that the player has stepped thrice since the last battle
 .doneStepCounting
 	CheckEvent EVENT_IN_SAFARI_ZONE
-	jr z,.notSafariZone
+	jr z, .notSafariZone
 	callba SafariZoneCheckSteps
-	ld a,[wSafariZoneGameOver]
+	ld a, [wSafariZoneGameOver]
 	and a
-	jp nz,WarpFound2
+	jp nz, WarpFound2
 .notSafariZone
-	ld a,[wIsInBattle]
+	ld a, [wIsInBattle]
 	and a
-	jp nz,CheckWarpsNoCollision
+	jp nz, CheckWarpsNoCollision
 	predef ApplyOutOfBattlePoisonDamage ; also increment daycare mon exp
-	ld a,[wOutOfBattleBlackout]
+	ld a, [wOutOfBattleBlackout]
 	and a
-	jp nz,HandleBlackOut ; if all pokemon fainted
+	jp nz, HandleBlackOut ; if all pokemon fainted
 .newBattle
 	call NewBattle
-	ld hl,wd736
-	res 2,[hl] ; standing on warp flag
-	jp nc,CheckWarpsNoCollision ; check for warps if there was no battle
+	ld hl, wd736
+	res 2, [hl] ; standing on warp flag
+	jp nc, CheckWarpsNoCollision ; check for warps if there was no battle
 .battleOccurred
-	ld hl,wd72d
-	res 6,[hl]
-	ld hl,wFlags_D733
-	res 3,[hl]
-	ld hl,wCurrentMapScriptFlags
-	set 5,[hl]
-	set 6,[hl]
+	ld hl, wd72d
+	res 6, [hl]
+	ld hl, wFlags_D733
+	res 3, [hl]
+	ld hl, wCurrentMapScriptFlags
+	set 5, [hl]
+	set 6, [hl]
 	xor a
-	ld [hJoyHeld],a
-	ld a,[wCurMap]
+	ld [hJoyHeld], a
+	ld a, [wCurMap]
 	cp CINNABAR_GYM
-	jr nz,.notCinnabarGym
+	jr nz, .notCinnabarGym
 	SetEvent EVENT_2A7
 .notCinnabarGym
-	ld hl,wd72e
-	set 5,[hl]
-	ld a,[wCurMap]
+	ld hl, wd72e
+	set 5, [hl]
+	ld a, [wCurMap]
 	cp OAKS_LAB
-	jp z,.noFaintCheck ; no blacking out if the player lost to the rival in Oak's lab
+	jp z, .noFaintCheck ; no blacking out if the player lost to the rival in Oak's lab
 	callab AnyPartyAlive
-	ld a,d
+	ld a, d
 	and a
-	jr z,.allPokemonFainted
+	jr z, .allPokemonFainted
 .noFaintCheck
-	ld c,10
+	ld c, 10
 	call DelayFrames
 	jp EnterMap
 .allPokemonFainted
-	ld a,$ff
-	ld [wIsInBattle],a
+	ld a, $ff
+	ld [wIsInBattle], a
 	call RunMapScript
 	jp HandleBlackOut
 
 ; function to determine if there will be a battle and execute it (either a trainer battle or wild battle)
 ; sets carry if a battle occurred and unsets carry if not
 NewBattle::
-	ld a,[wd72d]
-	bit 4,a
-	jr nz,.noBattle
+	ld a, [wd72d]
+	bit 4, a
+	jr nz, .noBattle
 	call IsPlayerCharacterBeingControlledByGame
-	jr nz,.noBattle ; no battle if the player character is under the game's control
-	ld a,[wd72e]
-	bit 4,a
-	jr nz,.noBattle
+	jr nz, .noBattle ; no battle if the player character is under the game's control
+	ld a, [wd72e]
+	bit 4, a
+	jr nz, .noBattle
 	jpba InitBattle
 .noBattle
 	and a
@@ -375,13 +375,13 @@ NewBattle::
 
 ; function to make bikes twice as fast as walking
 DoBikeSpeedup::
-	ld a,[wNPCMovementScriptPointerTableNum]
+	ld a, [wNPCMovementScriptPointerTableNum]
 	and a
 	ret nz
-	ld a,[wCurMap]
+	ld a, [wCurMap]
 	cp ROUTE_17 ; Cycling Road
-	jr nz,.goFaster
-	ld a,[hJoyHeld]
+	jr nz, .goFaster
+	ld a, [hJoyHeld]
 	and D_UP | D_LEFT | D_RIGHT
 	ret nz
 .goFaster
@@ -389,73 +389,73 @@ DoBikeSpeedup::
 
 ; check if the player has stepped onto a warp after having not collided
 CheckWarpsNoCollision::
-	ld a,[wNumberOfWarps]
+	ld a, [wNumberOfWarps]
 	and a
-	jp z,CheckMapConnections
-	ld a,[wNumberOfWarps]
-	ld b,0
-	ld c,a
-	ld a,[wYCoord]
-	ld d,a
-	ld a,[wXCoord]
-	ld e,a
-	ld hl,wWarpEntries
+	jp z, CheckMapConnections
+	ld a, [wNumberOfWarps]
+	ld b, 0
+	ld c, a
+	ld a, [wYCoord]
+	ld d, a
+	ld a, [wXCoord]
+	ld e, a
+	ld hl, wWarpEntries
 CheckWarpsNoCollisionLoop::
-	ld a,[hli] ; check if the warp's Y position matches
+	ld a, [hli] ; check if the warp's Y position matches
 	cp d
-	jr nz,CheckWarpsNoCollisionRetry1
-	ld a,[hli] ; check if the warp's X position matches
+	jr nz, CheckWarpsNoCollisionRetry1
+	ld a, [hli] ; check if the warp's X position matches
 	cp e
-	jr nz,CheckWarpsNoCollisionRetry2
+	jr nz, CheckWarpsNoCollisionRetry2
 ; if a match was found
 	push hl
 	push bc
-	ld hl,wd736
-	set 2,[hl] ; standing on warp flag
+	ld hl, wd736
+	set 2, [hl] ; standing on warp flag
 	callba IsPlayerStandingOnDoorTileOrWarpTile
 	pop bc
 	pop hl
-	jr c,WarpFound1 ; jump if standing on door or warp
+	jr c, WarpFound1 ; jump if standing on door or warp
 	push hl
 	push bc
 	call ExtraWarpCheck
 	pop bc
 	pop hl
-	jr nc,CheckWarpsNoCollisionRetry2
+	jr nc, CheckWarpsNoCollisionRetry2
 ; if the extra check passed
-	ld a,[wFlags_D733]
-	bit 2,a
-	jr nz,WarpFound1
+	ld a, [wFlags_D733]
+	bit 2, a
+	jr nz, WarpFound1
 	push de
 	push bc
 	call Joypad
 	pop bc
 	pop de
-	ld a,[hJoyHeld]
+	ld a, [hJoyHeld]
 	and D_DOWN | D_UP | D_LEFT | D_RIGHT
-	jr z,CheckWarpsNoCollisionRetry2 ; if directional buttons aren't being pressed, do not pass through the warp
+	jr z, CheckWarpsNoCollisionRetry2 ; if directional buttons aren't being pressed, do not pass through the warp
 	jr WarpFound1
 
 ; check if the player has stepped onto a warp after having collided
 CheckWarpsCollision::
-	ld a,[wNumberOfWarps]
-	ld c,a
-	ld hl,wWarpEntries
+	ld a, [wNumberOfWarps]
+	ld c, a
+	ld hl, wWarpEntries
 .loop
-	ld a,[hli] ; Y coordinate of warp
-	ld b,a
-	ld a,[wYCoord]
+	ld a, [hli] ; Y coordinate of warp
+	ld b, a
+	ld a, [wYCoord]
 	cp b
-	jr nz,.retry1
-	ld a,[hli] ; X coordinate of warp
-	ld b,a
-	ld a,[wXCoord]
+	jr nz, .retry1
+	ld a, [hli] ; X coordinate of warp
+	ld b, a
+	ld a, [wXCoord]
 	cp b
-	jr nz,.retry2
-	ld a,[hli]
-	ld [wDestinationWarpID],a
-	ld a,[hl]
-	ld [hWarpDestinationMap],a
+	jr nz, .retry2
+	ld a, [hli]
+	ld [wDestinationWarpID], a
+	ld a, [hl]
+	ld [hWarpDestinationMap], a
 	jr WarpFound2
 .retry1
 	inc hl
@@ -463,7 +463,7 @@ CheckWarpsCollision::
 	inc hl
 	inc hl
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 	jp OverworldLoop
 
 CheckWarpsNoCollisionRetry1::
@@ -474,30 +474,30 @@ CheckWarpsNoCollisionRetry2::
 	jp ContinueCheckWarpsNoCollisionLoop
 
 WarpFound1::
-	ld a,[hli]
-	ld [wDestinationWarpID],a
-	ld a,[hli]
-	ld [hWarpDestinationMap],a
+	ld a, [hli]
+	ld [wDestinationWarpID], a
+	ld a, [hli]
+	ld [hWarpDestinationMap], a
 
 WarpFound2::
-	ld a,[wNumberOfWarps]
+	ld a, [wNumberOfWarps]
 	sub c
-	ld [wWarpedFromWhichWarp],a ; save ID of used warp
-	ld a,[wCurMap]
-	ld [wWarpedFromWhichMap],a
+	ld [wWarpedFromWhichWarp], a ; save ID of used warp
+	ld a, [wCurMap]
+	ld [wWarpedFromWhichMap], a
 	call CheckIfInOutsideMap
-	jr nz,.indoorMaps
+	jr nz, .indoorMaps
 ; this is for handling "outside" maps that can't have the 0xFF destination map
-	ld a,[wCurMap]
-	ld [wLastMap],a
-	ld a,[wCurMapWidth]
-	ld [wUnusedD366],a ; not read
-	ld a,[hWarpDestinationMap]
-	ld [wCurMap],a
+	ld a, [wCurMap]
+	ld [wLastMap], a
+	ld a, [wCurMapWidth]
+	ld [wUnusedD366], a ; not read
+	ld a, [hWarpDestinationMap]
+	ld [wCurMap], a
 	cp ROCK_TUNNEL_1
-	jr nz,.notRockTunnel
-	ld a,$06
-	ld [wMapPalOffset],a
+	jr nz, .notRockTunnel
+	ld a, $06
+	ld [wMapPalOffset], a
 	call GBFadeOutToBlack
 .notRockTunnel
 	call PlayMapChangeSound
@@ -506,172 +506,172 @@ WarpFound2::
 ; for maps that can have the 0xFF destination map, which means to return to the outside map
 ; not all these maps are necessarily indoors, though
 .indoorMaps
-	ld a,[hWarpDestinationMap] ; destination map
+	ld a, [hWarpDestinationMap] ; destination map
 	cp $ff
-	jr z,.goBackOutside
+	jr z, .goBackOutside
 ; if not going back to the previous map
-	ld [wCurMap],a
+	ld [wCurMap], a
 	callba IsPlayerStandingOnWarpPadOrHole
-	ld a,[wStandingOnWarpPadOrHole]
+	ld a, [wStandingOnWarpPadOrHole]
 	dec a ; is the player on a warp pad?
-	jr nz,.notWarpPad
+	jr nz, .notWarpPad
 ; if the player is on a warp pad
-	ld hl,wd732
-	set 3,[hl]
+	ld hl, wd732
+	set 3, [hl]
 	call LeaveMapAnim
 	jr .skipMapChangeSound
 .notWarpPad
 	call PlayMapChangeSound
 .skipMapChangeSound
-	ld hl,wd736
-	res 0,[hl]
-	res 1,[hl]
+	ld hl, wd736
+	res 0, [hl]
+	res 1, [hl]
 	jr .done
 .goBackOutside
-	ld a,[wLastMap]
-	ld [wCurMap],a
+	ld a, [wLastMap]
+	ld [wCurMap], a
 	call PlayMapChangeSound
 	xor a
-	ld [wMapPalOffset],a
+	ld [wMapPalOffset], a
 .done
-	ld hl,wd736
-	set 0,[hl] ; have the player's sprite step out from the door (if there is one)
+	ld hl, wd736
+	set 0, [hl] ; have the player's sprite step out from the door (if there is one)
 	call IgnoreInputForHalfSecond
 	jp EnterMap
 
 ContinueCheckWarpsNoCollisionLoop::
 	inc b ; increment warp number
 	dec c ; decrement number of warps
-	jp nz,CheckWarpsNoCollisionLoop
+	jp nz, CheckWarpsNoCollisionLoop
 
 ; if no matching warp was found
 CheckMapConnections::
 .checkWestMap
-	ld a,[wXCoord]
+	ld a, [wXCoord]
 	cp $ff
-	jr nz,.checkEastMap
-	ld a,[wMapConn3Ptr]
-	ld [wCurMap],a
-	ld a,[wWestConnectedMapXAlignment] ; new X coordinate upon entering west map
-	ld [wXCoord],a
-	ld a,[wYCoord]
-	ld c,a
-	ld a,[wWestConnectedMapYAlignment] ; Y adjustment upon entering west map
+	jr nz, .checkEastMap
+	ld a, [wMapConn3Ptr]
+	ld [wCurMap], a
+	ld a, [wWestConnectedMapXAlignment] ; new X coordinate upon entering west map
+	ld [wXCoord], a
+	ld a, [wYCoord]
+	ld c, a
+	ld a, [wWestConnectedMapYAlignment] ; Y adjustment upon entering west map
 	add c
-	ld c,a
-	ld [wYCoord],a
-	ld a,[wWestConnectedMapViewPointer] ; pointer to upper left corner of map without adjustment for Y position
-	ld l,a
-	ld a,[wWestConnectedMapViewPointer + 1]
-	ld h,a
+	ld c, a
+	ld [wYCoord], a
+	ld a, [wWestConnectedMapViewPointer] ; pointer to upper left corner of map without adjustment for Y position
+	ld l, a
+	ld a, [wWestConnectedMapViewPointer + 1]
+	ld h, a
 	srl c
-	jr z,.savePointer1
+	jr z, .savePointer1
 .pointerAdjustmentLoop1
-	ld a,[wWestConnectedMapWidth] ; width of connected map
+	ld a, [wWestConnectedMapWidth] ; width of connected map
 	add MAP_BORDER * 2
-	ld e,a
-	ld d,0
-	ld b,0
-	add hl,de
+	ld e, a
+	ld d, 0
+	ld b, 0
+	add hl, de
 	dec c
-	jr nz,.pointerAdjustmentLoop1
+	jr nz, .pointerAdjustmentLoop1
 .savePointer1
-	ld a,l
-	ld [wCurrentTileBlockMapViewPointer],a ; pointer to upper left corner of current tile block map section
-	ld a,h
-	ld [wCurrentTileBlockMapViewPointer + 1],a
+	ld a, l
+	ld [wCurrentTileBlockMapViewPointer], a ; pointer to upper left corner of current tile block map section
+	ld a, h
+	ld [wCurrentTileBlockMapViewPointer + 1], a
 	jp .loadNewMap
 
 .checkEastMap
-	ld b,a
-	ld a,[wCurrentMapWidth2] ; map width
+	ld b, a
+	ld a, [wCurrentMapWidth2] ; map width
 	cp b
-	jr nz,.checkNorthMap
-	ld a,[wMapConn4Ptr]
-	ld [wCurMap],a
-	ld a,[wEastConnectedMapXAlignment] ; new X coordinate upon entering east map
-	ld [wXCoord],a
-	ld a,[wYCoord]
-	ld c,a
-	ld a,[wEastConnectedMapYAlignment] ; Y adjustment upon entering east map
+	jr nz, .checkNorthMap
+	ld a, [wMapConn4Ptr]
+	ld [wCurMap], a
+	ld a, [wEastConnectedMapXAlignment] ; new X coordinate upon entering east map
+	ld [wXCoord], a
+	ld a, [wYCoord]
+	ld c, a
+	ld a, [wEastConnectedMapYAlignment] ; Y adjustment upon entering east map
 	add c
-	ld c,a
-	ld [wYCoord],a
-	ld a,[wEastConnectedMapViewPointer] ; pointer to upper left corner of map without adjustment for Y position
-	ld l,a
-	ld a,[wEastConnectedMapViewPointer + 1]
-	ld h,a
+	ld c, a
+	ld [wYCoord], a
+	ld a, [wEastConnectedMapViewPointer] ; pointer to upper left corner of map without adjustment for Y position
+	ld l, a
+	ld a, [wEastConnectedMapViewPointer + 1]
+	ld h, a
 	srl c
-	jr z,.savePointer2
+	jr z, .savePointer2
 .pointerAdjustmentLoop2
-	ld a,[wEastConnectedMapWidth]
+	ld a, [wEastConnectedMapWidth]
 	add MAP_BORDER * 2
-	ld e,a
-	ld d,0
-	ld b,0
-	add hl,de
+	ld e, a
+	ld d, 0
+	ld b, 0
+	add hl, de
 	dec c
-	jr nz,.pointerAdjustmentLoop2
+	jr nz, .pointerAdjustmentLoop2
 .savePointer2
-	ld a,l
-	ld [wCurrentTileBlockMapViewPointer],a ; pointer to upper left corner of current tile block map section
-	ld a,h
-	ld [wCurrentTileBlockMapViewPointer + 1],a
+	ld a, l
+	ld [wCurrentTileBlockMapViewPointer], a ; pointer to upper left corner of current tile block map section
+	ld a, h
+	ld [wCurrentTileBlockMapViewPointer + 1], a
 	jp .loadNewMap
 
 .checkNorthMap
-	ld a,[wYCoord]
+	ld a, [wYCoord]
 	cp $ff
-	jr nz,.checkSouthMap
-	ld a,[wMapConn1Ptr]
-	ld [wCurMap],a
-	ld a,[wNorthConnectedMapYAlignment] ; new Y coordinate upon entering north map
-	ld [wYCoord],a
-	ld a,[wXCoord]
-	ld c,a
-	ld a,[wNorthConnectedMapXAlignment] ; X adjustment upon entering north map
+	jr nz, .checkSouthMap
+	ld a, [wMapConn1Ptr]
+	ld [wCurMap], a
+	ld a, [wNorthConnectedMapYAlignment] ; new Y coordinate upon entering north map
+	ld [wYCoord], a
+	ld a, [wXCoord]
+	ld c, a
+	ld a, [wNorthConnectedMapXAlignment] ; X adjustment upon entering north map
 	add c
-	ld c,a
-	ld [wXCoord],a
-	ld a,[wNorthConnectedMapViewPointer] ; pointer to upper left corner of map without adjustment for X position
-	ld l,a
-	ld a,[wNorthConnectedMapViewPointer + 1]
-	ld h,a
-	ld b,0
+	ld c, a
+	ld [wXCoord], a
+	ld a, [wNorthConnectedMapViewPointer] ; pointer to upper left corner of map without adjustment for X position
+	ld l, a
+	ld a, [wNorthConnectedMapViewPointer + 1]
+	ld h, a
+	ld b, 0
 	srl c
-	add hl,bc
-	ld a,l
-	ld [wCurrentTileBlockMapViewPointer],a ; pointer to upper left corner of current tile block map section
-	ld a,h
-	ld [wCurrentTileBlockMapViewPointer + 1],a
+	add hl, bc
+	ld a, l
+	ld [wCurrentTileBlockMapViewPointer], a ; pointer to upper left corner of current tile block map section
+	ld a, h
+	ld [wCurrentTileBlockMapViewPointer + 1], a
 	jp .loadNewMap
 
 .checkSouthMap
-	ld b,a
-	ld a,[wCurrentMapHeight2]
+	ld b, a
+	ld a, [wCurrentMapHeight2]
 	cp b
-	jr nz,.didNotEnterConnectedMap
-	ld a,[wMapConn2Ptr]
-	ld [wCurMap],a
-	ld a,[wSouthConnectedMapYAlignment] ; new Y coordinate upon entering south map
-	ld [wYCoord],a
-	ld a,[wXCoord]
-	ld c,a
-	ld a,[wSouthConnectedMapXAlignment] ; X adjustment upon entering south map
+	jr nz, .didNotEnterConnectedMap
+	ld a, [wMapConn2Ptr]
+	ld [wCurMap], a
+	ld a, [wSouthConnectedMapYAlignment] ; new Y coordinate upon entering south map
+	ld [wYCoord], a
+	ld a, [wXCoord]
+	ld c, a
+	ld a, [wSouthConnectedMapXAlignment] ; X adjustment upon entering south map
 	add c
-	ld c,a
-	ld [wXCoord],a
-	ld a,[wSouthConnectedMapViewPointer] ; pointer to upper left corner of map without adjustment for X position
-	ld l,a
-	ld a,[wSouthConnectedMapViewPointer + 1]
-	ld h,a
-	ld b,0
+	ld c, a
+	ld [wXCoord], a
+	ld a, [wSouthConnectedMapViewPointer] ; pointer to upper left corner of map without adjustment for X position
+	ld l, a
+	ld a, [wSouthConnectedMapViewPointer + 1]
+	ld h, a
+	ld b, 0
 	srl c
-	add hl,bc
-	ld a,l
-	ld [wCurrentTileBlockMapViewPointer],a ; pointer to upper left corner of current tile block map section
-	ld a,h
-	ld [wCurrentTileBlockMapViewPointer + 1],a
+	add hl, bc
+	ld a, l
+	ld [wCurrentTileBlockMapViewPointer], a ; pointer to upper left corner of current tile block map section
+	ld a, h
+	ld [wCurrentTileBlockMapViewPointer + 1], a
 .loadNewMap ; load the connected map that was entered
 	call LoadMapHeader
 	call PlayDefaultMusicFadeOutCurrent
@@ -690,14 +690,14 @@ CheckMapConnections::
 PlayMapChangeSound::
 	aCoord 8, 8 ; upper left tile of the 4x4 square the player's sprite is standing on
 	cp $0b ; door tile in tileset 0
-	jr nz,.didNotGoThroughDoor
-	ld a,SFX_GO_INSIDE
+	jr nz, .didNotGoThroughDoor
+	ld a, SFX_GO_INSIDE
 	jr .playSound
 .didNotGoThroughDoor
-	ld a,SFX_GO_OUTSIDE
+	ld a, SFX_GO_OUTSIDE
 .playSound
 	call PlaySound
-	ld a,[wMapPalOffset]
+	ld a, [wMapPalOffset]
 	and a
 	ret nz
 	jp GBFadeOutToBlack
@@ -748,9 +748,9 @@ ExtraWarpCheck::
 
 MapEntryAfterBattle::
 	callba IsPlayerStandingOnWarp ; for enabling warp testing after collisions
-	ld a,[wMapPalOffset]
+	ld a, [wMapPalOffset]
 	and a
-	jp z,GBFadeInFromWhite
+	jp z, GBFadeInFromWhite
 	jp LoadGBPal
 
 HandleBlackOut::
@@ -871,205 +871,205 @@ INCLUDE "data/bike_riding_tilesets.asm"
 
 ; load the tile pattern data of the current tileset into VRAM
 LoadTilesetTilePatternData::
-	ld a,[wTilesetGfxPtr]
-	ld l,a
-	ld a,[wTilesetGfxPtr + 1]
-	ld h,a
-	ld de,vTileset
-	ld bc,$600
-	ld a,[wTilesetBank]
+	ld a, [wTilesetGfxPtr]
+	ld l, a
+	ld a, [wTilesetGfxPtr + 1]
+	ld h, a
+	ld de, vTileset
+	ld bc, $600
+	ld a, [wTilesetBank]
 	jp FarCopyData2
 
 ; this loads the current maps complete tile map (which references blocks, not individual tiles) to C6E8
 ; it can also load partial tile maps of connected maps into a border of length 3 around the current map
 LoadTileBlockMap::
 ; fill C6E8-CBFB with the background tile
-	ld hl,wOverworldMap
-	ld a,[wMapBackgroundTile]
-	ld d,a
-	ld bc,$0514
+	ld hl, wOverworldMap
+	ld a, [wMapBackgroundTile]
+	ld d, a
+	ld bc, $0514
 .backgroundTileLoop
-	ld a,d
-	ld [hli],a
+	ld a, d
+	ld [hli], a
 	dec bc
-	ld a,c
+	ld a, c
 	or b
-	jr nz,.backgroundTileLoop
+	jr nz, .backgroundTileLoop
 ; load tile map of current map (made of tile block IDs)
 ; a 3-byte border at the edges of the map is kept so that there is space for map connections
-	ld hl,wOverworldMap
-	ld a,[wCurMapWidth]
-	ld [hMapWidth],a
+	ld hl, wOverworldMap
+	ld a, [wCurMapWidth]
+	ld [hMapWidth], a
 	add MAP_BORDER * 2 ; east and west
-	ld [hMapStride],a ; map width + border
-	ld b,0
-	ld c,a
+	ld [hMapStride], a ; map width + border
+	ld b, 0
+	ld c, a
 ; make space for north border (next 3 lines)
-	add hl,bc
-	add hl,bc
-	add hl,bc
-	ld c,MAP_BORDER
-	add hl,bc ; this puts us past the (west) border
-	ld a,[wMapDataPtr] ; tile map pointer
-	ld e,a
-	ld a,[wMapDataPtr + 1]
-	ld d,a ; de = tile map pointer
-	ld a,[wCurMapHeight]
-	ld b,a
+	add hl, bc
+	add hl, bc
+	add hl, bc
+	ld c, MAP_BORDER
+	add hl, bc ; this puts us past the (west) border
+	ld a, [wMapDataPtr] ; tile map pointer
+	ld e, a
+	ld a, [wMapDataPtr + 1]
+	ld d, a ; de = tile map pointer
+	ld a, [wCurMapHeight]
+	ld b, a
 .rowLoop ; copy one row each iteration
 	push hl
-	ld a,[hMapWidth] ; map width (without border)
-	ld c,a
+	ld a, [hMapWidth] ; map width (without border)
+	ld c, a
 .rowInnerLoop
-	ld a,[de]
+	ld a, [de]
 	inc de
-	ld [hli],a
+	ld [hli], a
 	dec c
-	jr nz,.rowInnerLoop
+	jr nz, .rowInnerLoop
 ; add the map width plus the border to the base address of the current row to get the next row's address
 	pop hl
-	ld a,[hMapStride] ; map width + border
+	ld a, [hMapStride] ; map width + border
 	add l
-	ld l,a
-	jr nc,.noCarry
+	ld l, a
+	jr nc, .noCarry
 	inc h
 .noCarry
 	dec b
-	jr nz,.rowLoop
+	jr nz, .rowLoop
 .northConnection
-	ld a,[wMapConn1Ptr]
+	ld a, [wMapConn1Ptr]
 	cp $ff
-	jr z,.southConnection
+	jr z, .southConnection
 	call SwitchToMapRomBank
-	ld a,[wNorthConnectionStripSrc]
-	ld l,a
-	ld a,[wNorthConnectionStripSrc + 1]
-	ld h,a
-	ld a,[wNorthConnectionStripDest]
-	ld e,a
-	ld a,[wNorthConnectionStripDest + 1]
-	ld d,a
-	ld a,[wNorthConnectionStripWidth]
-	ld [hNorthSouthConnectionStripWidth],a
-	ld a,[wNorthConnectedMapWidth]
-	ld [hNorthSouthConnectedMapWidth],a
+	ld a, [wNorthConnectionStripSrc]
+	ld l, a
+	ld a, [wNorthConnectionStripSrc + 1]
+	ld h, a
+	ld a, [wNorthConnectionStripDest]
+	ld e, a
+	ld a, [wNorthConnectionStripDest + 1]
+	ld d, a
+	ld a, [wNorthConnectionStripWidth]
+	ld [hNorthSouthConnectionStripWidth], a
+	ld a, [wNorthConnectedMapWidth]
+	ld [hNorthSouthConnectedMapWidth], a
 	call LoadNorthSouthConnectionsTileMap
 .southConnection
-	ld a,[wMapConn2Ptr]
+	ld a, [wMapConn2Ptr]
 	cp $ff
-	jr z,.westConnection
+	jr z, .westConnection
 	call SwitchToMapRomBank
-	ld a,[wSouthConnectionStripSrc]
-	ld l,a
-	ld a,[wSouthConnectionStripSrc + 1]
-	ld h,a
-	ld a,[wSouthConnectionStripDest]
-	ld e,a
-	ld a,[wSouthConnectionStripDest + 1]
-	ld d,a
-	ld a,[wSouthConnectionStripWidth]
-	ld [hNorthSouthConnectionStripWidth],a
-	ld a,[wSouthConnectedMapWidth]
-	ld [hNorthSouthConnectedMapWidth],a
+	ld a, [wSouthConnectionStripSrc]
+	ld l, a
+	ld a, [wSouthConnectionStripSrc + 1]
+	ld h, a
+	ld a, [wSouthConnectionStripDest]
+	ld e, a
+	ld a, [wSouthConnectionStripDest + 1]
+	ld d, a
+	ld a, [wSouthConnectionStripWidth]
+	ld [hNorthSouthConnectionStripWidth], a
+	ld a, [wSouthConnectedMapWidth]
+	ld [hNorthSouthConnectedMapWidth], a
 	call LoadNorthSouthConnectionsTileMap
 .westConnection
-	ld a,[wMapConn3Ptr]
+	ld a, [wMapConn3Ptr]
 	cp $ff
-	jr z,.eastConnection
+	jr z, .eastConnection
 	call SwitchToMapRomBank
-	ld a,[wWestConnectionStripSrc]
-	ld l,a
-	ld a,[wWestConnectionStripSrc + 1]
-	ld h,a
-	ld a,[wWestConnectionStripDest]
-	ld e,a
-	ld a,[wWestConnectionStripDest + 1]
-	ld d,a
-	ld a,[wWestConnectionStripHeight]
-	ld b,a
-	ld a,[wWestConnectedMapWidth]
-	ld [hEastWestConnectedMapWidth],a
+	ld a, [wWestConnectionStripSrc]
+	ld l, a
+	ld a, [wWestConnectionStripSrc + 1]
+	ld h, a
+	ld a, [wWestConnectionStripDest]
+	ld e, a
+	ld a, [wWestConnectionStripDest + 1]
+	ld d, a
+	ld a, [wWestConnectionStripHeight]
+	ld b, a
+	ld a, [wWestConnectedMapWidth]
+	ld [hEastWestConnectedMapWidth], a
 	call LoadEastWestConnectionsTileMap
 .eastConnection
-	ld a,[wMapConn4Ptr]
+	ld a, [wMapConn4Ptr]
 	cp $ff
-	jr z,.done
+	jr z, .done
 	call SwitchToMapRomBank
-	ld a,[wEastConnectionStripSrc]
-	ld l,a
-	ld a,[wEastConnectionStripSrc + 1]
-	ld h,a
-	ld a,[wEastConnectionStripDest]
-	ld e,a
-	ld a,[wEastConnectionStripDest + 1]
-	ld d,a
-	ld a,[wEastConnectionStripHeight]
-	ld b,a
-	ld a,[wEastConnectedMapWidth]
-	ld [hEastWestConnectedMapWidth],a
+	ld a, [wEastConnectionStripSrc]
+	ld l, a
+	ld a, [wEastConnectionStripSrc + 1]
+	ld h, a
+	ld a, [wEastConnectionStripDest]
+	ld e, a
+	ld a, [wEastConnectionStripDest + 1]
+	ld d, a
+	ld a, [wEastConnectionStripHeight]
+	ld b, a
+	ld a, [wEastConnectedMapWidth]
+	ld [hEastWestConnectedMapWidth], a
 	call LoadEastWestConnectionsTileMap
 .done
 	ret
 
 LoadNorthSouthConnectionsTileMap::
-	ld c,MAP_BORDER
+	ld c, MAP_BORDER
 .loop
 	push de
 	push hl
-	ld a,[hNorthSouthConnectionStripWidth]
-	ld b,a
+	ld a, [hNorthSouthConnectionStripWidth]
+	ld b, a
 .innerLoop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	dec b
-	jr nz,.innerLoop
+	jr nz, .innerLoop
 	pop hl
 	pop de
-	ld a,[hNorthSouthConnectedMapWidth]
+	ld a, [hNorthSouthConnectedMapWidth]
 	add l
-	ld l,a
-	jr nc,.noCarry1
+	ld l, a
+	jr nc, .noCarry1
 	inc h
 .noCarry1
-	ld a,[wCurMapWidth]
+	ld a, [wCurMapWidth]
 	add MAP_BORDER * 2
 	add e
-	ld e,a
-	jr nc,.noCarry2
+	ld e, a
+	jr nc, .noCarry2
 	inc d
 .noCarry2
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 LoadEastWestConnectionsTileMap::
 	push hl
 	push de
-	ld c,MAP_BORDER
+	ld c, MAP_BORDER
 .innerLoop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	dec c
-	jr nz,.innerLoop
+	jr nz, .innerLoop
 	pop de
 	pop hl
-	ld a,[hEastWestConnectedMapWidth]
+	ld a, [hEastWestConnectedMapWidth]
 	add l
-	ld l,a
-	jr nc,.noCarry1
+	ld l, a
+	jr nc, .noCarry1
 	inc h
 .noCarry1
-	ld a,[wCurMapWidth]
+	ld a, [wCurMapWidth]
 	add MAP_BORDER * 2
 	add e
-	ld e,a
-	jr nc,.noCarry2
+	ld e, a
+	jr nc, .noCarry2
 	inc d
 .noCarry2
 	dec b
-	jr nz,LoadEastWestConnectionsTileMap
+	jr nz, LoadEastWestConnectionsTileMap
 	ret
 
 ; function to check if there is a sign or sprite in front of the player
@@ -1077,177 +1077,177 @@ LoadEastWestConnectionsTileMap::
 ; if not, [hSpriteIndexOrTextID] is set to 0
 IsSpriteOrSignInFrontOfPlayer::
 	xor a
-	ld [hSpriteIndexOrTextID],a
-	ld a,[wNumSigns]
+	ld [hSpriteIndexOrTextID], a
+	ld a, [wNumSigns]
 	and a
-	jr z,.extendRangeOverCounter
+	jr z, .extendRangeOverCounter
 ; if there are signs
 	predef GetTileAndCoordsInFrontOfPlayer ; get the coordinates in front of the player in de
-	ld hl,wSignCoords
-	ld a,[wNumSigns]
-	ld b,a
-	ld c,0
+	ld hl, wSignCoords
+	ld a, [wNumSigns]
+	ld b, a
+	ld c, 0
 .signLoop
 	inc c
-	ld a,[hli] ; sign Y
+	ld a, [hli] ; sign Y
 	cp d
-	jr z,.yCoordMatched
+	jr z, .yCoordMatched
 	inc hl
 	jr .retry
 .yCoordMatched
-	ld a,[hli] ; sign X
+	ld a, [hli] ; sign X
 	cp e
-	jr nz,.retry
+	jr nz, .retry
 .xCoordMatched
 ; found sign
 	push hl
 	push bc
-	ld hl,wSignTextIDs
-	ld b,0
+	ld hl, wSignTextIDs
+	ld b, 0
 	dec c
-	add hl,bc
-	ld a,[hl]
-	ld [hSpriteIndexOrTextID],a ; store sign text ID
+	add hl, bc
+	ld a, [hl]
+	ld [hSpriteIndexOrTextID], a ; store sign text ID
 	pop bc
 	pop hl
 	ret
 .retry
 	dec b
-	jr nz,.signLoop
+	jr nz, .signLoop
 ; check if the player is front of a counter in a pokemon center, pokemart, etc. and if so, extend the range at which he can talk to the NPC
 .extendRangeOverCounter
 	predef GetTileAndCoordsInFrontOfPlayer ; get the tile in front of the player in c
-	ld hl,wTilesetTalkingOverTiles ; list of tiles that extend talking range (counter tiles)
-	ld b,3
-	ld d,$20 ; talking range in pixels (long range)
+	ld hl, wTilesetTalkingOverTiles ; list of tiles that extend talking range (counter tiles)
+	ld b, 3
+	ld d, $20 ; talking range in pixels (long range)
 .counterTilesLoop
-	ld a,[hli]
+	ld a, [hli]
 	cp c
-	jr z,IsSpriteInFrontOfPlayer2 ; jumps if the tile in front of the player is a counter tile
+	jr z, IsSpriteInFrontOfPlayer2 ; jumps if the tile in front of the player is a counter tile
 	dec b
-	jr nz,.counterTilesLoop
+	jr nz, .counterTilesLoop
 
 ; part of the above function, but sometimes its called on its own, when signs are irrelevant
 ; the caller must zero [hSpriteIndexOrTextID]
 IsSpriteInFrontOfPlayer::
-	ld d,$10 ; talking range in pixels (normal range)
+	ld d, $10 ; talking range in pixels (normal range)
 IsSpriteInFrontOfPlayer2::
 	lb bc, $3c, $40 ; Y and X position of player sprite
-	ld a,[wSpriteStateData1 + 9] ; direction the player is facing
+	ld a, [wSpriteStateData1 + 9] ; direction the player is facing
 .checkIfPlayerFacingUp
 	cp SPRITE_FACING_UP
-	jr nz,.checkIfPlayerFacingDown
+	jr nz, .checkIfPlayerFacingDown
 ; facing up
-	ld a,b
+	ld a, b
 	sub d
-	ld b,a
-	ld a,PLAYER_DIR_UP
+	ld b, a
+	ld a, PLAYER_DIR_UP
 	jr .doneCheckingDirection
 
 .checkIfPlayerFacingDown
 	cp SPRITE_FACING_DOWN
-	jr nz,.checkIfPlayerFacingRight
+	jr nz, .checkIfPlayerFacingRight
 ; facing down
-	ld a,b
+	ld a, b
 	add d
-	ld b,a
-	ld a,PLAYER_DIR_DOWN
+	ld b, a
+	ld a, PLAYER_DIR_DOWN
 	jr .doneCheckingDirection
 
 .checkIfPlayerFacingRight
 	cp SPRITE_FACING_RIGHT
-	jr nz,.playerFacingLeft
+	jr nz, .playerFacingLeft
 ; facing right
-	ld a,c
+	ld a, c
 	add d
-	ld c,a
-	ld a,PLAYER_DIR_RIGHT
+	ld c, a
+	ld a, PLAYER_DIR_RIGHT
 	jr .doneCheckingDirection
 
 .playerFacingLeft
 ; facing left
-	ld a,c
+	ld a, c
 	sub d
-	ld c,a
-	ld a,PLAYER_DIR_LEFT
+	ld c, a
+	ld a, PLAYER_DIR_LEFT
 .doneCheckingDirection
-	ld [wPlayerDirection],a
-	ld a,[wNumSprites] ; number of sprites
+	ld [wPlayerDirection], a
+	ld a, [wNumSprites] ; number of sprites
 	and a
 	ret z
 ; if there are sprites
-	ld hl,wSpriteStateData1 + $10
-	ld d,a
-	ld e,$01
+	ld hl, wSpriteStateData1 + $10
+	ld d, a
+	ld e, $01
 .spriteLoop
 	push hl
-	ld a,[hli] ; image (0 if no sprite)
+	ld a, [hli] ; image (0 if no sprite)
 	and a
-	jr z,.nextSprite
+	jr z, .nextSprite
 	inc l
-	ld a,[hli] ; sprite visibility
+	ld a, [hli] ; sprite visibility
 	inc a
-	jr z,.nextSprite
+	jr z, .nextSprite
 	inc l
-	ld a,[hli] ; Y location
+	ld a, [hli] ; Y location
 	cp b
-	jr nz,.nextSprite
+	jr nz, .nextSprite
 	inc l
-	ld a,[hl] ; X location
+	ld a, [hl] ; X location
 	cp c
-	jr z,.foundSpriteInFrontOfPlayer
+	jr z, .foundSpriteInFrontOfPlayer
 .nextSprite
 	pop hl
-	ld a,l
-	add a,$10
-	ld l,a
+	ld a, l
+	add $10
+	ld l, a
 	inc e
 	dec d
-	jr nz,.spriteLoop
+	jr nz, .spriteLoop
 	ret
 .foundSpriteInFrontOfPlayer
 	pop hl
-	ld a,l
-	and a,$f0
+	ld a, l
+	and $f0
 	inc a
-	ld l,a ; hl = $c1x1
-	set 7,[hl] ; set flag to make the sprite face the player
-	ld a,e
-	ld [hSpriteIndexOrTextID],a
+	ld l, a ; hl = $c1x1
+	set 7, [hl] ; set flag to make the sprite face the player
+	ld a, e
+	ld [hSpriteIndexOrTextID], a
 	ret
 
 ; function to check if the player will jump down a ledge and check if the tile ahead is passable (when not surfing)
 ; sets the carry flag if there is a collision, and unsets it if there isn't a collision
 CollisionCheckOnLand::
-	ld a,[wd736]
-	bit 6,a ; is the player jumping?
-	jr nz,.noCollision
+	ld a, [wd736]
+	bit 6, a ; is the player jumping?
+	jr nz, .noCollision
 ; if not jumping a ledge
-	ld a,[wSimulatedJoypadStatesIndex]
+	ld a, [wSimulatedJoypadStatesIndex]
 	and a
-	jr nz,.noCollision ; no collisions when the player's movements are being controlled by the game
-	ld a,[wPlayerDirection] ; the direction that the player is trying to go in
-	ld d,a
-	ld a,[wSpriteStateData1 + 12] ; the player sprite's collision data (bit field) (set in the sprite movement code)
+	jr nz, .noCollision ; no collisions when the player's movements are being controlled by the game
+	ld a, [wPlayerDirection] ; the direction that the player is trying to go in
+	ld d, a
+	ld a, [wSpriteStateData1 + 12] ; the player sprite's collision data (bit field) (set in the sprite movement code)
 	and d ; check if a sprite is in the direction the player is trying to go
-	jr nz,.collision
+	jr nz, .collision
 	xor a
-	ld [hSpriteIndexOrTextID],a
+	ld [hSpriteIndexOrTextID], a
 	call IsSpriteInFrontOfPlayer ; check for sprite collisions again? when does the above check fail to detect a sprite collision?
-	ld a,[hSpriteIndexOrTextID]
+	ld a, [hSpriteIndexOrTextID]
 	and a ; was there a sprite collision?
-	jr nz,.collision
+	jr nz, .collision
 ; if no sprite collision
-	ld hl,TilePairCollisionsLand
+	ld hl, TilePairCollisionsLand
 	call CheckForJumpingAndTilePairCollisions
-	jr c,.collision
+	jr c, .collision
 	call CheckTilePassable
-	jr nc,.noCollision
+	jr nc, .noCollision
 .collision
-	ld a,[wChannelSoundIDs + Ch4]
+	ld a, [wChannelSoundIDs + Ch4]
 	cp SFX_COLLISION ; check if collision sound is already playing
-	jr z,.setCarry
-	ld a,SFX_COLLISION
+	jr z, .setCarry
+	ld a, SFX_COLLISION
 	call PlaySound ; play collision sound (if it's not already playing)
 .setCarry
 	scf
@@ -1260,16 +1260,16 @@ CollisionCheckOnLand::
 ; clears carry if it is, sets carry if not
 CheckTilePassable::
 	predef GetTileAndCoordsInFrontOfPlayer ; get tile in front of player
-	ld a,[wTileInFrontOfPlayer] ; tile in front of player
-	ld c,a
-	ld hl,wTilesetCollisionPtr ; pointer to list of passable tiles
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a ; hl now points to passable tiles
+	ld a, [wTileInFrontOfPlayer] ; tile in front of player
+	ld c, a
+	ld hl, wTilesetCollisionPtr ; pointer to list of passable tiles
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a ; hl now points to passable tiles
 .loop
-	ld a,[hli]
-	cp a,$ff
-	jr z,.tileNotPassable
+	ld a, [hli]
+	cp $ff
+	jr z, .tileNotPassable
 	cp c
 	ret z
 	jr .loop
@@ -1291,53 +1291,53 @@ CheckForJumpingAndTilePairCollisions::
 	pop de
 	pop hl
 	and a
-	ld a,[wd736]
-	bit 6,a ; is the player jumping?
+	ld a, [wd736]
+	bit 6, a ; is the player jumping?
 	ret nz
 ; if not jumping
 
 CheckForTilePairCollisions2::
 	aCoord 8, 9 ; tile the player is on
-	ld [wTilePlayerStandingOn],a
+	ld [wTilePlayerStandingOn], a
 
 CheckForTilePairCollisions::
-	ld a,[wTileInFrontOfPlayer]
-	ld c,a
+	ld a, [wTileInFrontOfPlayer]
+	ld c, a
 .tilePairCollisionLoop
-	ld a,[wCurMapTileset] ; tileset number
-	ld b,a
-	ld a,[hli]
+	ld a, [wCurMapTileset] ; tileset number
+	ld b, a
+	ld a, [hli]
 	cp $ff
-	jr z,.noMatch
+	jr z, .noMatch
 	cp b
-	jr z,.tilesetMatches
+	jr z, .tilesetMatches
 	inc hl
 .retry
 	inc hl
 	jr .tilePairCollisionLoop
 .tilesetMatches
-	ld a,[wTilePlayerStandingOn] ; tile the player is on
-	ld b,a
-	ld a,[hl]
+	ld a, [wTilePlayerStandingOn] ; tile the player is on
+	ld b, a
+	ld a, [hl]
 	cp b
-	jr z,.currentTileMatchesFirstInPair
+	jr z, .currentTileMatchesFirstInPair
 	inc hl
-	ld a,[hl]
+	ld a, [hl]
 	cp b
-	jr z,.currentTileMatchesSecondInPair
+	jr z, .currentTileMatchesSecondInPair
 	jr .retry
 .currentTileMatchesFirstInPair
 	inc hl
-	ld a,[hl]
+	ld a, [hl]
 	cp c
-	jr z,.foundMatch
+	jr z, .foundMatch
 	jr .tilePairCollisionLoop
 .currentTileMatchesSecondInPair
 	dec hl
-	ld a,[hli]
+	ld a, [hli]
 	cp c
 	inc hl
-	jr nz,.tilePairCollisionLoop
+	jr nz, .tilePairCollisionLoop
 .foundMatch
 	scf
 	ret
@@ -1372,27 +1372,27 @@ TilePairCollisionsWater::
 
 ; this builds a tile map from the tile block map based on the current X/Y coordinates of the player's character
 LoadCurrentMapView::
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,[wTilesetBank] ; tile data ROM bank
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a ; switch to ROM bank that contains tile data
-	ld a,[wCurrentTileBlockMapViewPointer] ; address of upper left corner of current map view
-	ld e,a
-	ld a,[wCurrentTileBlockMapViewPointer + 1]
-	ld d,a
-	ld hl,wTileMapBackup
-	ld b,$05
+	ld a, [wTilesetBank] ; tile data ROM bank
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a ; switch to ROM bank that contains tile data
+	ld a, [wCurrentTileBlockMapViewPointer] ; address of upper left corner of current map view
+	ld e, a
+	ld a, [wCurrentTileBlockMapViewPointer + 1]
+	ld d, a
+	ld hl, wTileMapBackup
+	ld b, $05
 .rowLoop ; each loop iteration fills in one row of tile blocks
 	push hl
 	push de
-	ld c,$06
+	ld c, $06
 .rowInnerLoop ; loop to draw each tile block of the current row
 	push bc
 	push de
 	push hl
-	ld a,[de]
-	ld c,a ; tile block number
+	ld a, [de]
+	ld c, a ; tile block number
 	call DrawTileBlock
 	pop hl
 	pop de
@@ -1403,256 +1403,256 @@ LoadCurrentMapView::
 	inc hl
 	inc de
 	dec c
-	jr nz,.rowInnerLoop
+	jr nz, .rowInnerLoop
 ; update tile block map pointer to next row's address
 	pop de
-	ld a,[wCurMapWidth]
+	ld a, [wCurMapWidth]
 	add MAP_BORDER * 2
 	add e
-	ld e,a
-	jr nc,.noCarry
+	ld e, a
+	jr nc, .noCarry
 	inc d
 .noCarry
 ; update tile map pointer to next row's address
 	pop hl
-	ld a,$60
+	ld a, $60
 	add l
-	ld l,a
-	jr nc,.noCarry2
+	ld l, a
+	jr nc, .noCarry2
 	inc h
 .noCarry2
 	dec b
-	jr nz,.rowLoop
-	ld hl,wTileMapBackup
-	ld bc,$0000
+	jr nz, .rowLoop
+	ld hl, wTileMapBackup
+	ld bc, $0000
 .adjustForYCoordWithinTileBlock
-	ld a,[wYBlockCoord]
+	ld a, [wYBlockCoord]
 	and a
-	jr z,.adjustForXCoordWithinTileBlock
-	ld bc,$0030
-	add hl,bc
+	jr z, .adjustForXCoordWithinTileBlock
+	ld bc, $0030
+	add hl, bc
 .adjustForXCoordWithinTileBlock
-	ld a,[wXBlockCoord]
+	ld a, [wXBlockCoord]
 	and a
-	jr z,.copyToVisibleAreaBuffer
-	ld bc,$0002
-	add hl,bc
+	jr z, .copyToVisibleAreaBuffer
+	ld bc, $0002
+	add hl, bc
 .copyToVisibleAreaBuffer
 	coord de, 0, 0 ; base address for the tiles that are directly transferred to VRAM during V-blank
 	ld b, SCREEN_HEIGHT
 .rowLoop2
 	ld c, SCREEN_WIDTH
 .rowInnerLoop2
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	dec c
-	jr nz,.rowInnerLoop2
-	ld a,$04
+	jr nz, .rowInnerLoop2
+	ld a, $04
 	add l
-	ld l,a
-	jr nc,.noCarry3
+	ld l, a
+	jr nc, .noCarry3
 	inc h
 .noCarry3
 	dec b
-	jr nz,.rowLoop2
+	jr nz, .rowLoop2
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a ; restore previous ROM bank
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a ; restore previous ROM bank
 	ret
 
 AdvancePlayerSprite::
-	ld a,[wSpriteStateData1 + 3] ; delta Y
-	ld b,a
-	ld a,[wSpriteStateData1 + 5] ; delta X
-	ld c,a
-	ld hl,wWalkCounter ; walking animation counter
+	ld a, [wSpriteStateData1 + 3] ; delta Y
+	ld b, a
+	ld a, [wSpriteStateData1 + 5] ; delta X
+	ld c, a
+	ld hl, wWalkCounter ; walking animation counter
 	dec [hl]
-	jr nz,.afterUpdateMapCoords
+	jr nz, .afterUpdateMapCoords
 ; if it's the end of the animation, update the player's map coordinates
-	ld a,[wYCoord]
+	ld a, [wYCoord]
 	add b
-	ld [wYCoord],a
-	ld a,[wXCoord]
+	ld [wYCoord], a
+	ld a, [wXCoord]
 	add c
-	ld [wXCoord],a
+	ld [wXCoord], a
 .afterUpdateMapCoords
-	ld a,[wWalkCounter] ; walking animation counter
-	cp a,$07
-	jp nz,.scrollBackgroundAndSprites
+	ld a, [wWalkCounter] ; walking animation counter
+	cp $07
+	jp nz, .scrollBackgroundAndSprites
 ; if this is the first iteration of the animation
-	ld a,c
-	cp a,$01
-	jr nz,.checkIfMovingWest
+	ld a, c
+	cp $01
+	jr nz, .checkIfMovingWest
 ; moving east
-	ld a,[wMapViewVRAMPointer]
-	ld e,a
-	and a,$e0
-	ld d,a
-	ld a,e
-	add a,$02
-	and a,$1f
+	ld a, [wMapViewVRAMPointer]
+	ld e, a
+	and $e0
+	ld d, a
+	ld a, e
+	add $02
+	and $1f
 	or d
-	ld [wMapViewVRAMPointer],a
+	ld [wMapViewVRAMPointer], a
 	jr .adjustXCoordWithinBlock
 .checkIfMovingWest
-	cp a,$ff
-	jr nz,.checkIfMovingSouth
+	cp $ff
+	jr nz, .checkIfMovingSouth
 ; moving west
-	ld a,[wMapViewVRAMPointer]
-	ld e,a
-	and a,$e0
-	ld d,a
-	ld a,e
-	sub a,$02
-	and a,$1f
+	ld a, [wMapViewVRAMPointer]
+	ld e, a
+	and $e0
+	ld d, a
+	ld a, e
+	sub $02
+	and $1f
 	or d
-	ld [wMapViewVRAMPointer],a
+	ld [wMapViewVRAMPointer], a
 	jr .adjustXCoordWithinBlock
 .checkIfMovingSouth
-	ld a,b
-	cp a,$01
-	jr nz,.checkIfMovingNorth
+	ld a, b
+	cp $01
+	jr nz, .checkIfMovingNorth
 ; moving south
-	ld a,[wMapViewVRAMPointer]
-	add a,$40
-	ld [wMapViewVRAMPointer],a
-	jr nc,.adjustXCoordWithinBlock
-	ld a,[wMapViewVRAMPointer + 1]
+	ld a, [wMapViewVRAMPointer]
+	add $40
+	ld [wMapViewVRAMPointer], a
+	jr nc, .adjustXCoordWithinBlock
+	ld a, [wMapViewVRAMPointer + 1]
 	inc a
-	and a,$03
-	or a,$98
-	ld [wMapViewVRAMPointer + 1],a
+	and $03
+	or $98
+	ld [wMapViewVRAMPointer + 1], a
 	jr .adjustXCoordWithinBlock
 .checkIfMovingNorth
-	cp a,$ff
-	jr nz,.adjustXCoordWithinBlock
+	cp $ff
+	jr nz, .adjustXCoordWithinBlock
 ; moving north
-	ld a,[wMapViewVRAMPointer]
-	sub a,$40
-	ld [wMapViewVRAMPointer],a
-	jr nc,.adjustXCoordWithinBlock
-	ld a,[wMapViewVRAMPointer + 1]
+	ld a, [wMapViewVRAMPointer]
+	sub $40
+	ld [wMapViewVRAMPointer], a
+	jr nc, .adjustXCoordWithinBlock
+	ld a, [wMapViewVRAMPointer + 1]
 	dec a
-	and a,$03
-	or a,$98
-	ld [wMapViewVRAMPointer + 1],a
+	and $03
+	or $98
+	ld [wMapViewVRAMPointer + 1], a
 .adjustXCoordWithinBlock
-	ld a,c
+	ld a, c
 	and a
-	jr z,.pointlessJump ; mistake?
+	jr z, .pointlessJump ; mistake?
 .pointlessJump
-	ld hl,wXBlockCoord
-	ld a,[hl]
+	ld hl, wXBlockCoord
+	ld a, [hl]
 	add c
-	ld [hl],a
-	cp a,$02
-	jr nz,.checkForMoveToWestBlock
+	ld [hl], a
+	cp $02
+	jr nz, .checkForMoveToWestBlock
 ; moved into the tile block to the east
 	xor a
-	ld [hl],a
-	ld hl,wXOffsetSinceLastSpecialWarp
+	ld [hl], a
+	ld hl, wXOffsetSinceLastSpecialWarp
 	inc [hl]
-	ld de,wCurrentTileBlockMapViewPointer
+	ld de, wCurrentTileBlockMapViewPointer
 	call MoveTileBlockMapPointerEast
 	jr .updateMapView
 .checkForMoveToWestBlock
-	cp a,$ff
-	jr nz,.adjustYCoordWithinBlock
+	cp $ff
+	jr nz, .adjustYCoordWithinBlock
 ; moved into the tile block to the west
-	ld a,$01
-	ld [hl],a
-	ld hl,wXOffsetSinceLastSpecialWarp
+	ld a, $01
+	ld [hl], a
+	ld hl, wXOffsetSinceLastSpecialWarp
 	dec [hl]
-	ld de,wCurrentTileBlockMapViewPointer
+	ld de, wCurrentTileBlockMapViewPointer
 	call MoveTileBlockMapPointerWest
 	jr .updateMapView
 .adjustYCoordWithinBlock
-	ld hl,wYBlockCoord
-	ld a,[hl]
+	ld hl, wYBlockCoord
+	ld a, [hl]
 	add b
-	ld [hl],a
-	cp a,$02
-	jr nz,.checkForMoveToNorthBlock
+	ld [hl], a
+	cp $02
+	jr nz, .checkForMoveToNorthBlock
 ; moved into the tile block to the south
 	xor a
-	ld [hl],a
-	ld hl,wYOffsetSinceLastSpecialWarp
+	ld [hl], a
+	ld hl, wYOffsetSinceLastSpecialWarp
 	inc [hl]
-	ld de,wCurrentTileBlockMapViewPointer
-	ld a,[wCurMapWidth]
+	ld de, wCurrentTileBlockMapViewPointer
+	ld a, [wCurMapWidth]
 	call MoveTileBlockMapPointerSouth
 	jr .updateMapView
 .checkForMoveToNorthBlock
-	cp a,$ff
-	jr nz,.updateMapView
+	cp $ff
+	jr nz, .updateMapView
 ; moved into the tile block to the north
-	ld a,$01
-	ld [hl],a
-	ld hl,wYOffsetSinceLastSpecialWarp
+	ld a, $01
+	ld [hl], a
+	ld hl, wYOffsetSinceLastSpecialWarp
 	dec [hl]
-	ld de,wCurrentTileBlockMapViewPointer
-	ld a,[wCurMapWidth]
+	ld de, wCurrentTileBlockMapViewPointer
+	ld a, [wCurMapWidth]
 	call MoveTileBlockMapPointerNorth
 .updateMapView
 	call LoadCurrentMapView
-	ld a,[wSpriteStateData1 + 3] ; delta Y
-	cp a,$01
-	jr nz,.checkIfMovingNorth2
+	ld a, [wSpriteStateData1 + 3] ; delta Y
+	cp $01
+	jr nz, .checkIfMovingNorth2
 ; if moving south
 	call ScheduleSouthRowRedraw
 	jr .scrollBackgroundAndSprites
 .checkIfMovingNorth2
-	cp a,$ff
-	jr nz,.checkIfMovingEast2
+	cp $ff
+	jr nz, .checkIfMovingEast2
 ; if moving north
 	call ScheduleNorthRowRedraw
 	jr .scrollBackgroundAndSprites
 .checkIfMovingEast2
-	ld a,[wSpriteStateData1 + 5] ; delta X
-	cp a,$01
-	jr nz,.checkIfMovingWest2
+	ld a, [wSpriteStateData1 + 5] ; delta X
+	cp $01
+	jr nz, .checkIfMovingWest2
 ; if moving east
 	call ScheduleEastColumnRedraw
 	jr .scrollBackgroundAndSprites
 .checkIfMovingWest2
-	cp a,$ff
-	jr nz,.scrollBackgroundAndSprites
+	cp $ff
+	jr nz, .scrollBackgroundAndSprites
 ; if moving west
 	call ScheduleWestColumnRedraw
 .scrollBackgroundAndSprites
-	ld a,[wSpriteStateData1 + 3] ; delta Y
-	ld b,a
-	ld a,[wSpriteStateData1 + 5] ; delta X
-	ld c,a
+	ld a, [wSpriteStateData1 + 3] ; delta Y
+	ld b, a
+	ld a, [wSpriteStateData1 + 5] ; delta X
+	ld c, a
 	sla b
 	sla c
-	ld a,[hSCY]
+	ld a, [hSCY]
 	add b
-	ld [hSCY],a ; update background scroll Y
-	ld a,[hSCX]
+	ld [hSCY], a ; update background scroll Y
+	ld a, [hSCX]
 	add c
-	ld [hSCX],a ; update background scroll X
+	ld [hSCX], a ; update background scroll X
 ; shift all the sprites in the direction opposite of the player's motion
 ; so that the player appears to move relative to them
-	ld hl,wSpriteStateData1 + $14
-	ld a,[wNumSprites] ; number of sprites
+	ld hl, wSpriteStateData1 + $14
+	ld a, [wNumSprites] ; number of sprites
 	and a ; are there any sprites?
-	jr z,.done
-	ld e,a
+	jr z, .done
+	ld e, a
 .spriteShiftLoop
-	ld a,[hl]
+	ld a, [hl]
 	sub b
-	ld [hli],a
+	ld [hli], a
 	inc l
-	ld a,[hl]
+	ld a, [hl]
 	sub c
-	ld [hl],a
-	ld a,$0e
+	ld [hl], a
+	ld a, $0e
 	add l
-	ld l,a
+	ld l, a
 	dec e
-	jr nz,.spriteShiftLoop
+	jr nz, .spriteShiftLoop
 .done
 	ret
 
@@ -1660,51 +1660,51 @@ AdvancePlayerSprite::
 ; corner of the tile block map in the direction of motion
 
 MoveTileBlockMapPointerEast::
-	ld a,[de]
-	add a,$01
-	ld [de],a
+	ld a, [de]
+	add $01
+	ld [de], a
 	ret nc
 	inc de
-	ld a,[de]
+	ld a, [de]
 	inc a
-	ld [de],a
+	ld [de], a
 	ret
 
 MoveTileBlockMapPointerWest::
-	ld a,[de]
-	sub a,$01
-	ld [de],a
+	ld a, [de]
+	sub $01
+	ld [de], a
 	ret nc
 	inc de
-	ld a,[de]
+	ld a, [de]
 	dec a
-	ld [de],a
+	ld [de], a
 	ret
 
 MoveTileBlockMapPointerSouth::
-	add a,MAP_BORDER * 2
-	ld b,a
-	ld a,[de]
+	add MAP_BORDER * 2
+	ld b, a
+	ld a, [de]
 	add b
-	ld [de],a
+	ld [de], a
 	ret nc
 	inc de
-	ld a,[de]
+	ld a, [de]
 	inc a
-	ld [de],a
+	ld [de], a
 	ret
 
 MoveTileBlockMapPointerNorth::
-	add a,MAP_BORDER * 2
-	ld b,a
-	ld a,[de]
+	add MAP_BORDER * 2
+	ld b, a
+	ld a, [de]
 	sub b
-	ld [de],a
+	ld [de], a
 	ret nc
 	inc de
-	ld a,[de]
+	ld a, [de]
 	dec a
-	ld [de],a
+	ld [de], a
 	ret
 
 ; the following 6 functions are used to tell the V-blank handler to redraw
@@ -1713,196 +1713,196 @@ MoveTileBlockMapPointerNorth::
 ScheduleNorthRowRedraw::
 	coord hl, 0, 0
 	call CopyToRedrawRowOrColumnSrcTiles
-	ld a,[wMapViewVRAMPointer]
-	ld [hRedrawRowOrColumnDest],a
-	ld a,[wMapViewVRAMPointer + 1]
-	ld [hRedrawRowOrColumnDest + 1],a
-	ld a,REDRAW_ROW
-	ld [hRedrawRowOrColumnMode],a
+	ld a, [wMapViewVRAMPointer]
+	ld [hRedrawRowOrColumnDest], a
+	ld a, [wMapViewVRAMPointer + 1]
+	ld [hRedrawRowOrColumnDest + 1], a
+	ld a, REDRAW_ROW
+	ld [hRedrawRowOrColumnMode], a
 	ret
 
 CopyToRedrawRowOrColumnSrcTiles::
-	ld de,wRedrawRowOrColumnSrcTiles
-	ld c,2 * SCREEN_WIDTH
+	ld de, wRedrawRowOrColumnSrcTiles
+	ld c, 2 * SCREEN_WIDTH
 .loop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 ScheduleSouthRowRedraw::
 	coord hl, 0, 16
 	call CopyToRedrawRowOrColumnSrcTiles
-	ld a,[wMapViewVRAMPointer]
-	ld l,a
-	ld a,[wMapViewVRAMPointer + 1]
-	ld h,a
-	ld bc,$0200
-	add hl,bc
-	ld a,h
+	ld a, [wMapViewVRAMPointer]
+	ld l, a
+	ld a, [wMapViewVRAMPointer + 1]
+	ld h, a
+	ld bc, $0200
+	add hl, bc
+	ld a, h
 	and $03
 	or $98
-	ld [hRedrawRowOrColumnDest + 1],a
-	ld a,l
-	ld [hRedrawRowOrColumnDest],a
-	ld a,REDRAW_ROW
-	ld [hRedrawRowOrColumnMode],a
+	ld [hRedrawRowOrColumnDest + 1], a
+	ld a, l
+	ld [hRedrawRowOrColumnDest], a
+	ld a, REDRAW_ROW
+	ld [hRedrawRowOrColumnMode], a
 	ret
 
 ScheduleEastColumnRedraw::
 	coord hl, 18, 0
 	call ScheduleColumnRedrawHelper
-	ld a,[wMapViewVRAMPointer]
-	ld c,a
+	ld a, [wMapViewVRAMPointer]
+	ld c, a
 	and $e0
-	ld b,a
-	ld a,c
+	ld b, a
+	ld a, c
 	add 18
 	and $1f
 	or b
-	ld [hRedrawRowOrColumnDest],a
-	ld a,[wMapViewVRAMPointer + 1]
-	ld [hRedrawRowOrColumnDest + 1],a
-	ld a,REDRAW_COL
-	ld [hRedrawRowOrColumnMode],a
+	ld [hRedrawRowOrColumnDest], a
+	ld a, [wMapViewVRAMPointer + 1]
+	ld [hRedrawRowOrColumnDest + 1], a
+	ld a, REDRAW_COL
+	ld [hRedrawRowOrColumnMode], a
 	ret
 
 ScheduleColumnRedrawHelper::
-	ld de,wRedrawRowOrColumnSrcTiles
-	ld c,SCREEN_HEIGHT
+	ld de, wRedrawRowOrColumnSrcTiles
+	ld c, SCREEN_HEIGHT
 .loop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
-	ld a,[hl]
-	ld [de],a
+	ld a, [hl]
+	ld [de], a
 	inc de
-	ld a,19
+	ld a, 19
 	add l
-	ld l,a
-	jr nc,.noCarry
+	ld l, a
+	jr nc, .noCarry
 	inc h
 .noCarry
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 ScheduleWestColumnRedraw::
 	coord hl, 0, 0
 	call ScheduleColumnRedrawHelper
-	ld a,[wMapViewVRAMPointer]
-	ld [hRedrawRowOrColumnDest],a
-	ld a,[wMapViewVRAMPointer + 1]
-	ld [hRedrawRowOrColumnDest + 1],a
-	ld a,REDRAW_COL
-	ld [hRedrawRowOrColumnMode],a
+	ld a, [wMapViewVRAMPointer]
+	ld [hRedrawRowOrColumnDest], a
+	ld a, [wMapViewVRAMPointer + 1]
+	ld [hRedrawRowOrColumnDest + 1], a
+	ld a, REDRAW_COL
+	ld [hRedrawRowOrColumnMode], a
 	ret
 
 ; function to write the tiles that make up a tile block to memory
 ; Input: c = tile block ID, hl = destination address
 DrawTileBlock::
 	push hl
-	ld a,[wTilesetBlocksPtr] ; pointer to tiles
-	ld l,a
-	ld a,[wTilesetBlocksPtr + 1]
-	ld h,a
-	ld a,c
+	ld a, [wTilesetBlocksPtr] ; pointer to tiles
+	ld l, a
+	ld a, [wTilesetBlocksPtr + 1]
+	ld h, a
+	ld a, c
 	swap a
-	ld b,a
+	ld b, a
 	and $f0
-	ld c,a
-	ld a,b
+	ld c, a
+	ld a, b
 	and $0f
-	ld b,a ; bc = tile block ID * 0x10
-	add hl,bc
-	ld d,h
-	ld e,l ; de = address of the tile block's tiles
+	ld b, a ; bc = tile block ID * 0x10
+	add hl, bc
+	ld d, h
+	ld e, l ; de = address of the tile block's tiles
 	pop hl
-	ld c,$04 ; 4 loop iterations
+	ld c, $04 ; 4 loop iterations
 .loop ; each loop iteration, write 4 tile numbers
 	push bc
-	ld a,[de]
-	ld [hli],a
+	ld a, [de]
+	ld [hli], a
 	inc de
-	ld a,[de]
-	ld [hli],a
+	ld a, [de]
+	ld [hli], a
 	inc de
-	ld a,[de]
-	ld [hli],a
+	ld a, [de]
+	ld [hli], a
 	inc de
-	ld a,[de]
-	ld [hl],a
+	ld a, [de]
+	ld [hl], a
 	inc de
-	ld bc,$0015
-	add hl,bc
+	ld bc, $0015
+	add hl, bc
 	pop bc
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 ; function to update joypad state and simulate button presses
 JoypadOverworld::
 	xor a
-	ld [wSpriteStateData1 + 3],a
-	ld [wSpriteStateData1 + 5],a
+	ld [wSpriteStateData1 + 3], a
+	ld [wSpriteStateData1 + 5], a
 	call RunMapScript
 	call Joypad
-	ld a,[wFlags_D733]
-	bit 3,a ; check if a trainer wants a challenge
-	jr nz,.notForcedDownwards
-	ld a,[wCurMap]
+	ld a, [wFlags_D733]
+	bit 3, a ; check if a trainer wants a challenge
+	jr nz, .notForcedDownwards
+	ld a, [wCurMap]
 	cp ROUTE_17 ; Cycling Road
-	jr nz,.notForcedDownwards
-	ld a,[hJoyHeld]
+	jr nz, .notForcedDownwards
+	ld a, [hJoyHeld]
 	and D_DOWN | D_UP | D_LEFT | D_RIGHT | B_BUTTON | A_BUTTON
-	jr nz,.notForcedDownwards
-	ld a,D_DOWN
-	ld [hJoyHeld],a ; on the cycling road, if there isn't a trainer and the player isn't pressing buttons, simulate a down press
+	jr nz, .notForcedDownwards
+	ld a, D_DOWN
+	ld [hJoyHeld], a ; on the cycling road, if there isn't a trainer and the player isn't pressing buttons, simulate a down press
 .notForcedDownwards
-	ld a,[wd730]
-	bit 7,a
+	ld a, [wd730]
+	bit 7, a
 	ret z
 ; if simulating button presses
-	ld a,[hJoyHeld]
-	ld b,a
-	ld a,[wOverrideSimulatedJoypadStatesMask] ; bit mask for button presses that override simulated ones
+	ld a, [hJoyHeld]
+	ld b, a
+	ld a, [wOverrideSimulatedJoypadStatesMask] ; bit mask for button presses that override simulated ones
 	and b
 	ret nz ; return if the simulated button presses are overridden
-	ld hl,wSimulatedJoypadStatesIndex
+	ld hl, wSimulatedJoypadStatesIndex
 	dec [hl]
-	ld a,[hl]
-	cp a,$ff
-	jr z,.doneSimulating ; if the end of the simulated button presses has been reached
-	ld hl,wSimulatedJoypadStatesEnd
+	ld a, [hl]
+	cp $ff
+	jr z, .doneSimulating ; if the end of the simulated button presses has been reached
+	ld hl, wSimulatedJoypadStatesEnd
 	add l
-	ld l,a
-	jr nc,.noCarry
+	ld l, a
+	jr nc, .noCarry
 	inc h
 .noCarry
-	ld a,[hl]
-	ld [hJoyHeld],a ; store simulated button press in joypad state
+	ld a, [hl]
+	ld [hJoyHeld], a ; store simulated button press in joypad state
 	and a
 	ret nz
-	ld [hJoyPressed],a
-	ld [hJoyReleased],a
+	ld [hJoyPressed], a
+	ld [hJoyReleased], a
 	ret
 
 ; if done simulating button presses
 .doneSimulating
 	xor a
-	ld [wWastedByteCD3A],a
-	ld [wSimulatedJoypadStatesIndex],a
-	ld [wSimulatedJoypadStatesEnd],a
-	ld [wJoyIgnore],a
-	ld [hJoyHeld],a
-	ld hl,wd736
-	ld a,[hl]
+	ld [wWastedByteCD3A], a
+	ld [wSimulatedJoypadStatesIndex], a
+	ld [wSimulatedJoypadStatesEnd], a
+	ld [wJoyIgnore], a
+	ld [hJoyHeld], a
+	ld hl, wd736
+	ld a, [hl]
 	and $f8
-	ld [hl],a
-	ld hl,wd730
-	res 7,[hl]
+	ld [hl], a
+	ld hl, wd730
+	res 7, [hl]
 	ret
 
 ; function to check the tile ahead to determine if the character should get on land or keep surfing
@@ -1915,43 +1915,43 @@ JoypadOverworld::
 ; and 2429 always sets c to 0xF0. There is no 0xF0 background tile, so it
 ; is considered impassable and it is detected as a collision.
 CollisionCheckOnWater::
-	ld a,[wd730]
-	bit 7,a
-	jp nz,.noCollision ; return and clear carry if button presses are being simulated
-	ld a,[wPlayerDirection] ; the direction that the player is trying to go in
-	ld d,a
-	ld a,[wSpriteStateData1 + 12] ; the player sprite's collision data (bit field) (set in the sprite movement code)
+	ld a, [wd730]
+	bit 7, a
+	jp nz, .noCollision ; return and clear carry if button presses are being simulated
+	ld a, [wPlayerDirection] ; the direction that the player is trying to go in
+	ld d, a
+	ld a, [wSpriteStateData1 + 12] ; the player sprite's collision data (bit field) (set in the sprite movement code)
 	and d ; check if a sprite is in the direction the player is trying to go
-	jr nz,.checkIfNextTileIsPassable ; bug?
-	ld hl,TilePairCollisionsWater
+	jr nz, .checkIfNextTileIsPassable ; bug?
+	ld hl, TilePairCollisionsWater
 	call CheckForJumpingAndTilePairCollisions
-	jr c,.collision
+	jr c, .collision
 	predef GetTileAndCoordsInFrontOfPlayer ; get tile in front of player (puts it in c and [wTileInFrontOfPlayer])
-	ld a,[wTileInFrontOfPlayer] ; tile in front of player
-	cp a,$14 ; water tile
-	jr z,.noCollision ; keep surfing if it's a water tile
-	cp a,$32 ; either the left tile of the S.S. Anne boarding platform or the tile on eastern coastlines (depending on the current tileset)
-	jr z,.checkIfVermilionDockTileset
-	cp a,$48 ; tile on right on coast lines in Safari Zone
-	jr z,.noCollision ; keep surfing
+	ld a, [wTileInFrontOfPlayer] ; tile in front of player
+	cp $14 ; water tile
+	jr z, .noCollision ; keep surfing if it's a water tile
+	cp $32 ; either the left tile of the S.S. Anne boarding platform or the tile on eastern coastlines (depending on the current tileset)
+	jr z, .checkIfVermilionDockTileset
+	cp $48 ; tile on right on coast lines in Safari Zone
+	jr z, .noCollision ; keep surfing
 ; check if the [land] tile in front of the player is passable
 .checkIfNextTileIsPassable
-	ld hl,wTilesetCollisionPtr ; pointer to list of passable tiles
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
+	ld hl, wTilesetCollisionPtr ; pointer to list of passable tiles
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
 .loop
-	ld a,[hli]
-	cp a,$ff
-	jr z,.collision
+	ld a, [hli]
+	cp $ff
+	jr z, .collision
 	cp c
-	jr z,.stopSurfing ; stop surfing if the tile is passable
+	jr z, .stopSurfing ; stop surfing if the tile is passable
 	jr .loop
 .collision
-	ld a,[wChannelSoundIDs + Ch4]
+	ld a, [wChannelSoundIDs + Ch4]
 	cp SFX_COLLISION ; check if collision sound is already playing
-	jr z,.setCarry
-	ld a,SFX_COLLISION
+	jr z, .setCarry
+	ld a, SFX_COLLISION
 	call PlaySound ; play collision sound (if it's not already playing)
 .setCarry
 	scf
@@ -1962,7 +1962,7 @@ CollisionCheckOnWater::
 	ret
 .stopSurfing
 	xor a
-	ld [wWalkBikeSurfState],a
+	ld [wWalkBikeSurfState], a
 	call LoadPlayerSpriteGraphics
 	call PlayDefaultMusic
 	jr .noCollision
@@ -1978,40 +1978,40 @@ RunMapScript::
 	push de
 	push bc
 	callba TryPushingBoulder
-	ld a,[wFlags_0xcd60]
-	bit 1,a ; play boulder dust animation
-	jr z,.afterBoulderEffect
+	ld a, [wFlags_0xcd60]
+	bit 1, a ; play boulder dust animation
+	jr z, .afterBoulderEffect
 	callba DoBoulderDustAnimation
 .afterBoulderEffect
 	pop bc
 	pop de
 	pop hl
 	call RunNPCMovementScript
-	ld a,[wCurMap] ; current map number
+	ld a, [wCurMap] ; current map number
 	call SwitchToMapRomBank ; change to the ROM bank the map's data is in
-	ld hl,wMapScriptPtr
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a
-	ld de,.return
+	ld hl, wMapScriptPtr
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
+	ld de, .return
 	push de
 	jp hl ; jump to script
 .return
 	ret
 
 LoadWalkingPlayerSpriteGraphics::
-	ld de,RedSprite
-	ld hl,vNPCSprites
+	ld de, RedSprite
+	ld hl, vNPCSprites
 	jr LoadPlayerSpriteGraphicsCommon
 
 LoadSurfingPlayerSpriteGraphics::
-	ld de,SeelSprite
-	ld hl,vNPCSprites
+	ld de, SeelSprite
+	ld hl, vNPCSprites
 	jr LoadPlayerSpriteGraphicsCommon
 
 LoadBikePlayerSpriteGraphics::
-	ld de,RedCyclingSprite
-	ld hl,vNPCSprites
+	ld de, RedCyclingSprite
+	ld hl, vNPCSprites
 
 LoadPlayerSpriteGraphicsCommon::
 	push de
@@ -2020,321 +2020,321 @@ LoadPlayerSpriteGraphicsCommon::
 	call CopyVideoData
 	pop hl
 	pop de
-	ld a,$c0
+	ld a, $c0
 	add e
-	ld e,a
-	jr nc,.noCarry
+	ld e, a
+	jr nc, .noCarry
 	inc d
 .noCarry
-	set 3,h
+	set 3, h
 	lb bc, BANK(RedSprite), $0c
 	jp CopyVideoData
 
 ; function to load data from the map header
 LoadMapHeader::
 	callba MarkTownVisitedAndLoadMissableObjects
-	ld a,[wCurMapTileset]
-	ld [wUnusedD119],a
-	ld a,[wCurMap]
+	ld a, [wCurMapTileset]
+	ld [wUnusedD119], a
+	ld a, [wCurMap]
 	call SwitchToMapRomBank
-	ld a,[wCurMapTileset]
-	ld b,a
-	res 7,a
-	ld [wCurMapTileset],a
-	ld [hPreviousTileset],a
-	bit 7,b
+	ld a, [wCurMapTileset]
+	ld b, a
+	res 7, a
+	ld [wCurMapTileset], a
+	ld [hPreviousTileset], a
+	bit 7, b
 	ret nz
-	ld hl,MapHeaderPointers
-	ld a,[wCurMap]
+	ld hl, MapHeaderPointers
+	ld a, [wCurMap]
 	sla a
-	jr nc,.noCarry1
+	jr nc, .noCarry1
 	inc h
 .noCarry1
 	add l
-	ld l,a
-	jr nc,.noCarry2
+	ld l, a
+	jr nc, .noCarry2
 	inc h
 .noCarry2
-	ld a,[hli]
-	ld h,[hl]
-	ld l,a ; hl = base of map header
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a ; hl = base of map header
 ; copy the first 10 bytes (the fixed area) of the map data to D367-D370
-	ld de,wCurMapTileset
-	ld c,$0a
+	ld de, wCurMapTileset
+	ld c, $0a
 .copyFixedHeaderLoop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	dec c
-	jr nz,.copyFixedHeaderLoop
+	jr nz, .copyFixedHeaderLoop
 ; initialize all the connected maps to disabled at first, before loading the actual values
-	ld a,$ff
-	ld [wMapConn1Ptr],a
-	ld [wMapConn2Ptr],a
-	ld [wMapConn3Ptr],a
-	ld [wMapConn4Ptr],a
+	ld a, $ff
+	ld [wMapConn1Ptr], a
+	ld [wMapConn2Ptr], a
+	ld [wMapConn3Ptr], a
+	ld [wMapConn4Ptr], a
 ; copy connection data (if any) to WRAM
-	ld a,[wMapConnections]
-	ld b,a
+	ld a, [wMapConnections]
+	ld b, a
 .checkNorth
-	bit 3,b
-	jr z,.checkSouth
-	ld de,wMapConn1Ptr
+	bit 3, b
+	jr z, .checkSouth
+	ld de, wMapConn1Ptr
 	call CopyMapConnectionHeader
 .checkSouth
-	bit 2,b
-	jr z,.checkWest
-	ld de,wMapConn2Ptr
+	bit 2, b
+	jr z, .checkWest
+	ld de, wMapConn2Ptr
 	call CopyMapConnectionHeader
 .checkWest
-	bit 1,b
-	jr z,.checkEast
-	ld de,wMapConn3Ptr
+	bit 1, b
+	jr z, .checkEast
+	ld de, wMapConn3Ptr
 	call CopyMapConnectionHeader
 .checkEast
-	bit 0,b
-	jr z,.getObjectDataPointer
-	ld de,wMapConn4Ptr
+	bit 0, b
+	jr z, .getObjectDataPointer
+	ld de, wMapConn4Ptr
 	call CopyMapConnectionHeader
 .getObjectDataPointer
-	ld a,[hli]
-	ld [wObjectDataPointerTemp],a
-	ld a,[hli]
-	ld [wObjectDataPointerTemp + 1],a
+	ld a, [hli]
+	ld [wObjectDataPointerTemp], a
+	ld a, [hli]
+	ld [wObjectDataPointerTemp + 1], a
 	push hl
-	ld a,[wObjectDataPointerTemp]
-	ld l,a
-	ld a,[wObjectDataPointerTemp + 1]
-	ld h,a ; hl = base of object data
-	ld de,wMapBackgroundTile
-	ld a,[hli]
-	ld [de],a
+	ld a, [wObjectDataPointerTemp]
+	ld l, a
+	ld a, [wObjectDataPointerTemp + 1]
+	ld h, a ; hl = base of object data
+	ld de, wMapBackgroundTile
+	ld a, [hli]
+	ld [de], a
 .loadWarpData
-	ld a,[hli]
-	ld [wNumberOfWarps],a
+	ld a, [hli]
+	ld [wNumberOfWarps], a
 	and a
-	jr z,.loadSignData
-	ld c,a
-	ld de,wWarpEntries
+	jr z, .loadSignData
+	ld c, a
+	ld de, wWarpEntries
 .warpLoop ; one warp per loop iteration
-	ld b,$04
+	ld b, $04
 .warpInnerLoop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	dec b
-	jr nz,.warpInnerLoop
+	jr nz, .warpInnerLoop
 	dec c
-	jr nz,.warpLoop
+	jr nz, .warpLoop
 .loadSignData
-	ld a,[hli] ; number of signs
-	ld [wNumSigns],a
+	ld a, [hli] ; number of signs
+	ld [wNumSigns], a
 	and a ; are there any signs?
-	jr z,.loadSpriteData ; if not, skip this
-	ld c,a
-	ld de,wSignTextIDs
-	ld a,d
-	ld [hSignCoordPointer],a
-	ld a,e
-	ld [hSignCoordPointer + 1],a
-	ld de,wSignCoords
+	jr z, .loadSpriteData ; if not, skip this
+	ld c, a
+	ld de, wSignTextIDs
+	ld a, d
+	ld [hSignCoordPointer], a
+	ld a, e
+	ld [hSignCoordPointer + 1], a
+	ld de, wSignCoords
 .signLoop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	push de
-	ld a,[hSignCoordPointer]
-	ld d,a
-	ld a,[hSignCoordPointer + 1]
-	ld e,a
-	ld a,[hli]
-	ld [de],a
+	ld a, [hSignCoordPointer]
+	ld d, a
+	ld a, [hSignCoordPointer + 1]
+	ld e, a
+	ld a, [hli]
+	ld [de], a
 	inc de
-	ld a,d
-	ld [hSignCoordPointer],a
-	ld a,e
-	ld [hSignCoordPointer + 1],a
+	ld a, d
+	ld [hSignCoordPointer], a
+	ld a, e
+	ld [hSignCoordPointer + 1], a
 	pop de
 	dec c
-	jr nz,.signLoop
+	jr nz, .signLoop
 .loadSpriteData
-	ld a,[wd72e]
-	bit 5,a ; did a battle happen immediately before this?
-	jp nz,.finishUp ; if so, skip this because battles don't destroy this data
-	ld a,[hli]
-	ld [wNumSprites],a ; save the number of sprites
+	ld a, [wd72e]
+	bit 5, a ; did a battle happen immediately before this?
+	jp nz, .finishUp ; if so, skip this because battles don't destroy this data
+	ld a, [hli]
+	ld [wNumSprites], a ; save the number of sprites
 	push hl
 ; zero C110-C1FF and C210-C2FF
-	ld hl,wSpriteStateData1 + $10
-	ld de,wSpriteStateData2 + $10
+	ld hl, wSpriteStateData1 + $10
+	ld de, wSpriteStateData2 + $10
 	xor a
-	ld b,$f0
+	ld b, $f0
 .zeroSpriteDataLoop
-	ld [hli],a
-	ld [de],a
+	ld [hli], a
+	ld [de], a
 	inc e
 	dec b
-	jr nz,.zeroSpriteDataLoop
+	jr nz, .zeroSpriteDataLoop
 ; initialize all C100-C1FF sprite entries to disabled (other than player's)
-	ld hl,wSpriteStateData1 + $12
-	ld de,$0010
-	ld c,$0f
+	ld hl, wSpriteStateData1 + $12
+	ld de, $0010
+	ld c, $0f
 .disableSpriteEntriesLoop
-	ld [hl],$ff
-	add hl,de
+	ld [hl], $ff
+	add hl, de
 	dec c
-	jr nz,.disableSpriteEntriesLoop
+	jr nz, .disableSpriteEntriesLoop
 	pop hl
-	ld de,wSpriteStateData1 + $10
-	ld a,[wNumSprites] ; number of sprites
+	ld de, wSpriteStateData1 + $10
+	ld a, [wNumSprites] ; number of sprites
 	and a ; are there any sprites?
-	jp z,.finishUp ; if there are no sprites, skip the rest
-	ld b,a
-	ld c,$00
+	jp z, .finishUp ; if there are no sprites, skip the rest
+	ld b, a
+	ld c, $00
 .loadSpriteLoop
-	ld a,[hli]
-	ld [de],a ; store picture ID at C1X0
+	ld a, [hli]
+	ld [de], a ; store picture ID at C1X0
 	inc d
-	ld a,$04
+	ld a, $04
 	add e
-	ld e,a
-	ld a,[hli]
-	ld [de],a ; store Y position at C2X4
+	ld e, a
+	ld a, [hli]
+	ld [de], a ; store Y position at C2X4
 	inc e
-	ld a,[hli]
-	ld [de],a ; store X position at C2X5
+	ld a, [hli]
+	ld [de], a ; store X position at C2X5
 	inc e
-	ld a,[hli]
-	ld [de],a ; store movement byte 1 at C2X6
-	ld a,[hli]
-	ld [hLoadSpriteTemp1],a ; save movement byte 2
-	ld a,[hli]
-	ld [hLoadSpriteTemp2],a ; save text ID and flags byte
+	ld a, [hli]
+	ld [de], a ; store movement byte 1 at C2X6
+	ld a, [hli]
+	ld [hLoadSpriteTemp1], a ; save movement byte 2
+	ld a, [hli]
+	ld [hLoadSpriteTemp2], a ; save text ID and flags byte
 	push bc
 	push hl
-	ld b,$00
-	ld hl,wMapSpriteData
-	add hl,bc
-	ld a,[hLoadSpriteTemp1]
-	ld [hli],a ; store movement byte 2 in byte 0 of sprite entry
-	ld a,[hLoadSpriteTemp2]
-	ld [hl],a ; this appears pointless, since the value is overwritten immediately after
-	ld a,[hLoadSpriteTemp2]
-	ld [hLoadSpriteTemp1],a
-	and a,$3f
-	ld [hl],a ; store text ID in byte 1 of sprite entry
+	ld b, $00
+	ld hl, wMapSpriteData
+	add hl, bc
+	ld a, [hLoadSpriteTemp1]
+	ld [hli], a ; store movement byte 2 in byte 0 of sprite entry
+	ld a, [hLoadSpriteTemp2]
+	ld [hl], a ; this appears pointless, since the value is overwritten immediately after
+	ld a, [hLoadSpriteTemp2]
+	ld [hLoadSpriteTemp1], a
+	and $3f
+	ld [hl], a ; store text ID in byte 1 of sprite entry
 	pop hl
-	ld a,[hLoadSpriteTemp1]
-	bit 6,a
-	jr nz,.trainerSprite
-	bit 7,a
-	jr nz,.itemBallSprite
+	ld a, [hLoadSpriteTemp1]
+	bit 6, a
+	jr nz, .trainerSprite
+	bit 7, a
+	jr nz, .itemBallSprite
 	jr .regularSprite
 .trainerSprite
-	ld a,[hli]
-	ld [hLoadSpriteTemp1],a ; save trainer class
-	ld a,[hli]
-	ld [hLoadSpriteTemp2],a ; save trainer number (within class)
+	ld a, [hli]
+	ld [hLoadSpriteTemp1], a ; save trainer class
+	ld a, [hli]
+	ld [hLoadSpriteTemp2], a ; save trainer number (within class)
 	push hl
-	ld hl,wMapSpriteExtraData
-	add hl,bc
-	ld a,[hLoadSpriteTemp1]
-	ld [hli],a ; store trainer class in byte 0 of the entry
-	ld a,[hLoadSpriteTemp2]
-	ld [hl],a ; store trainer number in byte 1 of the entry
+	ld hl, wMapSpriteExtraData
+	add hl, bc
+	ld a, [hLoadSpriteTemp1]
+	ld [hli], a ; store trainer class in byte 0 of the entry
+	ld a, [hLoadSpriteTemp2]
+	ld [hl], a ; store trainer number in byte 1 of the entry
 	pop hl
 	jr .nextSprite
 .itemBallSprite
-	ld a,[hli]
-	ld [hLoadSpriteTemp1],a ; save item number
+	ld a, [hli]
+	ld [hLoadSpriteTemp1], a ; save item number
 	push hl
-	ld hl,wMapSpriteExtraData
-	add hl,bc
-	ld a,[hLoadSpriteTemp1]
-	ld [hli],a ; store item number in byte 0 of the entry
+	ld hl, wMapSpriteExtraData
+	add hl, bc
+	ld a, [hLoadSpriteTemp1]
+	ld [hli], a ; store item number in byte 0 of the entry
 	xor a
-	ld [hl],a ; zero byte 1, since it is not used
+	ld [hl], a ; zero byte 1, since it is not used
 	pop hl
 	jr .nextSprite
 .regularSprite
 	push hl
-	ld hl,wMapSpriteExtraData
-	add hl,bc
+	ld hl, wMapSpriteExtraData
+	add hl, bc
 ; zero both bytes, since regular sprites don't use this extra space
 	xor a
-	ld [hli],a
-	ld [hl],a
+	ld [hli], a
+	ld [hl], a
 	pop hl
 .nextSprite
 	pop bc
 	dec d
-	ld a,$0a
+	ld a, $0a
 	add e
-	ld e,a
+	ld e, a
 	inc c
 	inc c
 	dec b
-	jp nz,.loadSpriteLoop
+	jp nz, .loadSpriteLoop
 .finishUp
 	predef LoadTilesetHeader
 	callab LoadWildData
 	pop hl ; restore hl from before going to the warp/sign/sprite data (this value was saved for seemingly no purpose)
-	ld a,[wCurMapHeight] ; map height in 4x4 tile blocks
+	ld a, [wCurMapHeight] ; map height in 4x4 tile blocks
 	add a ; double it
-	ld [wCurrentMapHeight2],a ; store map height in 2x2 tile blocks
-	ld a,[wCurMapWidth] ; map width in 4x4 tile blocks
+	ld [wCurrentMapHeight2], a ; store map height in 2x2 tile blocks
+	ld a, [wCurMapWidth] ; map width in 4x4 tile blocks
 	add a ; double it
-	ld [wCurrentMapWidth2],a ; map width in 2x2 tile blocks
-	ld a,[wCurMap]
-	ld c,a
-	ld b,$00
-	ld a,[H_LOADEDROMBANK]
+	ld [wCurrentMapWidth2], a ; map width in 2x2 tile blocks
+	ld a, [wCurMap]
+	ld c, a
+	ld b, $00
+	ld a, [H_LOADEDROMBANK]
 	push af
 	ld a, BANK(MapSongBanks)
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ld hl, MapSongBanks
-	add hl,bc
-	add hl,bc
-	ld a,[hli]
-	ld [wMapMusicSoundID],a ; music 1
-	ld a,[hl]
-	ld [wMapMusicROMBank],a ; music 2
+	add hl, bc
+	add hl, bc
+	ld a, [hli]
+	ld [wMapMusicSoundID], a ; music 1
+	ld a, [hl]
+	ld [wMapMusicROMBank], a ; music 2
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 ; function to copy map connection data from ROM to WRAM
 ; Input: hl = source, de = destination
 CopyMapConnectionHeader::
-	ld c,$0b
+	ld c, $0b
 .loop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	dec c
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 ; function to load map data
 LoadMapData::
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
 	call DisableLCD
-	ld a,$98
-	ld [wMapViewVRAMPointer + 1],a
+	ld a, $98
+	ld [wMapViewVRAMPointer + 1], a
 	xor a
-	ld [wMapViewVRAMPointer],a
-	ld [hSCY],a
-	ld [hSCX],a
-	ld [wWalkCounter],a
-	ld [wUnusedD119],a
-	ld [wWalkBikeSurfStateCopy],a
-	ld [wSpriteSetID],a
+	ld [wMapViewVRAMPointer], a
+	ld [hSCY], a
+	ld [hSCX], a
+	ld [wWalkCounter], a
+	ld [wUnusedD119], a
+	ld [wWalkBikeSurfStateCopy], a
+	ld [wSpriteSetID], a
 	call LoadTextBoxTilePatterns
 	call LoadMapHeader
 	callba InitMapSprites ; load tile pattern data for sprites
@@ -2343,42 +2343,42 @@ LoadMapData::
 	call LoadCurrentMapView
 ; copy current map view to VRAM
 	coord hl, 0, 0
-	ld de,vBGMap0
-	ld b,18
+	ld de, vBGMap0
+	ld b, 18
 .vramCopyLoop
-	ld c,20
+	ld c, 20
 .vramCopyInnerLoop
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc e
 	dec c
-	jr nz,.vramCopyInnerLoop
-	ld a,32 - 20
+	jr nz, .vramCopyInnerLoop
+	ld a, 32 - 20
 	add e
-	ld e,a
-	jr nc,.noCarry
+	ld e, a
+	jr nc, .noCarry
 	inc d
 .noCarry
 	dec b
-	jr nz,.vramCopyLoop
-	ld a,$01
-	ld [wUpdateSpritesEnabled],a
+	jr nz, .vramCopyLoop
+	ld a, $01
+	ld [wUpdateSpritesEnabled], a
 	call EnableLCD
 	ld b, SET_PAL_OVERWORLD
 	call RunPaletteCommand
 	call LoadPlayerSpriteGraphics
-	ld a,[wd732]
-	and a,1 << 4 | 1 << 3 ; fly warp or dungeon warp
-	jr nz,.restoreRomBank
-	ld a,[wFlags_D733]
-	bit 1,a
-	jr nz,.restoreRomBank
+	ld a, [wd732]
+	and 1 << 4 | 1 << 3 ; fly warp or dungeon warp
+	jr nz, .restoreRomBank
+	ld a, [wFlags_D733]
+	bit 1, a
+	jr nz, .restoreRomBank
 	call UpdateMusic6Times
 	call PlayDefaultMusicFadeOutCurrent
 .restoreRomBank
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	ret
 
 ; function to switch to the ROM bank that a map is stored in
@@ -2386,18 +2386,18 @@ LoadMapData::
 SwitchToMapRomBank::
 	push hl
 	push bc
-	ld c,a
-	ld b,$00
-	ld a,Bank(MapHeaderBanks)
+	ld c, a
+	ld b, $00
+	ld a, Bank(MapHeaderBanks)
 	call BankswitchHome ; switch to ROM bank 3
-	ld hl,MapHeaderBanks
-	add hl,bc
-	ld a,[hl]
-	ld [$ffe8],a ; save map ROM bank
+	ld hl, MapHeaderBanks
+	add hl, bc
+	ld a, [hl]
+	ld [$ffe8], a ; save map ROM bank
 	call BankswitchBack
-	ld a,[$ffe8]
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a ; switch to map ROM bank
+	ld a, [$ffe8]
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a ; switch to map ROM bank
 	pop bc
 	pop hl
 	ret

--- a/home/text.asm
+++ b/home/text.asm
@@ -18,7 +18,7 @@ TextBoxBorder::
 .next
 	push hl
 	ld a, "│"
-	ld [hli],a
+	ld [hli], a
 	ld a, " "
 	call NPlaceChar
 	ld [hl], "│"
@@ -49,12 +49,12 @@ NPlaceChar::
 PlaceString::
 	push hl
 PlaceNextChar::
-	ld a,[de]
+	ld a, [de]
 
 	cp "@"
 	jr nz, Char4ETest
-	ld b,h
-	ld c,l
+	ld b, h
+	ld c, l
 	pop hl
 	ret
 
@@ -62,19 +62,19 @@ Char4ETest::
 	cp $4E ; next
 	jr nz, .char4FTest
 	ld bc, 2 * SCREEN_WIDTH
-	ld a,[hFlags_0xFFF6]
-	bit 2,a
-	jr z,.ok
-	ld bc,SCREEN_WIDTH
+	ld a, [hFlags_0xFFF6]
+	bit 2, a
+	jr z, .ok
+	ld bc, SCREEN_WIDTH
 .ok
 	pop hl
-	add hl,bc
+	add hl, bc
 	push hl
 	jp PlaceNextChar_inc
 
 .char4FTest
 	cp $4F ; line
-	jr nz,.next3
+	jr nz, .next3
 	pop hl
 	coord hl, 1, 16
 	push hl
@@ -111,17 +111,17 @@ endm
 	dict $59, Char59 ; TARGET
 	dict $5A, Char5A ; USER
 
-	ld [hli],a
+	ld [hli], a
 	call PrintLetterDelay
 PlaceNextChar_inc::
 	inc de
 	jp PlaceNextChar
 
 Char00::
-	ld b,h
-	ld c,l
+	ld b, h
+	ld c, l
 	pop hl
-	ld de,Char00Text
+	ld de, Char00Text
 	dec de
 	ret
 
@@ -131,47 +131,47 @@ Char00Text:: ; “%d ERROR.”
 
 Char52:: ; player’s name
 	push de
-	ld de,wPlayerName
+	ld de, wPlayerName
 	jr FinishDTE
 
 Char53:: ; rival’s name
 	push de
-	ld de,wRivalName
+	ld de, wRivalName
 	jr FinishDTE
 
 Char5D:: ; TRAINER
 	push de
-	ld de,Char5DText
+	ld de, Char5DText
 	jr FinishDTE
 
 Char5C:: ; TM
 	push de
-	ld de,Char5CText
+	ld de, Char5CText
 	jr FinishDTE
 
 Char5B:: ; PC
 	push de
-	ld de,Char5BText
+	ld de, Char5BText
 	jr FinishDTE
 
 Char5E:: ; ROCKET
 	push de
-	ld de,Char5EText
+	ld de, Char5EText
 	jr FinishDTE
 
 Char54:: ; POKé
 	push de
-	ld de,Char54Text
+	ld de, Char54Text
 	jr FinishDTE
 
 Char56:: ; ……
 	push de
-	ld de,Char56Text
+	ld de, Char56Text
 	jr FinishDTE
 
 Char4A:: ; PKMN
 	push de
-	ld de,Char4AText
+	ld de, Char4AText
 	jr FinishDTE
 
 Char59::
@@ -180,7 +180,7 @@ Char59::
 ; or
 ; player active monster’s name
 ; (like Char5A but flipped)
-	ld a,[H_WHOSETURN]
+	ld a, [H_WHOSETURN]
 	xor 1
 	jr MonsterNameCharsCommon
 
@@ -189,26 +189,26 @@ Char5A::
 ; player active monster’s name
 ; or
 ; enemy active monster’s name, prefixed with “Enemy ”
-	ld a,[H_WHOSETURN]
+	ld a, [H_WHOSETURN]
 MonsterNameCharsCommon::
 	push de
 	and a
-	jr nz,.Enemy
-	ld de,wBattleMonNick ; player active monster name
+	jr nz, .Enemy
+	ld de, wBattleMonNick ; player active monster name
 	jr FinishDTE
 
 .Enemy
 	; print “Enemy ”
-	ld de,Char5AText
+	ld de, Char5AText
 	call PlaceString
-	ld h,b
-	ld l,c
-	ld de,wEnemyMonNick ; enemy active monster name
+	ld h, b
+	ld l, c
+	ld de, wEnemyMonNick ; enemy active monster name
 
 FinishDTE::
 	call PlaceString
-	ld h,b
-	ld l,c
+	ld h, b
+	ld l, c
 	pop de
 	inc de
 	jp PlaceNextChar
@@ -232,12 +232,12 @@ Char4AText::
 
 Char55::
 	push de
-	ld b,h
-	ld c,l
-	ld hl,Char55Text
+	ld b, h
+	ld c, l
+	ld hl, Char55Text
 	call TextCommandProcessor
-	ld h,b
-	ld l,c
+	ld h, b
+	ld l, c
 	pop de
 	inc de
 	jp PlaceNextChar
@@ -249,12 +249,12 @@ Char55Text::
 
 Char5F::
 ; ends a Pokédex entry
-	ld [hl],"."
+	ld [hl], "."
 	pop hl
 	ret
 
 Char58:: ; prompt
-	ld a,[wLinkState]
+	ld a, [wLinkState]
 	cp LINK_STATE_BATTLING
 	jp z, .ok
 	ld a, "▼"
@@ -290,14 +290,14 @@ Char51:: ; para
 
 Char49::
 	push de
-	ld a,"▼"
+	ld a, "▼"
 	Coorda 18, 16
 	call ProtectedDelay3
 	call ManualTextScroll
 	coord hl, 1, 10
 	lb bc, 7, 18
 	call ClearScreenArea
-	ld c,20
+	ld c, 20
 	call DelayFrames
 	pop de
 	pop hl
@@ -306,7 +306,7 @@ Char49::
 	jp PlaceNextChar_inc
 
 Char4B::
-	ld a,"▼"
+	ld a, "▼"
 	Coorda 18, 16
 	call ProtectedDelay3
 	push de
@@ -332,25 +332,25 @@ ScrollTextUpOneLine::
 	coord de, 0, 13 ; empty line above text
 	ld b, SCREEN_WIDTH * 3
 .copyText
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
 	dec b
-	jr nz,.copyText
+	jr nz, .copyText
 	coord hl, 1, 16
 	ld a, " "
-	ld b,SCREEN_WIDTH - 2
+	ld b, SCREEN_WIDTH - 2
 .clearText
-	ld [hli],a
+	ld [hli], a
 	dec b
-	jr nz,.clearText
+	jr nz, .clearText
 
 	; wait five frames
-	ld b,5
+	ld b, 5
 .WaitFrame
 	call DelayFrame
 	dec b
-	jr nz,.WaitFrame
+	jr nz, .WaitFrame
 
 	ret
 
@@ -361,33 +361,33 @@ ProtectedDelay3::
 	ret
 
 TextCommandProcessor::
-	ld a,[wLetterPrintingDelayFlags]
+	ld a, [wLetterPrintingDelayFlags]
 	push af
-	set 1,a
-	ld e,a
+	set 1, a
+	ld e, a
 	ld a, [$fff4]
 	xor e
-	ld [wLetterPrintingDelayFlags],a
-	ld a,c
-	ld [wTextDest],a
-	ld a,b
-	ld [wTextDest + 1],a
+	ld [wLetterPrintingDelayFlags], a
+	ld a, c
+	ld [wTextDest], a
+	ld a, b
+	ld [wTextDest + 1], a
 
 NextTextCommand::
-	ld a,[hli]
-	cp a, "@" ; terminator
-	jr nz,.doTextCommand
+	ld a, [hli]
+	cp "@" ; terminator
+	jr nz, .doTextCommand
 	pop af
-	ld [wLetterPrintingDelayFlags],a
+	ld [wLetterPrintingDelayFlags], a
 	ret
 .doTextCommand
 	push hl
-	cp a, $17
+	cp $17
 	jp z, TextCommand17
-	cp a, $0e
-	jp nc,TextCommand0B ; if a != 0x17 and a >= 0xE, go to command 0xB
+	cp $0e
+	jp nc, TextCommand0B ; if a != 0x17 and a >= 0xE, go to command 0xB
 ; if a < 0xE, use a jump table
-	ld hl,TextCommandJumpTable
+	ld hl, TextCommandJumpTable
 	push bc
 	add a
 	ld b, 0
@@ -406,17 +406,17 @@ NextTextCommand::
 ; CC = width
 TextCommand04::
 	pop hl
-	ld a,[hli]
-	ld e,a
-	ld a,[hli]
-	ld d,a
-	ld a,[hli]
-	ld b,a
-	ld a,[hli]
-	ld c,a
+	ld a, [hli]
+	ld e, a
+	ld a, [hli]
+	ld d, a
+	ld a, [hli]
+	ld b, a
+	ld a, [hli]
+	ld c, a
 	push hl
-	ld h,d
-	ld l,e
+	ld h, d
+	ld l, e
 	call TextBoxBorder
 	pop hl
 	jr NextTextCommand
@@ -425,13 +425,13 @@ TextCommand04::
 ; 00{string}
 TextCommand00::
 	pop hl
-	ld d,h
-	ld e,l
-	ld h,b
-	ld l,c
+	ld d, h
+	ld e, l
+	ld h, b
+	ld l, c
 	call PlaceString
-	ld h,d
-	ld l,e
+	ld h, d
+	ld l, e
 	inc hl
 	jr NextTextCommand
 
@@ -440,13 +440,13 @@ TextCommand00::
 ; AAAA = address of string
 TextCommand01::
 	pop hl
-	ld a,[hli]
-	ld e,a
-	ld a,[hli]
-	ld d,a
+	ld a, [hli]
+	ld e, a
+	ld a, [hli]
+	ld d, a
 	push hl
-	ld h,b
-	ld l,c
+	ld h, b
+	ld l, c
 	call PlaceString
 	pop hl
 	jr NextTextCommand
@@ -459,18 +459,18 @@ TextCommand01::
 ; bits 5-7 = unknown flags
 TextCommand02::
 	pop hl
-	ld a,[hli]
-	ld e,a
-	ld a,[hli]
-	ld d,a
-	ld a,[hli]
+	ld a, [hli]
+	ld e, a
+	ld a, [hli]
+	ld d, a
+	ld a, [hli]
 	push hl
-	ld h,b
-	ld l,c
-	ld c,a
+	ld h, b
+	ld l, c
+	ld c, a
 	call PrintBCDNumber
-	ld b,h
-	ld c,l
+	ld b, h
+	ld c, l
 	pop hl
 	jr NextTextCommand
 
@@ -479,12 +479,12 @@ TextCommand02::
 ; AAAA = new destination address
 TextCommand03::
 	pop hl
-	ld a,[hli]
-	ld [wTextDest],a
-	ld c,a
-	ld a,[hli]
-	ld [wTextDest + 1],a
-	ld b,a
+	ld a, [hli]
+	ld [wTextDest], a
+	ld c, a
+	ld a, [hli]
+	ld [wTextDest + 1], a
+	ld b, a
 	jp NextTextCommand
 
 ; repoint destination to second line of dialogue text box
@@ -499,15 +499,15 @@ TextCommand05::
 ; 06
 ; (no arguments)
 TextCommand06::
-	ld a,[wLinkState]
-	cp a,LINK_STATE_BATTLING
-	jp z,TextCommand0D
-	ld a,"▼"
+	ld a, [wLinkState]
+	cp LINK_STATE_BATTLING
+	jp z, TextCommand0D
+	ld a, "▼"
 	Coorda 18, 16 ; place down arrow in lower right corner of dialogue text box
 	push bc
 	call ManualTextScroll ; blink arrow and wait for A or B to be pressed
 	pop bc
-	ld a," "
+	ld a, " "
 	Coorda 18, 16 ; overwrite down arrow with blank space
 	pop hl
 	jp NextTextCommand
@@ -528,7 +528,7 @@ TextCommand07::
 ; 08{code}
 TextCommand08::
 	pop hl
-	ld de,NextTextCommand
+	ld de, NextTextCommand
 	push de ; return address
 	jp hl
 
@@ -540,25 +540,25 @@ TextCommand08::
 ; bits 4-7 = how long the number is in bytes
 TextCommand09::
 	pop hl
-	ld a,[hli]
-	ld e,a
-	ld a,[hli]
-	ld d,a
-	ld a,[hli]
+	ld a, [hli]
+	ld e, a
+	ld a, [hli]
+	ld d, a
+	ld a, [hli]
 	push hl
-	ld h,b
-	ld l,c
-	ld b,a
-	and a,$0f
-	ld c,a
-	ld a,b
-	and a,$f0
+	ld h, b
+	ld l, c
+	ld b, a
+	and $0f
+	ld c, a
+	ld a, b
+	and $f0
 	swap a
 	set BIT_LEFT_ALIGN,a
-	ld b,a
+	ld b, a
 	call PrintNumber
-	ld b,h
-	ld c,l
+	ld b, h
+	ld c, l
 	pop hl
 	jp NextTextCommand
 
@@ -568,10 +568,10 @@ TextCommand09::
 TextCommand0A::
 	push bc
 	call Joypad
-	ld a,[hJoyHeld]
-	and a,A_BUTTON | B_BUTTON
-	jr nz,.skipDelay
-	ld c,30
+	ld a, [hJoyHeld]
+	and A_BUTTON | B_BUTTON
+	jr nz, .skipDelay
+	ld c, 30
 	call DelayFrames
 .skipDelay
 	pop bc
@@ -585,24 +585,24 @@ TextCommand0B::
 	pop hl
 	push bc
 	dec hl
-	ld a,[hli]
-	ld b,a ; b = command number that got us here
+	ld a, [hli]
+	ld b, a ; b = command number that got us here
 	push hl
-	ld hl,TextCommandSounds
+	ld hl, TextCommandSounds
 .loop
-	ld a,[hli]
+	ld a, [hli]
 	cp b
-	jr z,.matchFound
+	jr z, .matchFound
 	inc hl
 	jr .loop
 .matchFound
-	cp a,$14
-	jr z,.pokemonCry
-	cp a,$15
-	jr z,.pokemonCry
-	cp a,$16
-	jr z,.pokemonCry
-	ld a,[hl]
+	cp $14
+	jr z, .pokemonCry
+	cp $15
+	jr z, .pokemonCry
+	cp $16
+	jr z, .pokemonCry
+	ld a, [hl]
 	call PlaySound
 	call WaitForSoundToFinish
 	pop hl
@@ -610,7 +610,7 @@ TextCommand0B::
 	jp NextTextCommand
 .pokemonCry
 	push de
-	ld a,[hl]
+	ld a, [hl]
 	call PlayCry
 	pop de
 	pop hl
@@ -635,27 +635,27 @@ TextCommandSounds::
 ; AA = number of ellipses to draw
 TextCommand0C::
 	pop hl
-	ld a,[hli]
-	ld d,a
+	ld a, [hli]
+	ld d, a
 	push hl
-	ld h,b
-	ld l,c
+	ld h, b
+	ld l, c
 .loop
-	ld a,"…"
-	ld [hli],a
+	ld a, "…"
+	ld [hli], a
 	push de
 	call Joypad
 	pop de
-	ld a,[hJoyHeld] ; joypad state
-	and a,A_BUTTON | B_BUTTON
-	jr nz,.skipDelay ; if so, skip the delay
-	ld c,10
+	ld a, [hJoyHeld] ; joypad state
+	and A_BUTTON | B_BUTTON
+	jr nz, .skipDelay ; if so, skip the delay
+	ld c, 10
 	call DelayFrames
 .skipDelay
 	dec d
-	jr nz,.loop
-	ld b,h
-	ld c,l
+	jr nz, .loop
+	ld b, h
+	ld c, l
 	pop hl
 	jp NextTextCommand
 
@@ -675,23 +675,23 @@ TextCommand0D::
 ; BB = bank
 TextCommand17::
 	pop hl
-	ld a,[H_LOADEDROMBANK]
+	ld a, [H_LOADEDROMBANK]
 	push af
-	ld a,[hli]
-	ld e,a
-	ld a,[hli]
-	ld d,a
-	ld a,[hli]
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld a, [hli]
+	ld e, a
+	ld a, [hli]
+	ld d, a
+	ld a, [hli]
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	push hl
-	ld l,e
-	ld h,d
+	ld l, e
+	ld h, d
 	call TextCommandProcessor
 	pop hl
 	pop af
-	ld [H_LOADEDROMBANK],a
-	ld [MBC1RomBank],a
+	ld [H_LOADEDROMBANK], a
+	ld [MBC1RomBank], a
 	jp NextTextCommand
 
 TextCommandJumpTable::

--- a/home/vcopy.asm
+++ b/home/vcopy.asm
@@ -10,27 +10,27 @@ GetRowColAddressBgMap::
 	srl h
 	rr a
 	or l
-	ld l,a
-	ld a,b
+	ld l, a
+	ld a, b
 	or h
-	ld h,a
+	ld h, a
 	ret
 
 ; clears a VRAM background map with blank space tiles
 ; INPUT: h - high byte of background tile map address in VRAM
 ClearBgMap::
-	ld a," "
+	ld a, " "
 	jr .next
-	ld a,l
+	ld a, l
 .next
-	ld de,$400 ; size of VRAM background map
-	ld l,e
+	ld de, $400 ; size of VRAM background map
+	ld l, e
 .loop
-	ld [hli],a
+	ld [hli], a
 	dec e
-	jr nz,.loop
+	jr nz, .loop
 	dec d
-	jr nz,.loop
+	jr nz, .loop
 	ret
 
 ; This function redraws a BG row of height 2 or a BG column of width 2.
@@ -40,76 +40,76 @@ ClearBgMap::
 ; However, this function is also called repeatedly to redraw the whole screen
 ; when necessary. It is also used in trade animation and elevator code.
 RedrawRowOrColumn::
-	ld a,[hRedrawRowOrColumnMode]
+	ld a, [hRedrawRowOrColumnMode]
 	and a
 	ret z
-	ld b,a
+	ld b, a
 	xor a
-	ld [hRedrawRowOrColumnMode],a
+	ld [hRedrawRowOrColumnMode], a
 	dec b
-	jr nz,.redrawRow
+	jr nz, .redrawRow
 .redrawColumn
-	ld hl,wRedrawRowOrColumnSrcTiles
-	ld a,[hRedrawRowOrColumnDest]
-	ld e,a
-	ld a,[hRedrawRowOrColumnDest + 1]
-	ld d,a
-	ld c,SCREEN_HEIGHT
+	ld hl, wRedrawRowOrColumnSrcTiles
+	ld a, [hRedrawRowOrColumnDest]
+	ld e, a
+	ld a, [hRedrawRowOrColumnDest + 1]
+	ld d, a
+	ld c, SCREEN_HEIGHT
 .loop1
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
-	ld a,[hli]
-	ld [de],a
-	ld a,BG_MAP_WIDTH - 1
+	ld a, [hli]
+	ld [de], a
+	ld a, BG_MAP_WIDTH - 1
 	add e
-	ld e,a
-	jr nc,.noCarry
+	ld e, a
+	jr nc, .noCarry
 	inc d
 .noCarry
 ; the following 4 lines wrap us from bottom to top if necessary
-	ld a,d
-	and a,$03
-	or a,$98
-	ld d,a
+	ld a, d
+	and $03
+	or $98
+	ld d, a
 	dec c
-	jr nz,.loop1
+	jr nz, .loop1
 	xor a
-	ld [hRedrawRowOrColumnMode],a
+	ld [hRedrawRowOrColumnMode], a
 	ret
 .redrawRow
-	ld hl,wRedrawRowOrColumnSrcTiles
-	ld a,[hRedrawRowOrColumnDest]
-	ld e,a
-	ld a,[hRedrawRowOrColumnDest + 1]
-	ld d,a
+	ld hl, wRedrawRowOrColumnSrcTiles
+	ld a, [hRedrawRowOrColumnDest]
+	ld e, a
+	ld a, [hRedrawRowOrColumnDest + 1]
+	ld d, a
 	push de
 	call .DrawHalf ; draw upper half
 	pop de
-	ld a,BG_MAP_WIDTH ; width of VRAM background map
+	ld a, BG_MAP_WIDTH ; width of VRAM background map
 	add e
-	ld e,a
+	ld e, a
 	; fall through and draw lower half
 
 .DrawHalf
-	ld c,SCREEN_WIDTH / 2
+	ld c, SCREEN_WIDTH / 2
 .loop2
-	ld a,[hli]
-	ld [de],a
+	ld a, [hli]
+	ld [de], a
 	inc de
-	ld a,[hli]
-	ld [de],a
-	ld a,e
+	ld a, [hli]
+	ld [de], a
+	ld a, e
 	inc a
 ; the following 6 lines wrap us from the right edge to the left edge if necessary
-	and a,$1f
-	ld b,a
-	ld a,e
-	and a,$e0
+	and $1f
+	ld b, a
+	ld a, e
+	and $e0
 	or b
-	ld e,a
+	ld e, a
 	dec c
-	jr nz,.loop2
+	jr nz, .loop2
 	ret
 
 ; This function automatically transfers tile number data from the tile map at
@@ -120,52 +120,52 @@ RedrawRowOrColumn::
 ; the above function, RedrawRowOrColumn, is used when walking to
 ; improve efficiency.
 AutoBgMapTransfer::
-	ld a,[H_AUTOBGTRANSFERENABLED]
+	ld a, [H_AUTOBGTRANSFERENABLED]
 	and a
 	ret z
-	ld hl,sp + 0
-	ld a,h
-	ld [H_SPTEMP],a
-	ld a,l
-	ld [H_SPTEMP + 1],a ; save stack pinter
-	ld a,[H_AUTOBGTRANSFERPORTION]
+	ld hl, sp + 0
+	ld a, h
+	ld [H_SPTEMP], a
+	ld a, l
+	ld [H_SPTEMP + 1], a ; save stack pinter
+	ld a, [H_AUTOBGTRANSFERPORTION]
 	and a
-	jr z,.transferTopThird
+	jr z, .transferTopThird
 	dec a
-	jr z,.transferMiddleThird
+	jr z, .transferMiddleThird
 .transferBottomThird
 	coord hl, 0, 12
-	ld sp,hl
-	ld a,[H_AUTOBGTRANSFERDEST + 1]
-	ld h,a
-	ld a,[H_AUTOBGTRANSFERDEST]
-	ld l,a
-	ld de,(12 * 32)
-	add hl,de
+	ld sp, hl
+	ld a, [H_AUTOBGTRANSFERDEST + 1]
+	ld h, a
+	ld a, [H_AUTOBGTRANSFERDEST]
+	ld l, a
+	ld de, (12 * 32)
+	add hl, de
 	xor a ; TRANSFERTOP
 	jr .doTransfer
 .transferTopThird
 	coord hl, 0, 0
-	ld sp,hl
-	ld a,[H_AUTOBGTRANSFERDEST + 1]
-	ld h,a
-	ld a,[H_AUTOBGTRANSFERDEST]
-	ld l,a
-	ld a,TRANSFERMIDDLE
+	ld sp, hl
+	ld a, [H_AUTOBGTRANSFERDEST + 1]
+	ld h, a
+	ld a, [H_AUTOBGTRANSFERDEST]
+	ld l, a
+	ld a, TRANSFERMIDDLE
 	jr .doTransfer
 .transferMiddleThird
 	coord hl, 0, 6
-	ld sp,hl
-	ld a,[H_AUTOBGTRANSFERDEST + 1]
-	ld h,a
-	ld a,[H_AUTOBGTRANSFERDEST]
-	ld l,a
-	ld de,(6 * 32)
-	add hl,de
-	ld a,TRANSFERBOTTOM
+	ld sp, hl
+	ld a, [H_AUTOBGTRANSFERDEST + 1]
+	ld h, a
+	ld a, [H_AUTOBGTRANSFERDEST]
+	ld l, a
+	ld de, (6 * 32)
+	add hl, de
+	ld a, TRANSFERBOTTOM
 .doTransfer
-	ld [H_AUTOBGTRANSFERPORTION],a ; store next portion
-	ld b,6
+	ld [H_AUTOBGTRANSFERPORTION], a ; store next portion
+	ld b, 6
 
 TransferBgRows::
 ; unrolled loop and using pop for speed
@@ -202,27 +202,27 @@ TransferBgRows::
 ; Copies [H_VBCOPYBGNUMROWS] rows from H_VBCOPYBGSRC to H_VBCOPYBGDEST.
 ; If H_VBCOPYBGSRC is XX00, the transfer is disabled.
 VBlankCopyBgMap::
-	ld a,[H_VBCOPYBGSRC] ; doubles as enabling byte
+	ld a, [H_VBCOPYBGSRC] ; doubles as enabling byte
 	and a
 	ret z
-	ld hl,sp + 0
-	ld a,h
-	ld [H_SPTEMP],a
-	ld a,l
-	ld [H_SPTEMP + 1],a ; save stack pointer
-	ld a,[H_VBCOPYBGSRC]
-	ld l,a
-	ld a,[H_VBCOPYBGSRC + 1]
-	ld h,a
-	ld sp,hl
-	ld a,[H_VBCOPYBGDEST]
-	ld l,a
-	ld a,[H_VBCOPYBGDEST + 1]
-	ld h,a
-	ld a,[H_VBCOPYBGNUMROWS]
-	ld b,a
+	ld hl, sp + 0
+	ld a, h
+	ld [H_SPTEMP], a
+	ld a, l
+	ld [H_SPTEMP + 1], a ; save stack pointer
+	ld a, [H_VBCOPYBGSRC]
+	ld l, a
+	ld a, [H_VBCOPYBGSRC + 1]
+	ld h, a
+	ld sp, hl
+	ld a, [H_VBCOPYBGDEST]
+	ld l, a
+	ld a, [H_VBCOPYBGDEST + 1]
+	ld h, a
+	ld a, [H_VBCOPYBGNUMROWS]
+	ld b, a
 	xor a
-	ld [H_VBCOPYBGSRC],a ; disable transfer so it doesn't continue next V-blank
+	ld [H_VBCOPYBGSRC], a ; disable transfer so it doesn't continue next V-blank
 	jr TransferBgRows
 
 

--- a/scripts/celadongamecorner.asm
+++ b/scripts/celadongamecorner.asm
@@ -144,7 +144,7 @@ CeladonGameCornerText2:
 	ld a, [wCurrentMenuItem]
 	and a
 	jr nz, .asm_48d0f
-	ld b,COIN_CASE
+	ld b, COIN_CASE
 	call IsItemInBag
 	jr z, .asm_48d19
 	call Has9990Coins
@@ -362,7 +362,7 @@ CeladonGameCornerText10:
 	jr nz, .asm_48e75
 	ld hl, CeladonGameCornerText_48e88
 	call PrintText
-	ld b,COIN_CASE
+	ld b, COIN_CASE
 	call IsItemInBag
 	jr z, .asm_48e7f
 	call Has9990Coins

--- a/scripts/ceruleancity.asm
+++ b/scripts/ceruleancity.asm
@@ -113,10 +113,10 @@ CeruleanCityMovement1:
 	db $FF
 
 CeruleanCityScript_1955d:
-	ld a,1
-	ld [H_SPRITEINDEX],a
+	ld a, 1
+	ld [H_SPRITEINDEX], a
 	xor a ; SPRITE_FACING_DOWN
-	ld [hSpriteFacingDirection],a
+	ld [hSpriteFacingDirection], a
 	jp SetSpriteFacingDirectionAndDelay ; face object
 
 CeruleanCityScript1:

--- a/scripts/fightingdojo.asm
+++ b/scripts/fightingdojo.asm
@@ -302,7 +302,7 @@ FightingDojoText7:
 	jr nz, .done
 	ld a, [wcf91]
 	ld b, a
-	ld c,30
+	ld c, 30
 	call GivePokemon
 	jr nc, .done
 	SetEvents EVENT_GOT_HITMONCHAN, EVENT_DEFEATED_FIGHTING_DOJO

--- a/scripts/fuchsiahouse2.asm
+++ b/scripts/fuchsiahouse2.asm
@@ -12,7 +12,7 @@ FuchsiaHouse2Text1:
 	TX_ASM
 	CheckEvent EVENT_GOT_HM04
 	jr nz, .subtract
-	ld b,GOLD_TEETH
+	ld b, GOLD_TEETH
 	call IsItemInBag
 	jr nz, .asm_3f30f
 	CheckEvent EVENT_GAVE_GOLD_TEETH

--- a/scripts/oakslab.asm
+++ b/scripts/oakslab.asm
@@ -981,7 +981,7 @@ OaksLabText5:
 	predef DisplayDexRating
 	jp .asm_1d2ed
 .asm_1d279
-	ld b,POKE_BALL
+	ld b, POKE_BALL
 	call IsItemInBag
 	jr nz, .asm_1d2e7
 	CheckEvent EVENT_BEAT_ROUTE22_RIVAL_1ST_BATTLE

--- a/scripts/pallettown.asm
+++ b/scripts/pallettown.asm
@@ -1,11 +1,11 @@
 PalletTownScript:
 	CheckEvent EVENT_GOT_POKEBALLS_FROM_OAK
-	jr z,.next
+	jr z, .next
 	SetEvent EVENT_PALLET_AFTER_GETTING_POKEBALLS
 .next
 	call EnableAutoTextBoxDrawing
-	ld hl,PalletTownScriptPointers
-	ld a,[wPalletTownCurScript]
+	ld hl, PalletTownScriptPointers
+	ld a, [wPalletTownCurScript]
 	jp CallFunctionInTable
 
 PalletTownScriptPointers:
@@ -20,126 +20,126 @@ PalletTownScriptPointers:
 PalletTownScript0:
 	CheckEvent EVENT_FOLLOWED_OAK_INTO_LAB
 	ret nz
-	ld a,[wYCoord]
+	ld a, [wYCoord]
 	cp 1 ; is player near north exit?
 	ret nz
 	xor a
-	ld [hJoyHeld],a
-	ld a,PLAYER_DIR_DOWN
-	ld [wPlayerMovingDirection],a
-	ld a,$FF
+	ld [hJoyHeld], a
+	ld a, PLAYER_DIR_DOWN
+	ld [wPlayerMovingDirection], a
+	ld a, $FF
 	call PlaySound ; stop music
 	ld a, BANK(Music_MeetProfOak)
-	ld c,a
+	ld c, a
 	ld a, MUSIC_MEET_PROF_OAK ; “oak appears” music
 	call PlayMusic
-	ld a,$FC
-	ld [wJoyIgnore],a
+	ld a, $FC
+	ld [wJoyIgnore], a
 	SetEvent EVENT_OAK_APPEARED_IN_PALLET
 
 	; trigger the next script
-	ld a,1
-	ld [wPalletTownCurScript],a
+	ld a, 1
+	ld [wPalletTownCurScript], a
 	ret
 
 PalletTownScript1:
 	xor a
-	ld [wcf0d],a
-	ld a,1
-	ld [hSpriteIndexOrTextID],a
+	ld [wcf0d], a
+	ld a, 1
+	ld [hSpriteIndexOrTextID], a
 	call DisplayTextID
-	ld a,$FF
-	ld [wJoyIgnore],a
-	ld a,HS_PALLET_TOWN_OAK
-	ld [wMissableObjectIndex],a
+	ld a, $FF
+	ld [wJoyIgnore], a
+	ld a, HS_PALLET_TOWN_OAK
+	ld [wMissableObjectIndex], a
 	predef ShowObject
 
 	; trigger the next script
-	ld a,2
-	ld [wPalletTownCurScript],a
+	ld a, 2
+	ld [wPalletTownCurScript], a
 	ret
 
 PalletTownScript2:
-	ld a,1
-	ld [H_SPRITEINDEX],a
-	ld a,SPRITE_FACING_UP
-	ld [hSpriteFacingDirection],a
+	ld a, 1
+	ld [H_SPRITEINDEX], a
+	ld a, SPRITE_FACING_UP
+	ld [hSpriteFacingDirection], a
 	call SetSpriteFacingDirectionAndDelay
 	call Delay3
-	ld a,1
-	ld [wYCoord],a
-	ld a,1
-	ld [hNPCPlayerRelativePosPerspective],a
-	ld a,1
+	ld a, 1
+	ld [wYCoord], a
+	ld a, 1
+	ld [hNPCPlayerRelativePosPerspective], a
+	ld a, 1
 	swap a
-	ld [hNPCSpriteOffset],a
+	ld [hNPCSpriteOffset], a
 	predef CalcPositionOfPlayerRelativeToNPC
-	ld hl,hNPCPlayerYDistance
+	ld hl, hNPCPlayerYDistance
 	dec [hl]
 	predef FindPathToPlayer ; load Oak’s movement into wNPCMovementDirections2
-	ld de,wNPCMovementDirections2
-	ld a,1 ; oak
-	ld [H_SPRITEINDEX],a
+	ld de, wNPCMovementDirections2
+	ld a, 1 ; oak
+	ld [H_SPRITEINDEX], a
 	call MoveSprite
-	ld a,$FF
-	ld [wJoyIgnore],a
+	ld a, $FF
+	ld [wJoyIgnore], a
 
 	; trigger the next script
-	ld a,3
-	ld [wPalletTownCurScript],a
+	ld a, 3
+	ld [wPalletTownCurScript], a
 	ret
 
 PalletTownScript3:
-	ld a,[wd730]
-	bit 0,a
+	ld a, [wd730]
+	bit 0, a
 	ret nz
 	xor a ; ld a, SPRITE_FACING_DOWN
-	ld [wSpriteStateData1 + 9],a
-	ld a,1
-	ld [wcf0d],a
-	ld a,$FC
-	ld [wJoyIgnore],a
-	ld a,1
-	ld [hSpriteIndexOrTextID],a
+	ld [wSpriteStateData1 + 9], a
+	ld a, 1
+	ld [wcf0d], a
+	ld a, $FC
+	ld [wJoyIgnore], a
+	ld a, 1
+	ld [hSpriteIndexOrTextID], a
 	call DisplayTextID
 ; set up movement script that causes the player to follow Oak to his lab
-	ld a,$FF
-	ld [wJoyIgnore],a
-	ld a,1
-	ld [wSpriteIndex],a
+	ld a, $FF
+	ld [wJoyIgnore], a
+	ld a, 1
+	ld [wSpriteIndex], a
 	xor a
-	ld [wNPCMovementScriptFunctionNum],a
-	ld a,1
-	ld [wNPCMovementScriptPointerTableNum],a
-	ld a,[H_LOADEDROMBANK]
-	ld [wNPCMovementScriptBank],a
+	ld [wNPCMovementScriptFunctionNum], a
+	ld a, 1
+	ld [wNPCMovementScriptPointerTableNum], a
+	ld a, [H_LOADEDROMBANK]
+	ld [wNPCMovementScriptBank], a
 
 	; trigger the next script
-	ld a,4
-	ld [wPalletTownCurScript],a
+	ld a, 4
+	ld [wPalletTownCurScript], a
 	ret
 
 PalletTownScript4:
-	ld a,[wNPCMovementScriptPointerTableNum]
+	ld a, [wNPCMovementScriptPointerTableNum]
 	and a ; is the movement script over?
 	ret nz
 
 	; trigger the next script
-	ld a,5
-	ld [wPalletTownCurScript],a
+	ld a, 5
+	ld [wPalletTownCurScript], a
 	ret
 
 PalletTownScript5:
 	CheckEvent EVENT_DAISY_WALKING
-	jr nz,.next
+	jr nz, .next
 	CheckBothEventsSet EVENT_GOT_TOWN_MAP, EVENT_ENTERED_BLUES_HOUSE, 1
-	jr nz,.next
+	jr nz, .next
 	SetEvent EVENT_DAISY_WALKING
-	ld a,HS_DAISY_SITTING
-	ld [wMissableObjectIndex],a
+	ld a, HS_DAISY_SITTING
+	ld [wMissableObjectIndex], a
 	predef HideObject
-	ld a,HS_DAISY_WALKING
-	ld [wMissableObjectIndex],a
+	ld a, HS_DAISY_WALKING
+	ld [wMissableObjectIndex], a
 	predef_jump ShowObject
 .next
 	CheckEvent EVENT_GOT_POKEBALLS_FROM_OAK
@@ -159,15 +159,15 @@ PalletTownTextPointers:
 
 PalletTownText1:
 	TX_ASM
-	ld a,[wcf0d]
+	ld a, [wcf0d]
 	and a
-	jr nz,.next
-	ld a,1
-	ld [wDoNotWaitForButtonPressAfterDisplayingText],a
-	ld hl,OakAppearsText
+	jr nz, .next
+	ld a, 1
+	ld [wDoNotWaitForButtonPressAfterDisplayingText], a
+	ld hl, OakAppearsText
 	jr .done
 .next
-	ld hl,OakWalksUpText
+	ld hl, OakWalksUpText
 .done
 	call PrintText
 	jp TextScriptEnd
@@ -175,14 +175,14 @@ PalletTownText1:
 OakAppearsText:
 	TX_FAR _OakAppearsText
 	TX_ASM
-	ld c,10
+	ld c, 10
 	call DelayFrames
 	xor a
-	ld [wEmotionBubbleSpriteIndex],a ; player's sprite
-	ld [wWhichEmotionBubble],a ; EXCLAMATION_BUBBLE
+	ld [wEmotionBubbleSpriteIndex], a ; player's sprite
+	ld [wWhichEmotionBubble], a ; EXCLAMATION_BUBBLE
 	predef EmotionBubble
-	ld a,PLAYER_DIR_DOWN
-	ld [wPlayerMovingDirection],a
+	ld a, PLAYER_DIR_DOWN
+	ld [wPlayerMovingDirection], a
 	jp TextScriptEnd
 
 OakWalksUpText:

--- a/scripts/redshouse1f.asm
+++ b/scripts/redshouse1f.asm
@@ -51,11 +51,11 @@ MomHealText2:
 
 RedsHouse1FText2: ; TV
 	TX_ASM
-	ld a,[wSpriteStateData1 + 9]
+	ld a, [wSpriteStateData1 + 9]
 	cp SPRITE_FACING_UP
-	ld hl,TVWrongSideText
-	jr nz,.notUp
-	ld hl,StandByMeText
+	ld hl, TVWrongSideText
+	jr nz, .notUp
+	ld hl, StandByMeText
 .notUp
 	call PrintText
 	jp TextScriptEnd

--- a/scripts/redshouse2f.asm
+++ b/scripts/redshouse2f.asm
@@ -1,7 +1,7 @@
 RedsHouse2FScript:
 	call EnableAutoTextBoxDrawing
-	ld hl,RedsHouse2FScriptPointers
-	ld a,[wRedsHouse2CurScript]
+	ld hl, RedsHouse2FScriptPointers
+	ld a, [wRedsHouse2CurScript]
 	jp CallFunctionInTable
 
 RedsHouse2FScriptPointers:
@@ -10,11 +10,11 @@ RedsHouse2FScriptPointers:
 
 RedsHouse2FScript0:
 	xor a
-	ld [hJoyHeld],a
-	ld a,PLAYER_DIR_UP
-	ld [wPlayerMovingDirection],a
-	ld a,1
-	ld [wRedsHouse2CurScript],a
+	ld [hJoyHeld], a
+	ld a, PLAYER_DIR_UP
+	ld [wPlayerMovingDirection], a
+	ld a, 1
+	ld [wRedsHouse2CurScript], a
 	ret
 
 RedsHouse2FScript1:

--- a/scripts/safarizoneentrance.asm
+++ b/scripts/safarizoneentrance.asm
@@ -117,10 +117,10 @@ SafariZoneEntranceScriptPointers:
 
 SafariZoneEntranceAutoWalk:
 	push af
-	ld b,0
-	ld a,c
-	ld [wSimulatedJoypadStatesIndex],a
-	ld hl,wSimulatedJoypadStatesEnd
+	ld b, 0
+	ld a, c
+	ld [wSimulatedJoypadStatesIndex], a
+	ld hl, wSimulatedJoypadStatesEnd
 	pop af
 	call FillMemory
 	jp StartSimulatingJoypadStates
@@ -146,64 +146,64 @@ SafariZoneEntranceTextPointers:
 	TX_FAR SafariZoneEntranceText_9e6e4
 	TX_ASM
 	ld a, MONEY_BOX
-	ld [wTextBoxID],a
+	ld [wTextBoxID], a
 	call DisplayTextBoxID
 	call YesNoChoice
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	and a
-	jp nz,.PleaseComeAgain
+	jp nz, .PleaseComeAgain
 	xor a
-	ld [hMoney],a
-	ld a,$05
-	ld [hMoney + 1],a
-	ld a,$00
-	ld [hMoney + 2],a
+	ld [hMoney], a
+	ld a, $05
+	ld [hMoney + 1], a
+	ld a, $00
+	ld [hMoney + 2], a
 	call HasEnoughMoney
-	jr nc,.success
-	ld hl,.NotEnoughMoneyText
+	jr nc, .success
+	ld hl, .NotEnoughMoneyText
 	call PrintText
 	jr .CantPayWalkDown
 
 .success
 	xor a
-	ld [wPriceTemp],a
-	ld a,$05
-	ld [wPriceTemp + 1],a
-	ld a,$00
-	ld [wPriceTemp + 2],a
-	ld hl,wPriceTemp + 2
-	ld de,wPlayerMoney + 2
-	ld c,3
+	ld [wPriceTemp], a
+	ld a, $05
+	ld [wPriceTemp + 1], a
+	ld a, $00
+	ld [wPriceTemp + 2], a
+	ld hl, wPriceTemp + 2
+	ld de, wPlayerMoney + 2
+	ld c, 3
 	predef SubBCDPredef
-	ld a,MONEY_BOX
-	ld [wTextBoxID],a
+	ld a, MONEY_BOX
+	ld [wTextBoxID], a
 	call DisplayTextBoxID
-	ld hl,.MakePaymentText
+	ld hl, .MakePaymentText
 	call PrintText
-	ld a,30
-	ld [wNumSafariBalls],a
-	ld a,502 / $100
-	ld [wSafariSteps],a
+	ld a, 30
+	ld [wNumSafariBalls], a
+	ld a, 502 / $100
+	ld [wSafariSteps], a
 	ld a, 502 % $100
-	ld [wSafariSteps + 1],a
-	ld a,D_UP
-	ld c,3
+	ld [wSafariSteps + 1], a
+	ld a, D_UP
+	ld c, 3
 	call SafariZoneEntranceAutoWalk
 	SetEvent EVENT_IN_SAFARI_ZONE
 	ResetEventReuseHL EVENT_SAFARI_GAME_OVER
-	ld a,3
-	ld [wSafariZoneEntranceCurScript],a
+	ld a, 3
+	ld [wSafariZoneEntranceCurScript], a
 	jr .done
 
 .PleaseComeAgain
-	ld hl,.PleaseComeAgainText
+	ld hl, .PleaseComeAgainText
 	call PrintText
 .CantPayWalkDown
-	ld a,D_DOWN
-	ld c,1
+	ld a, D_DOWN
+	ld c, 1
 	call SafariZoneEntranceAutoWalk
-	ld a,4
-	ld [wSafariZoneEntranceCurScript],a
+	ld a, 4
+	ld [wSafariZoneEntranceCurScript], a
 .done
 	jp TextScriptEnd
 
@@ -225,7 +225,7 @@ SafariZoneEntranceTextPointers:
 	TX_FAR SafariZoneEntranceText_9e814
 	TX_ASM
 	call YesNoChoice
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	and a
 	jr nz, .asm_7539c
 	ld hl, .SafariZoneEntranceText_753bb
@@ -268,14 +268,14 @@ SafariZoneEntranceTextPointers:
 
 .SafariZoneEntranceText2
 	TX_ASM
-	ld hl,.FirstTimeQuestionText
+	ld hl, .FirstTimeQuestionText
 	call PrintText
 	call YesNoChoice
-	ld a,[wCurrentMenuItem]
+	ld a, [wCurrentMenuItem]
 	and a
-	ld hl,.RegularText
-	jr nz,.Explanation
-	ld hl,.ExplanationText
+	ld hl, .RegularText
+	jr nz, .Explanation
+	ld hl, .ExplanationText
 .Explanation
 	call PrintText
 	jp TextScriptEnd


### PR DESCRIPTION
Tempted to just fix a space into anything that matches ``([^\s]),([^(\s|")])`` but maybe very long data arrays are better without a space? (pokecrystal has a few of these without spaces).