### PR TITLE
Rename unknownsfx0x20, unknownsfx0x10 and unknownnoise0x20

### DIFF
--- a/audio/sfx/59_1.asm
+++ b/audio/sfx/59_1.asm
@@ -1,11 +1,11 @@
 SFX_59_1_Ch4:
 	duty 2
-	unknownsfx0x20 4, 241, 128, 7
+	squarenote 4, 241, 128, 7
 	endchannel
 
 
 SFX_59_1_Ch5:
 	duty 2
-	unknownsfx0x20 1, 8, 0, 0
-	unknownsfx0x20 4, 161, 97, 7
+	squarenote 1, 8, 0, 0
+	squarenote 4, 161, 97, 7
 	endchannel

--- a/audio/sfx/59_3.asm
+++ b/audio/sfx/59_3.asm
@@ -1,11 +1,11 @@
 SFX_59_3_Ch4:
 	duty 2
-	unknownsfx0x20 4, 241, 128, 7
+	squarenote 4, 241, 128, 7
 	endchannel
 
 
 SFX_59_3_Ch5:
 	duty 2
-	unknownsfx0x20 1, 8, 0, 0
-	unknownsfx0x20 4, 161, 97, 7
+	squarenote 1, 8, 0, 0
+	squarenote 4, 161, 97, 7
 	endchannel

--- a/audio/sfx/arrow_tiles_1.asm
+++ b/audio/sfx/arrow_tiles_1.asm
@@ -1,6 +1,6 @@
 SFX_Arrow_Tiles_1_Ch4:
 	duty 0
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 210, 0, 7
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 210, 0, 7
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/arrow_tiles_3.asm
+++ b/audio/sfx/arrow_tiles_3.asm
@@ -1,6 +1,6 @@
 SFX_Arrow_Tiles_3_Ch4:
 	duty 0
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 210, 0, 7
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 210, 0, 7
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/ball_poof.asm
+++ b/audio/sfx/ball_poof.asm
@@ -1,11 +1,11 @@
 SFX_Ball_Poof_Ch4:
 	duty 2
-	unknownsfx0x10 22
-	unknownsfx0x20 15, 242, 0, 4
-	unknownsfx0x10 8
+	pitchenvelope 22
+	squarenote 15, 242, 0, 4
+	pitchenvelope 8
 	endchannel
 
 
 SFX_Ball_Poof_Ch7:
-	unknownnoise0x20 15, 162, 34
+	noisenote 15, 162, 34
 	endchannel

--- a/audio/sfx/ball_toss.asm
+++ b/audio/sfx/ball_toss.asm
@@ -1,11 +1,11 @@
 SFX_Ball_Toss_Ch4:
 	duty 2
-	unknownsfx0x10 47
-	unknownsfx0x20 15, 242, 128, 7
+	pitchenvelope 47
+	squarenote 15, 242, 128, 7
 	endchannel
 
 
 SFX_Ball_Toss_Ch5:
 	duty 2
-	unknownsfx0x20 15, 194, 130, 7
+	squarenote 15, 194, 130, 7
 	endchannel

--- a/audio/sfx/battle_09.asm
+++ b/audio/sfx/battle_09.asm
@@ -1,6 +1,6 @@
 SFX_Battle_09_Ch4:
 	duty 1
-	unknownsfx0x10 151
-	unknownsfx0x20 15, 242, 0, 5
-	unknownsfx0x10 8
+	pitchenvelope 151
+	squarenote 15, 242, 0, 5
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/battle_0b.asm
+++ b/audio/sfx/battle_0b.asm
@@ -1,3 +1,3 @@
 SFX_Battle_0B_Ch7:
-	unknownnoise0x20 8, 241, 84
+	noisenote 8, 241, 84
 	endchannel

--- a/audio/sfx/battle_0c.asm
+++ b/audio/sfx/battle_0c.asm
@@ -1,5 +1,5 @@
 SFX_Battle_0C_Ch7:
-	unknownnoise0x20 15, 143, 17
-	unknownnoise0x20 4, 255, 18
-	unknownnoise0x20 10, 241, 85
+	noisenote 15, 143, 17
+	noisenote 4, 255, 18
+	noisenote 10, 241, 85
 	endchannel

--- a/audio/sfx/battle_0d.asm
+++ b/audio/sfx/battle_0d.asm
@@ -1,5 +1,5 @@
 SFX_Battle_0D_Ch7:
-	unknownnoise0x20 15, 143, 52
-	unknownnoise0x20 8, 242, 53
-	unknownnoise0x20 10, 241, 85
+	noisenote 15, 143, 52
+	noisenote 8, 242, 53
+	noisenote 10, 241, 85
 	endchannel

--- a/audio/sfx/battle_0e.asm
+++ b/audio/sfx/battle_0e.asm
@@ -1,4 +1,4 @@
 SFX_Battle_0E_Ch7:
-	unknownnoise0x20 15, 159, 35
-	unknownnoise0x20 8, 241, 33
+	noisenote 15, 159, 35
+	noisenote 8, 241, 33
 	endchannel

--- a/audio/sfx/battle_0f.asm
+++ b/audio/sfx/battle_0f.asm
@@ -1,6 +1,6 @@
 SFX_Battle_0F_Ch7:
-	unknownnoise0x20 2, 225, 75
-	unknownnoise0x20 10, 241, 68
-	unknownnoise0x20 2, 225, 58
-	unknownnoise0x20 6, 241, 52
+	noisenote 2, 225, 75
+	noisenote 10, 241, 68
+	noisenote 2, 225, 58
+	noisenote 6, 241, 52
 	endchannel

--- a/audio/sfx/battle_12.asm
+++ b/audio/sfx/battle_12.asm
@@ -1,6 +1,6 @@
 SFX_Battle_12_Ch7:
-	unknownnoise0x20 8, 79, 35
-	unknownnoise0x20 4, 196, 34
-	unknownnoise0x20 6, 242, 35
+	noisenote 8, 79, 35
+	noisenote 4, 196, 34
+	noisenote 6, 242, 35
 	loopchannel 4, SFX_Battle_12_Ch7
 	endchannel

--- a/audio/sfx/battle_13.asm
+++ b/audio/sfx/battle_13.asm
@@ -1,6 +1,6 @@
 SFX_Battle_13_Ch7:
-	unknownnoise0x20 8, 79, 51
-	unknownnoise0x20 4, 196, 34
-	unknownnoise0x20 6, 242, 35
-	unknownnoise0x20 15, 242, 34
+	noisenote 8, 79, 51
+	noisenote 4, 196, 34
+	noisenote 6, 242, 35
+	noisenote 15, 242, 34
 	endchannel

--- a/audio/sfx/battle_14.asm
+++ b/audio/sfx/battle_14.asm
@@ -1,6 +1,6 @@
 SFX_Battle_14_Ch7:
-	unknownnoise0x20 8, 255, 50
-	unknownnoise0x20 8, 244, 67
-	unknownnoise0x20 8, 242, 84
-	unknownnoise0x20 8, 241, 101
+	noisenote 8, 255, 50
+	noisenote 8, 244, 67
+	noisenote 8, 242, 84
+	noisenote 8, 241, 101
 	endchannel

--- a/audio/sfx/battle_16.asm
+++ b/audio/sfx/battle_16.asm
@@ -1,5 +1,5 @@
 SFX_Battle_16_Ch7:
-	unknownnoise0x20 1, 148, 35
-	unknownnoise0x20 1, 180, 34
-	unknownnoise0x20 8, 241, 68
+	noisenote 1, 148, 35
+	noisenote 1, 180, 34
+	noisenote 8, 241, 68
 	endchannel

--- a/audio/sfx/battle_17.asm
+++ b/audio/sfx/battle_17.asm
@@ -1,6 +1,6 @@
 SFX_Battle_17_Ch7:
-	unknownnoise0x20 2, 148, 51
-	unknownnoise0x20 4, 180, 34
-	unknownnoise0x20 4, 241, 68
-	unknownnoise0x20 8, 241, 85
+	noisenote 2, 148, 51
+	noisenote 4, 180, 34
+	noisenote 4, 241, 68
+	noisenote 8, 241, 85
 	endchannel

--- a/audio/sfx/battle_18.asm
+++ b/audio/sfx/battle_18.asm
@@ -1,4 +1,4 @@
 SFX_Battle_18_Ch7:
-	unknownnoise0x20 4, 255, 85
-	unknownnoise0x20 8, 241, 101
+	noisenote 4, 255, 85
+	noisenote 8, 241, 101
 	endchannel

--- a/audio/sfx/battle_19.asm
+++ b/audio/sfx/battle_19.asm
@@ -1,5 +1,5 @@
 SFX_Battle_19_Ch7:
-	unknownnoise0x20 2, 132, 67
-	unknownnoise0x20 2, 196, 34
-	unknownnoise0x20 8, 242, 52
+	noisenote 2, 132, 67
+	noisenote 2, 196, 34
+	noisenote 8, 242, 52
 	endchannel

--- a/audio/sfx/battle_1b.asm
+++ b/audio/sfx/battle_1b.asm
@@ -1,4 +1,4 @@
 SFX_Battle_1B_Ch7:
-	unknownnoise0x20 2, 241, 34
-	unknownnoise0x20 15, 242, 18
+	noisenote 2, 241, 34
+	noisenote 15, 242, 18
 	endchannel

--- a/audio/sfx/battle_1c.asm
+++ b/audio/sfx/battle_1c.asm
@@ -1,5 +1,5 @@
 SFX_Battle_1C_Ch7:
-	unknownnoise0x20 2, 194, 1
-	unknownnoise0x20 15, 244, 1
-	unknownnoise0x20 15, 242, 1
+	noisenote 2, 194, 1
+	noisenote 15, 244, 1
+	noisenote 15, 242, 1
 	endchannel

--- a/audio/sfx/battle_1e.asm
+++ b/audio/sfx/battle_1e.asm
@@ -1,16 +1,16 @@
 SFX_Battle_1E_Ch4:
 	duty 0
-	unknownsfx0x10 58
-	unknownsfx0x20 4, 242, 0, 2
-	unknownsfx0x10 34
-	unknownsfx0x20 8, 226, 0, 2
-	unknownsfx0x10 8
+	pitchenvelope 58
+	squarenote 4, 242, 0, 2
+	pitchenvelope 34
+	squarenote 8, 226, 0, 2
+	pitchenvelope 8
 	endchannel
 
 
 SFX_Battle_1E_Ch7:
-	unknownnoise0x20 0, 209, 66
-	unknownnoise0x20 4, 161, 50
-	unknownnoise0x20 0, 209, 34
-	unknownnoise0x20 6, 161, 50
+	noisenote 0, 209, 66
+	noisenote 4, 161, 50
+	noisenote 0, 209, 34
+	noisenote 6, 161, 50
 	endchannel

--- a/audio/sfx/battle_20.asm
+++ b/audio/sfx/battle_20.asm
@@ -1,4 +1,4 @@
 SFX_Battle_20_Ch7:
-	unknownnoise0x20 12, 241, 84
-	unknownnoise0x20 8, 241, 100
+	noisenote 12, 241, 84
+	noisenote 8, 241, 100
 	endchannel

--- a/audio/sfx/battle_21.asm
+++ b/audio/sfx/battle_21.asm
@@ -1,7 +1,7 @@
 SFX_Battle_21_Ch7:
-	unknownnoise0x20 2, 241, 51
-	unknownnoise0x20 2, 193, 50
-	unknownnoise0x20 2, 161, 49
-	unknownnoise0x20 15, 130, 50
-	unknownnoise0x20 8, 241, 52
+	noisenote 2, 241, 51
+	noisenote 2, 193, 50
+	noisenote 2, 161, 49
+	noisenote 15, 130, 50
+	noisenote 8, 241, 52
 	endchannel

--- a/audio/sfx/battle_22.asm
+++ b/audio/sfx/battle_22.asm
@@ -1,4 +1,4 @@
 SFX_Battle_22_Ch7:
-	unknownnoise0x20 2, 210, 50
-	unknownnoise0x20 15, 242, 67
+	noisenote 2, 210, 50
+	noisenote 15, 242, 67
 	endchannel

--- a/audio/sfx/battle_23.asm
+++ b/audio/sfx/battle_23.asm
@@ -1,7 +1,7 @@
 SFX_Battle_23_Ch7:
-	unknownnoise0x20 2, 242, 67
-	unknownnoise0x20 4, 181, 50
-	unknownnoise0x20 9, 134, 49
-	unknownnoise0x20 7, 100, 0
-	unknownnoise0x20 15, 242, 85
+	noisenote 2, 242, 67
+	noisenote 4, 181, 50
+	noisenote 9, 134, 49
+	noisenote 7, 100, 0
+	noisenote 15, 242, 85
 	endchannel

--- a/audio/sfx/battle_24.asm
+++ b/audio/sfx/battle_24.asm
@@ -1,12 +1,12 @@
 SFX_Battle_24_Ch4:
 	duty 1
-	unknownsfx0x10 151
-	unknownsfx0x20 15, 242, 0, 7
-	unknownsfx0x10 8
+	pitchenvelope 151
+	squarenote 15, 242, 0, 7
+	pitchenvelope 8
 	endchannel
 
 
 SFX_Battle_24_Ch7:
-	unknownnoise0x20 15, 63, 34
-	unknownnoise0x20 15, 242, 33
+	noisenote 15, 63, 34
+	noisenote 15, 242, 33
 	endchannel

--- a/audio/sfx/battle_25.asm
+++ b/audio/sfx/battle_25.asm
@@ -1,7 +1,7 @@
 SFX_Battle_25_Ch7:
-	unknownnoise0x20 15, 79, 65
-	unknownnoise0x20 8, 143, 65
-	unknownnoise0x20 8, 207, 65
-	unknownnoise0x20 8, 242, 66
-	unknownnoise0x20 15, 242, 65
+	noisenote 15, 79, 65
+	noisenote 8, 143, 65
+	noisenote 8, 207, 65
+	noisenote 8, 242, 66
+	noisenote 15, 242, 65
 	endchannel

--- a/audio/sfx/battle_26.asm
+++ b/audio/sfx/battle_26.asm
@@ -1,9 +1,9 @@
 SFX_Battle_26_Ch7:
-	unknownnoise0x20 10, 255, 80
-	unknownnoise0x20 15, 255, 81
-	unknownnoise0x20 8, 242, 81
-	unknownnoise0x20 6, 255, 82
-	unknownnoise0x20 6, 255, 83
-	unknownnoise0x20 8, 255, 84
-	unknownnoise0x20 15, 242, 84
+	noisenote 10, 255, 80
+	noisenote 15, 255, 81
+	noisenote 8, 242, 81
+	noisenote 6, 255, 82
+	noisenote 6, 255, 83
+	noisenote 8, 255, 84
+	noisenote 15, 242, 84
 	endchannel

--- a/audio/sfx/battle_27.asm
+++ b/audio/sfx/battle_27.asm
@@ -1,27 +1,27 @@
 SFX_Battle_27_Ch4:
 	duty 2
-	unknownsfx0x20 15, 63, 192, 7
+	squarenote 15, 63, 192, 7
 
 SFX_Battle_27_branch_2062a:
-	unknownsfx0x20 15, 223, 192, 7
+	squarenote 15, 223, 192, 7
 	loopchannel 4, SFX_Battle_27_branch_2062a
-	unknownsfx0x20 15, 209, 192, 7
+	squarenote 15, 209, 192, 7
 	endchannel
 
 
 SFX_Battle_27_Ch5:
 	dutycycle 179
-	unknownsfx0x20 15, 47, 200, 7
+	squarenote 15, 47, 200, 7
 
 SFX_Battle_27_branch_2063d:
-	unknownsfx0x20 15, 207, 199, 7
+	squarenote 15, 207, 199, 7
 	loopchannel 4, SFX_Battle_27_branch_2063d
-	unknownsfx0x20 15, 193, 200, 7
+	squarenote 15, 193, 200, 7
 	endchannel
 
 
 SFX_Battle_27_Ch7:
-	unknownnoise0x20 3, 151, 18
-	unknownnoise0x20 3, 161, 17
+	noisenote 3, 151, 18
+	noisenote 3, 161, 17
 	loopchannel 10, SFX_Battle_27_Ch7
 	endchannel

--- a/audio/sfx/battle_28.asm
+++ b/audio/sfx/battle_28.asm
@@ -1,21 +1,21 @@
 SFX_Battle_28_Ch4:
 	duty 0
-	unknownsfx0x20 0, 241, 192, 7
-	unknownsfx0x20 0, 241, 0, 7
+	squarenote 0, 241, 192, 7
+	squarenote 0, 241, 0, 7
 	loopchannel 12, SFX_Battle_28_Ch4
 	endchannel
 
 
 SFX_Battle_28_Ch5:
 	dutycycle 179
-	unknownsfx0x20 0, 225, 193, 7
-	unknownsfx0x20 0, 225, 1, 7
+	squarenote 0, 225, 193, 7
+	squarenote 0, 225, 1, 7
 	loopchannel 12, SFX_Battle_28_Ch5
 	endchannel
 
 
 SFX_Battle_28_Ch7:
-	unknownnoise0x20 1, 209, 73
-	unknownnoise0x20 1, 209, 41
+	noisenote 1, 209, 73
+	noisenote 1, 209, 41
 	loopchannel 6, SFX_Battle_28_Ch7
 	endchannel

--- a/audio/sfx/battle_29.asm
+++ b/audio/sfx/battle_29.asm
@@ -1,18 +1,18 @@
 SFX_Battle_29_Ch4:
 	dutycycle 201
-	unknownsfx0x20 11, 243, 32, 1
-	unknownsfx0x20 9, 211, 80, 1
+	squarenote 11, 243, 32, 1
+	squarenote 9, 211, 80, 1
 	loopchannel 5, SFX_Battle_29_Ch4
-	unknownsfx0x20 8, 227, 48, 1
-	unknownsfx0x20 15, 194, 16, 1
+	squarenote 8, 227, 48, 1
+	squarenote 15, 194, 16, 1
 	endchannel
 
 
 SFX_Battle_29_Ch7:
-	unknownnoise0x20 10, 243, 53
-	unknownnoise0x20 14, 246, 69
+	noisenote 10, 243, 53
+	noisenote 14, 246, 69
 	loopchannel 4, SFX_Battle_29_Ch7
-	unknownnoise0x20 12, 244, 188
-	unknownnoise0x20 12, 245, 156
-	unknownnoise0x20 15, 244, 172
+	noisenote 12, 244, 188
+	noisenote 12, 245, 156
+	noisenote 15, 244, 172
 	endchannel

--- a/audio/sfx/battle_2a.asm
+++ b/audio/sfx/battle_2a.asm
@@ -1,28 +1,28 @@
 SFX_Battle_2A_Ch4:
 	dutycycle 57
-	unknownsfx0x20 4, 244, 0, 6
-	unknownsfx0x20 3, 196, 0, 5
-	unknownsfx0x20 5, 181, 0, 6
-	unknownsfx0x20 13, 226, 192, 6
+	squarenote 4, 244, 0, 6
+	squarenote 3, 196, 0, 5
+	squarenote 5, 181, 0, 6
+	squarenote 13, 226, 192, 6
 	loopchannel 3, SFX_Battle_2A_Ch4
-	unknownsfx0x20 8, 209, 0, 6
+	squarenote 8, 209, 0, 6
 	endchannel
 
 
 SFX_Battle_2A_Ch5:
 	dutycycle 141
-	unknownsfx0x20 5, 228, 224, 5
-	unknownsfx0x20 4, 180, 224, 4
-	unknownsfx0x20 6, 165, 232, 5
-	unknownsfx0x20 14, 209, 160, 6
+	squarenote 5, 228, 224, 5
+	squarenote 4, 180, 224, 4
+	squarenote 6, 165, 232, 5
+	squarenote 14, 209, 160, 6
 	loopchannel 3, SFX_Battle_2A_Ch5
 	endchannel
 
 
 SFX_Battle_2A_Ch7:
-	unknownnoise0x20 5, 195, 51
-	unknownnoise0x20 3, 146, 67
-	unknownnoise0x20 10, 181, 51
-	unknownnoise0x20 15, 195, 50
+	noisenote 5, 195, 51
+	noisenote 3, 146, 67
+	noisenote 10, 181, 51
+	noisenote 15, 195, 50
 	loopchannel 2, SFX_Battle_2A_Ch7
 	endchannel

--- a/audio/sfx/battle_2b.asm
+++ b/audio/sfx/battle_2b.asm
@@ -1,21 +1,21 @@
 SFX_Battle_2B_Ch4:
 	dutycycle 210
-	unknownsfx0x20 3, 129, 0, 3
-	unknownsfx0x20 3, 193, 0, 4
-	unknownsfx0x20 3, 241, 0, 5
-	unknownsfx0x20 3, 177, 0, 4
-	unknownsfx0x20 3, 113, 0, 3
+	squarenote 3, 129, 0, 3
+	squarenote 3, 193, 0, 4
+	squarenote 3, 241, 0, 5
+	squarenote 3, 177, 0, 4
+	squarenote 3, 113, 0, 3
 	loopchannel 5, SFX_Battle_2B_Ch4
-	unknownsfx0x20 8, 129, 0, 4
+	squarenote 8, 129, 0, 4
 	endchannel
 
 
 SFX_Battle_2B_Ch7:
-	unknownnoise0x20 3, 98, 34
-	unknownnoise0x20 3, 162, 50
-	unknownnoise0x20 3, 210, 51
-	unknownnoise0x20 3, 146, 35
-	unknownnoise0x20 3, 82, 18
+	noisenote 3, 98, 34
+	noisenote 3, 162, 50
+	noisenote 3, 210, 51
+	noisenote 3, 146, 35
+	noisenote 3, 82, 18
 	loopchannel 5, SFX_Battle_2B_Ch7
-	unknownnoise0x20 8, 129, 18
+	noisenote 8, 129, 18
 	endchannel

--- a/audio/sfx/battle_2c.asm
+++ b/audio/sfx/battle_2c.asm
@@ -1,25 +1,25 @@
 SFX_Battle_2C_Ch4:
 	dutycycle 57
-	unknownsfx0x20 15, 244, 0, 5
-	unknownsfx0x20 15, 196, 0, 4
-	unknownsfx0x20 15, 226, 192, 5
+	squarenote 15, 244, 0, 5
+	squarenote 15, 196, 0, 4
+	squarenote 15, 226, 192, 5
 	loopchannel 3, SFX_Battle_2C_Ch4
 	endchannel
 
 
 SFX_Battle_2C_Ch5:
 	dutycycle 141
-	unknownsfx0x20 7, 228, 48, 4
-	unknownsfx0x20 15, 180, 48, 3
-	unknownsfx0x20 15, 162, 56, 4
+	squarenote 7, 228, 48, 4
+	squarenote 15, 180, 48, 3
+	squarenote 15, 162, 56, 4
 	loopchannel 4, SFX_Battle_2C_Ch5
 	endchannel
 
 
 SFX_Battle_2C_Ch7:
-	unknownnoise0x20 9, 244, 68
-	unknownnoise0x20 9, 242, 67
-	unknownnoise0x20 15, 244, 66
-	unknownnoise0x20 15, 244, 65
+	noisenote 9, 244, 68
+	noisenote 9, 242, 67
+	noisenote 15, 244, 66
+	noisenote 15, 244, 65
 	loopchannel 3, SFX_Battle_2C_Ch7
 	endchannel

--- a/audio/sfx/battle_2e.asm
+++ b/audio/sfx/battle_2e.asm
@@ -1,27 +1,27 @@
 SFX_Battle_2E_Ch4:
 	duty 0
-	unknownsfx0x20 2, 241, 0, 2
-	unknownsfx0x20 3, 241, 0, 7
-	unknownsfx0x20 4, 241, 0, 5
-	unknownsfx0x20 5, 241, 240, 7
+	squarenote 2, 241, 0, 2
+	squarenote 3, 241, 0, 7
+	squarenote 4, 241, 0, 5
+	squarenote 5, 241, 240, 7
 	loopchannel 8, SFX_Battle_2E_Ch4
 	endchannel
 
 
 SFX_Battle_2E_Ch5:
 	dutycycle 179
-	unknownsfx0x20 2, 225, 2, 3
-	unknownsfx0x20 3, 225, 242, 7
-	unknownsfx0x20 4, 225, 2, 6
-	unknownsfx0x20 5, 225, 2, 7
+	squarenote 2, 225, 2, 3
+	squarenote 3, 225, 242, 7
+	squarenote 4, 225, 2, 6
+	squarenote 5, 225, 2, 7
 	loopchannel 8, SFX_Battle_2E_Ch5
 	endchannel
 
 
 SFX_Battle_2E_Ch7:
-	unknownnoise0x20 2, 211, 16
-	unknownnoise0x20 3, 211, 17
-	unknownnoise0x20 2, 210, 16
-	unknownnoise0x20 5, 210, 18
+	noisenote 2, 211, 16
+	noisenote 3, 211, 17
+	noisenote 2, 210, 16
+	noisenote 5, 210, 18
 	loopchannel 9, SFX_Battle_2E_Ch7
 	endchannel

--- a/audio/sfx/battle_2f.asm
+++ b/audio/sfx/battle_2f.asm
@@ -1,21 +1,21 @@
 SFX_Battle_2F_Ch4:
 	dutycycle 43
-	unknownsfx0x20 3, 241, 240, 7
-	unknownsfx0x20 4, 242, 0, 2
+	squarenote 3, 241, 240, 7
+	squarenote 4, 242, 0, 2
 	loopchannel 8, SFX_Battle_2F_Ch4
 	endchannel
 
 
 SFX_Battle_2F_Ch5:
 	dutycycle 179
-	unknownsfx0x20 4, 226, 2, 2
-	unknownsfx0x20 4, 225, 226, 7
+	squarenote 4, 226, 2, 2
+	squarenote 4, 225, 226, 7
 	loopchannel 9, SFX_Battle_2F_Ch5
 	endchannel
 
 
 SFX_Battle_2F_Ch7:
-	unknownnoise0x20 4, 255, 67
-	unknownnoise0x20 4, 242, 68
+	noisenote 4, 255, 67
+	noisenote 4, 242, 68
 	loopchannel 9, SFX_Battle_2F_Ch7
 	endchannel

--- a/audio/sfx/battle_31.asm
+++ b/audio/sfx/battle_31.asm
@@ -1,18 +1,18 @@
 SFX_Battle_31_Ch4:
 	duty 2
-	unknownsfx0x20 15, 255, 224, 7
-	unknownsfx0x20 15, 255, 224, 7
-	unknownsfx0x20 15, 255, 224, 7
-	unknownsfx0x20 15, 255, 224, 7
-	unknownsfx0x20 15, 242, 224, 7
+	squarenote 15, 255, 224, 7
+	squarenote 15, 255, 224, 7
+	squarenote 15, 255, 224, 7
+	squarenote 15, 255, 224, 7
+	squarenote 15, 242, 224, 7
 	endchannel
 
 
 SFX_Battle_31_Ch5:
 	duty 3
-	unknownsfx0x20 15, 255, 226, 7
-	unknownsfx0x20 15, 255, 225, 7
-	unknownsfx0x20 15, 255, 226, 7
-	unknownsfx0x20 15, 255, 225, 7
-	unknownsfx0x20 15, 242, 226, 7
+	squarenote 15, 255, 226, 7
+	squarenote 15, 255, 225, 7
+	squarenote 15, 255, 226, 7
+	squarenote 15, 255, 225, 7
+	squarenote 15, 242, 226, 7
 	endchannel

--- a/audio/sfx/battle_32.asm
+++ b/audio/sfx/battle_32.asm
@@ -1,12 +1,12 @@
 SFX_Battle_32_Ch4:
 	duty 2
-	unknownsfx0x10 175
-	unknownsfx0x20 8, 241, 0, 7
-	unknownsfx0x10 8
+	pitchenvelope 175
+	squarenote 8, 241, 0, 7
+	pitchenvelope 8
 	endchannel
 
 
 SFX_Battle_32_Ch5:
 	duty 3
-	unknownsfx0x20 8, 241, 1, 7
+	squarenote 8, 241, 1, 7
 	endchannel

--- a/audio/sfx/battle_33.asm
+++ b/audio/sfx/battle_33.asm
@@ -1,18 +1,18 @@
 SFX_Battle_33_Ch4:
 	duty 2
-	unknownsfx0x20 6, 241, 0, 5
-	unknownsfx0x20 6, 241, 128, 5
-	unknownsfx0x20 6, 241, 0, 6
-	unknownsfx0x20 6, 241, 128, 6
-	unknownsfx0x20 8, 241, 0, 7
+	squarenote 6, 241, 0, 5
+	squarenote 6, 241, 128, 5
+	squarenote 6, 241, 0, 6
+	squarenote 6, 241, 128, 6
+	squarenote 8, 241, 0, 7
 	endchannel
 
 
 SFX_Battle_33_Ch5:
 	duty 3
-	unknownsfx0x20 6, 225, 16, 5
-	unknownsfx0x20 6, 225, 144, 5
-	unknownsfx0x20 6, 225, 16, 6
-	unknownsfx0x20 6, 225, 144, 6
-	unknownsfx0x20 8, 225, 16, 7
+	squarenote 6, 225, 16, 5
+	squarenote 6, 225, 144, 5
+	squarenote 6, 225, 16, 6
+	squarenote 6, 225, 144, 6
+	squarenote 8, 225, 16, 7
 	endchannel

--- a/audio/sfx/battle_34.asm
+++ b/audio/sfx/battle_34.asm
@@ -1,22 +1,22 @@
 SFX_Battle_34_Ch4:
 	dutycycle 237
-	unknownsfx0x20 8, 255, 248, 3
-	unknownsfx0x20 15, 255, 0, 4
-	unknownsfx0x20 15, 243, 0, 4
+	squarenote 8, 255, 248, 3
+	squarenote 15, 255, 0, 4
+	squarenote 15, 243, 0, 4
 	endchannel
 
 
 SFX_Battle_34_Ch5:
 	dutycycle 180
-	unknownsfx0x20 8, 239, 192, 3
-	unknownsfx0x20 15, 239, 192, 3
-	unknownsfx0x20 15, 227, 192, 3
+	squarenote 8, 239, 192, 3
+	squarenote 15, 239, 192, 3
+	squarenote 15, 227, 192, 3
 	endchannel
 
 
 SFX_Battle_34_Ch7:
-	unknownnoise0x20 4, 255, 81
-	unknownnoise0x20 8, 255, 84
-	unknownnoise0x20 15, 255, 85
-	unknownnoise0x20 15, 243, 86
+	noisenote 4, 255, 81
+	noisenote 8, 255, 84
+	noisenote 15, 255, 85
+	noisenote 15, 243, 86
 	endchannel

--- a/audio/sfx/battle_36.asm
+++ b/audio/sfx/battle_36.asm
@@ -1,47 +1,47 @@
 SFX_Battle_36_Ch4:
 	duty 0
-	unknownsfx0x20 2, 241, 128, 7
-	unknownsfx0x20 2, 241, 0, 7
-	unknownsfx0x20 2, 241, 144, 7
-	unknownsfx0x20 2, 241, 0, 7
-	unknownsfx0x20 2, 241, 160, 7
-	unknownsfx0x20 2, 241, 0, 7
-	unknownsfx0x20 2, 241, 176, 7
-	unknownsfx0x20 2, 241, 0, 7
-	unknownsfx0x20 2, 241, 192, 7
-	unknownsfx0x20 2, 241, 0, 7
-	unknownsfx0x20 2, 241, 208, 7
+	squarenote 2, 241, 128, 7
+	squarenote 2, 241, 0, 7
+	squarenote 2, 241, 144, 7
+	squarenote 2, 241, 0, 7
+	squarenote 2, 241, 160, 7
+	squarenote 2, 241, 0, 7
+	squarenote 2, 241, 176, 7
+	squarenote 2, 241, 0, 7
+	squarenote 2, 241, 192, 7
+	squarenote 2, 241, 0, 7
+	squarenote 2, 241, 208, 7
 
 SFX_Battle_36_branch_20930:
-	unknownsfx0x20 2, 241, 0, 7
-	unknownsfx0x20 2, 241, 224, 7
+	squarenote 2, 241, 0, 7
+	squarenote 2, 241, 224, 7
 	loopchannel 12, SFX_Battle_36_branch_20930
-	unknownsfx0x20 15, 241, 0, 7
+	squarenote 15, 241, 0, 7
 	endchannel
 
 
 SFX_Battle_36_Ch5:
 	dutycycle 179
-	unknownsfx0x20 2, 241, 129, 7
-	unknownsfx0x20 2, 241, 1, 7
-	unknownsfx0x20 2, 241, 145, 7
-	unknownsfx0x20 2, 241, 1, 7
-	unknownsfx0x20 2, 241, 161, 7
-	unknownsfx0x20 2, 241, 1, 7
-	unknownsfx0x20 2, 241, 177, 7
-	unknownsfx0x20 2, 241, 1, 7
-	unknownsfx0x20 2, 241, 193, 7
-	unknownsfx0x20 2, 241, 1, 7
-	unknownsfx0x20 2, 241, 209, 7
-	unknownsfx0x20 2, 241, 1, 7
-	unknownsfx0x20 2, 241, 225, 7
+	squarenote 2, 241, 129, 7
+	squarenote 2, 241, 1, 7
+	squarenote 2, 241, 145, 7
+	squarenote 2, 241, 1, 7
+	squarenote 2, 241, 161, 7
+	squarenote 2, 241, 1, 7
+	squarenote 2, 241, 177, 7
+	squarenote 2, 241, 1, 7
+	squarenote 2, 241, 193, 7
+	squarenote 2, 241, 1, 7
+	squarenote 2, 241, 209, 7
+	squarenote 2, 241, 1, 7
+	squarenote 2, 241, 225, 7
 	loopchannel 12, SFX_Battle_36_branch_20930
-	unknownsfx0x20 15, 241, 1, 7
+	squarenote 15, 241, 1, 7
 	endchannel
 
 
 SFX_Battle_36_Ch7:
-	unknownnoise0x20 1, 209, 73
-	unknownnoise0x20 1, 209, 41
+	noisenote 1, 209, 73
+	noisenote 1, 209, 41
 	loopchannel 26, SFX_Battle_36_Ch7
 	endchannel

--- a/audio/sfx/collision_1.asm
+++ b/audio/sfx/collision_1.asm
@@ -1,6 +1,6 @@
 SFX_Collision_1_Ch4:
 	duty 2
-	unknownsfx0x10 90
-	unknownsfx0x20 15, 241, 0, 3
-	unknownsfx0x10 8
+	pitchenvelope 90
+	squarenote 15, 241, 0, 3
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/collision_3.asm
+++ b/audio/sfx/collision_3.asm
@@ -1,6 +1,6 @@
 SFX_Collision_3_Ch4:
 	duty 2
-	unknownsfx0x10 90
-	unknownsfx0x20 15, 241, 0, 3
-	unknownsfx0x10 8
+	pitchenvelope 90
+	squarenote 15, 241, 0, 3
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/cry00_1.asm
+++ b/audio/sfx/cry00_1.asm
@@ -1,21 +1,21 @@
 SFX_Cry00_1_Ch4:
 	dutycycle 245
-	unknownsfx0x20 4, 243, 24, 7
-	unknownsfx0x20 15, 229, 152, 7
-	unknownsfx0x20 8, 145, 88, 7
+	squarenote 4, 243, 24, 7
+	squarenote 15, 229, 152, 7
+	squarenote 8, 145, 88, 7
 	endchannel
 
 
 SFX_Cry00_1_Ch5:
 	dutycycle 160
-	unknownsfx0x20 5, 179, 8, 7
-	unknownsfx0x20 15, 197, 136, 7
-	unknownsfx0x20 8, 113, 72, 7
+	squarenote 5, 179, 8, 7
+	squarenote 15, 197, 136, 7
+	squarenote 8, 113, 72, 7
 	endchannel
 
 
 SFX_Cry00_1_Ch7:
-	unknownnoise0x20 3, 161, 28
-	unknownnoise0x20 14, 148, 44
-	unknownnoise0x20 8, 129, 28
+	noisenote 3, 161, 28
+	noisenote 14, 148, 44
+	noisenote 8, 129, 28
 	endchannel

--- a/audio/sfx/cry00_2.asm
+++ b/audio/sfx/cry00_2.asm
@@ -1,21 +1,21 @@
 SFX_Cry00_2_Ch4:
 	dutycycle 245
-	unknownsfx0x20 4, 243, 24, 7
-	unknownsfx0x20 15, 229, 152, 7
-	unknownsfx0x20 8, 145, 88, 7
+	squarenote 4, 243, 24, 7
+	squarenote 15, 229, 152, 7
+	squarenote 8, 145, 88, 7
 	endchannel
 
 
 SFX_Cry00_2_Ch5:
 	dutycycle 160
-	unknownsfx0x20 5, 179, 8, 7
-	unknownsfx0x20 15, 197, 136, 7
-	unknownsfx0x20 8, 113, 72, 7
+	squarenote 5, 179, 8, 7
+	squarenote 15, 197, 136, 7
+	squarenote 8, 113, 72, 7
 	endchannel
 
 
 SFX_Cry00_2_Ch7:
-	unknownnoise0x20 3, 161, 28
-	unknownnoise0x20 14, 148, 44
-	unknownnoise0x20 8, 129, 28
+	noisenote 3, 161, 28
+	noisenote 14, 148, 44
+	noisenote 8, 129, 28
 	endchannel

--- a/audio/sfx/cry00_3.asm
+++ b/audio/sfx/cry00_3.asm
@@ -1,21 +1,21 @@
 SFX_Cry00_3_Ch4:
 	dutycycle 245
-	unknownsfx0x20 4, 243, 24, 7
-	unknownsfx0x20 15, 229, 152, 7
-	unknownsfx0x20 8, 145, 88, 7
+	squarenote 4, 243, 24, 7
+	squarenote 15, 229, 152, 7
+	squarenote 8, 145, 88, 7
 	endchannel
 
 
 SFX_Cry00_3_Ch5:
 	dutycycle 160
-	unknownsfx0x20 5, 179, 8, 7
-	unknownsfx0x20 15, 197, 136, 7
-	unknownsfx0x20 8, 113, 72, 7
+	squarenote 5, 179, 8, 7
+	squarenote 15, 197, 136, 7
+	squarenote 8, 113, 72, 7
 	endchannel
 
 
 SFX_Cry00_3_Ch7:
-	unknownnoise0x20 3, 161, 28
-	unknownnoise0x20 14, 148, 44
-	unknownnoise0x20 8, 129, 28
+	noisenote 3, 161, 28
+	noisenote 14, 148, 44
+	noisenote 8, 129, 28
 	endchannel

--- a/audio/sfx/cry01_1.asm
+++ b/audio/sfx/cry01_1.asm
@@ -1,24 +1,24 @@
 SFX_Cry01_1_Ch4:
 	dutycycle 160
-	unknownsfx0x20 4, 243, 0, 6
-	unknownsfx0x20 8, 213, 96, 7
-	unknownsfx0x20 3, 226, 32, 7
-	unknownsfx0x20 8, 209, 16, 7
+	squarenote 4, 243, 0, 6
+	squarenote 8, 213, 96, 7
+	squarenote 3, 226, 32, 7
+	squarenote 8, 209, 16, 7
 	endchannel
 
 
 SFX_Cry01_1_Ch5:
 	dutycycle 90
-	unknownsfx0x20 5, 179, 241, 6
-	unknownsfx0x20 7, 197, 82, 7
-	unknownsfx0x20 3, 162, 17, 7
-	unknownsfx0x20 8, 177, 1, 6
+	squarenote 5, 179, 241, 6
+	squarenote 7, 197, 82, 7
+	squarenote 3, 162, 17, 7
+	squarenote 8, 177, 1, 6
 	endchannel
 
 
 SFX_Cry01_1_Ch7:
-	unknownnoise0x20 3, 162, 60
-	unknownnoise0x20 12, 148, 44
-	unknownnoise0x20 3, 130, 28
-	unknownnoise0x20 8, 113, 44
+	noisenote 3, 162, 60
+	noisenote 12, 148, 44
+	noisenote 3, 130, 28
+	noisenote 8, 113, 44
 	endchannel

--- a/audio/sfx/cry01_2.asm
+++ b/audio/sfx/cry01_2.asm
@@ -1,24 +1,24 @@
 SFX_Cry01_2_Ch4:
 	dutycycle 160
-	unknownsfx0x20 4, 243, 0, 6
-	unknownsfx0x20 8, 213, 96, 7
-	unknownsfx0x20 3, 226, 32, 7
-	unknownsfx0x20 8, 209, 16, 7
+	squarenote 4, 243, 0, 6
+	squarenote 8, 213, 96, 7
+	squarenote 3, 226, 32, 7
+	squarenote 8, 209, 16, 7
 	endchannel
 
 
 SFX_Cry01_2_Ch5:
 	dutycycle 90
-	unknownsfx0x20 5, 179, 241, 6
-	unknownsfx0x20 7, 197, 82, 7
-	unknownsfx0x20 3, 162, 17, 7
-	unknownsfx0x20 8, 177, 1, 6
+	squarenote 5, 179, 241, 6
+	squarenote 7, 197, 82, 7
+	squarenote 3, 162, 17, 7
+	squarenote 8, 177, 1, 6
 	endchannel
 
 
 SFX_Cry01_2_Ch7:
-	unknownnoise0x20 3, 162, 60
-	unknownnoise0x20 12, 148, 44
-	unknownnoise0x20 3, 130, 28
-	unknownnoise0x20 8, 113, 44
+	noisenote 3, 162, 60
+	noisenote 12, 148, 44
+	noisenote 3, 130, 28
+	noisenote 8, 113, 44
 	endchannel

--- a/audio/sfx/cry01_3.asm
+++ b/audio/sfx/cry01_3.asm
@@ -1,24 +1,24 @@
 SFX_Cry01_3_Ch4:
 	dutycycle 160
-	unknownsfx0x20 4, 243, 0, 6
-	unknownsfx0x20 8, 213, 96, 7
-	unknownsfx0x20 3, 226, 32, 7
-	unknownsfx0x20 8, 209, 16, 7
+	squarenote 4, 243, 0, 6
+	squarenote 8, 213, 96, 7
+	squarenote 3, 226, 32, 7
+	squarenote 8, 209, 16, 7
 	endchannel
 
 
 SFX_Cry01_3_Ch5:
 	dutycycle 90
-	unknownsfx0x20 5, 179, 241, 6
-	unknownsfx0x20 7, 197, 82, 7
-	unknownsfx0x20 3, 162, 17, 7
-	unknownsfx0x20 8, 177, 1, 6
+	squarenote 5, 179, 241, 6
+	squarenote 7, 197, 82, 7
+	squarenote 3, 162, 17, 7
+	squarenote 8, 177, 1, 6
 	endchannel
 
 
 SFX_Cry01_3_Ch7:
-	unknownnoise0x20 3, 162, 60
-	unknownnoise0x20 12, 148, 44
-	unknownnoise0x20 3, 130, 28
-	unknownnoise0x20 8, 113, 44
+	noisenote 3, 162, 60
+	noisenote 12, 148, 44
+	noisenote 3, 130, 28
+	noisenote 8, 113, 44
 	endchannel

--- a/audio/sfx/cry02_1.asm
+++ b/audio/sfx/cry02_1.asm
@@ -1,16 +1,16 @@
 SFX_Cry02_1_Ch4:
 	duty 0
-	unknownsfx0x20 8, 245, 128, 4
-	unknownsfx0x20 2, 225, 224, 5
-	unknownsfx0x20 8, 209, 220, 5
+	squarenote 8, 245, 128, 4
+	squarenote 2, 225, 224, 5
+	squarenote 8, 209, 220, 5
 	endchannel
 
 
 SFX_Cry02_1_Ch5:
 	dutycycle 165
-	unknownsfx0x20 7, 149, 65, 4
-	unknownsfx0x20 2, 129, 33, 5
-	unknownsfx0x20 8, 97, 26, 5
+	squarenote 7, 149, 65, 4
+	squarenote 2, 129, 33, 5
+	squarenote 8, 97, 26, 5
 
 
 SFX_Cry02_1_Ch7:

--- a/audio/sfx/cry02_2.asm
+++ b/audio/sfx/cry02_2.asm
@@ -1,16 +1,16 @@
 SFX_Cry02_2_Ch4:
 	duty 0
-	unknownsfx0x20 8, 245, 128, 4
-	unknownsfx0x20 2, 225, 224, 5
-	unknownsfx0x20 8, 209, 220, 5
+	squarenote 8, 245, 128, 4
+	squarenote 2, 225, 224, 5
+	squarenote 8, 209, 220, 5
 	endchannel
 
 
 SFX_Cry02_2_Ch5:
 	dutycycle 165
-	unknownsfx0x20 7, 149, 65, 4
-	unknownsfx0x20 2, 129, 33, 5
-	unknownsfx0x20 8, 97, 26, 5
+	squarenote 7, 149, 65, 4
+	squarenote 2, 129, 33, 5
+	squarenote 8, 97, 26, 5
 
 
 SFX_Cry02_2_Ch7:

--- a/audio/sfx/cry02_3.asm
+++ b/audio/sfx/cry02_3.asm
@@ -1,16 +1,16 @@
 SFX_Cry02_3_Ch4:
 	duty 0
-	unknownsfx0x20 8, 245, 128, 4
-	unknownsfx0x20 2, 225, 224, 5
-	unknownsfx0x20 8, 209, 220, 5
+	squarenote 8, 245, 128, 4
+	squarenote 2, 225, 224, 5
+	squarenote 8, 209, 220, 5
 	endchannel
 
 
 SFX_Cry02_3_Ch5:
 	dutycycle 165
-	unknownsfx0x20 7, 149, 65, 4
-	unknownsfx0x20 2, 129, 33, 5
-	unknownsfx0x20 8, 97, 26, 5
+	squarenote 7, 149, 65, 4
+	squarenote 2, 129, 33, 5
+	squarenote 8, 97, 26, 5
 
 
 SFX_Cry02_3_Ch7:

--- a/audio/sfx/cry03_1.asm
+++ b/audio/sfx/cry03_1.asm
@@ -1,30 +1,30 @@
 SFX_Cry03_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 247, 8, 6
-	unknownsfx0x20 6, 230, 0, 6
-	unknownsfx0x20 6, 215, 240, 5
-	unknownsfx0x20 6, 196, 224, 5
-	unknownsfx0x20 5, 211, 192, 5
-	unknownsfx0x20 4, 211, 160, 5
-	unknownsfx0x20 8, 225, 128, 5
+	squarenote 4, 247, 8, 6
+	squarenote 6, 230, 0, 6
+	squarenote 6, 215, 240, 5
+	squarenote 6, 196, 224, 5
+	squarenote 5, 211, 192, 5
+	squarenote 4, 211, 160, 5
+	squarenote 8, 225, 128, 5
 	endchannel
 
 
 SFX_Cry03_1_Ch5:
 	dutycycle 10
-	unknownsfx0x20 4, 199, 4, 5
-	unknownsfx0x20 6, 166, 2, 5
-	unknownsfx0x20 6, 151, 241, 4
-	unknownsfx0x20 4, 180, 225, 4
-	unknownsfx0x20 5, 163, 194, 4
-	unknownsfx0x20 4, 179, 163, 4
-	unknownsfx0x20 8, 193, 130, 4
+	squarenote 4, 199, 4, 5
+	squarenote 6, 166, 2, 5
+	squarenote 6, 151, 241, 4
+	squarenote 4, 180, 225, 4
+	squarenote 5, 163, 194, 4
+	squarenote 4, 179, 163, 4
+	squarenote 8, 193, 130, 4
 	endchannel
 
 
 SFX_Cry03_1_Ch7:
-	unknownnoise0x20 12, 228, 76
-	unknownnoise0x20 10, 199, 92
-	unknownnoise0x20 12, 182, 76
-	unknownnoise0x20 15, 162, 92
+	noisenote 12, 228, 76
+	noisenote 10, 199, 92
+	noisenote 12, 182, 76
+	noisenote 15, 162, 92
 	endchannel

--- a/audio/sfx/cry03_2.asm
+++ b/audio/sfx/cry03_2.asm
@@ -1,30 +1,30 @@
 SFX_Cry03_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 247, 8, 6
-	unknownsfx0x20 6, 230, 0, 6
-	unknownsfx0x20 6, 215, 240, 5
-	unknownsfx0x20 6, 196, 224, 5
-	unknownsfx0x20 5, 211, 192, 5
-	unknownsfx0x20 4, 211, 160, 5
-	unknownsfx0x20 8, 225, 128, 5
+	squarenote 4, 247, 8, 6
+	squarenote 6, 230, 0, 6
+	squarenote 6, 215, 240, 5
+	squarenote 6, 196, 224, 5
+	squarenote 5, 211, 192, 5
+	squarenote 4, 211, 160, 5
+	squarenote 8, 225, 128, 5
 	endchannel
 
 
 SFX_Cry03_2_Ch5:
 	dutycycle 10
-	unknownsfx0x20 4, 199, 4, 5
-	unknownsfx0x20 6, 166, 2, 5
-	unknownsfx0x20 6, 151, 241, 4
-	unknownsfx0x20 4, 180, 225, 4
-	unknownsfx0x20 5, 163, 194, 4
-	unknownsfx0x20 4, 179, 163, 4
-	unknownsfx0x20 8, 193, 130, 4
+	squarenote 4, 199, 4, 5
+	squarenote 6, 166, 2, 5
+	squarenote 6, 151, 241, 4
+	squarenote 4, 180, 225, 4
+	squarenote 5, 163, 194, 4
+	squarenote 4, 179, 163, 4
+	squarenote 8, 193, 130, 4
 	endchannel
 
 
 SFX_Cry03_2_Ch7:
-	unknownnoise0x20 12, 228, 76
-	unknownnoise0x20 10, 199, 92
-	unknownnoise0x20 12, 182, 76
-	unknownnoise0x20 15, 162, 92
+	noisenote 12, 228, 76
+	noisenote 10, 199, 92
+	noisenote 12, 182, 76
+	noisenote 15, 162, 92
 	endchannel

--- a/audio/sfx/cry03_3.asm
+++ b/audio/sfx/cry03_3.asm
@@ -1,30 +1,30 @@
 SFX_Cry03_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 247, 8, 6
-	unknownsfx0x20 6, 230, 0, 6
-	unknownsfx0x20 6, 215, 240, 5
-	unknownsfx0x20 6, 196, 224, 5
-	unknownsfx0x20 5, 211, 192, 5
-	unknownsfx0x20 4, 211, 160, 5
-	unknownsfx0x20 8, 225, 128, 5
+	squarenote 4, 247, 8, 6
+	squarenote 6, 230, 0, 6
+	squarenote 6, 215, 240, 5
+	squarenote 6, 196, 224, 5
+	squarenote 5, 211, 192, 5
+	squarenote 4, 211, 160, 5
+	squarenote 8, 225, 128, 5
 	endchannel
 
 
 SFX_Cry03_3_Ch5:
 	dutycycle 10
-	unknownsfx0x20 4, 199, 4, 5
-	unknownsfx0x20 6, 166, 2, 5
-	unknownsfx0x20 6, 151, 241, 4
-	unknownsfx0x20 4, 180, 225, 4
-	unknownsfx0x20 5, 163, 194, 4
-	unknownsfx0x20 4, 179, 163, 4
-	unknownsfx0x20 8, 193, 130, 4
+	squarenote 4, 199, 4, 5
+	squarenote 6, 166, 2, 5
+	squarenote 6, 151, 241, 4
+	squarenote 4, 180, 225, 4
+	squarenote 5, 163, 194, 4
+	squarenote 4, 179, 163, 4
+	squarenote 8, 193, 130, 4
 	endchannel
 
 
 SFX_Cry03_3_Ch7:
-	unknownnoise0x20 12, 228, 76
-	unknownnoise0x20 10, 199, 92
-	unknownnoise0x20 12, 182, 76
-	unknownnoise0x20 15, 162, 92
+	noisenote 12, 228, 76
+	noisenote 10, 199, 92
+	noisenote 12, 182, 76
+	noisenote 15, 162, 92
 	endchannel

--- a/audio/sfx/cry04_1.asm
+++ b/audio/sfx/cry04_1.asm
@@ -1,32 +1,32 @@
 SFX_Cry04_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 247, 160, 6
-	unknownsfx0x20 8, 230, 164, 6
-	unknownsfx0x20 4, 214, 160, 6
-	unknownsfx0x20 12, 211, 32, 6
-	unknownsfx0x20 8, 195, 36, 6
-	unknownsfx0x20 4, 194, 32, 6
-	unknownsfx0x20 8, 177, 16, 6
+	squarenote 4, 247, 160, 6
+	squarenote 8, 230, 164, 6
+	squarenote 4, 214, 160, 6
+	squarenote 12, 211, 32, 6
+	squarenote 8, 195, 36, 6
+	squarenote 4, 194, 32, 6
+	squarenote 8, 177, 16, 6
 	endchannel
 
 
 SFX_Cry04_1_Ch5:
 	dutycycle 90
-	unknownsfx0x20 4, 231, 1, 6
-	unknownsfx0x20 8, 214, 3, 6
-	unknownsfx0x20 4, 198, 1, 6
-	unknownsfx0x20 12, 195, 129, 5
-	unknownsfx0x20 8, 179, 131, 5
-	unknownsfx0x20 4, 178, 130, 5
-	unknownsfx0x20 8, 161, 113, 5
+	squarenote 4, 231, 1, 6
+	squarenote 8, 214, 3, 6
+	squarenote 4, 198, 1, 6
+	squarenote 12, 195, 129, 5
+	squarenote 8, 179, 131, 5
+	squarenote 4, 178, 130, 5
+	squarenote 8, 161, 113, 5
 	endchannel
 
 
 SFX_Cry04_1_Ch7:
-	unknownnoise0x20 7, 214, 92
-	unknownnoise0x20 8, 230, 76
-	unknownnoise0x20 4, 212, 92
-	unknownnoise0x20 4, 212, 76
-	unknownnoise0x20 7, 195, 76
-	unknownnoise0x20 8, 161, 92
+	noisenote 7, 214, 92
+	noisenote 8, 230, 76
+	noisenote 4, 212, 92
+	noisenote 4, 212, 76
+	noisenote 7, 195, 76
+	noisenote 8, 161, 92
 	endchannel

--- a/audio/sfx/cry04_2.asm
+++ b/audio/sfx/cry04_2.asm
@@ -1,32 +1,32 @@
 SFX_Cry04_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 247, 160, 6
-	unknownsfx0x20 8, 230, 164, 6
-	unknownsfx0x20 4, 214, 160, 6
-	unknownsfx0x20 12, 211, 32, 6
-	unknownsfx0x20 8, 195, 36, 6
-	unknownsfx0x20 4, 194, 32, 6
-	unknownsfx0x20 8, 177, 16, 6
+	squarenote 4, 247, 160, 6
+	squarenote 8, 230, 164, 6
+	squarenote 4, 214, 160, 6
+	squarenote 12, 211, 32, 6
+	squarenote 8, 195, 36, 6
+	squarenote 4, 194, 32, 6
+	squarenote 8, 177, 16, 6
 	endchannel
 
 
 SFX_Cry04_2_Ch5:
 	dutycycle 90
-	unknownsfx0x20 4, 231, 1, 6
-	unknownsfx0x20 8, 214, 3, 6
-	unknownsfx0x20 4, 198, 1, 6
-	unknownsfx0x20 12, 195, 129, 5
-	unknownsfx0x20 8, 179, 131, 5
-	unknownsfx0x20 4, 178, 130, 5
-	unknownsfx0x20 8, 161, 113, 5
+	squarenote 4, 231, 1, 6
+	squarenote 8, 214, 3, 6
+	squarenote 4, 198, 1, 6
+	squarenote 12, 195, 129, 5
+	squarenote 8, 179, 131, 5
+	squarenote 4, 178, 130, 5
+	squarenote 8, 161, 113, 5
 	endchannel
 
 
 SFX_Cry04_2_Ch7:
-	unknownnoise0x20 7, 214, 92
-	unknownnoise0x20 8, 230, 76
-	unknownnoise0x20 4, 212, 92
-	unknownnoise0x20 4, 212, 76
-	unknownnoise0x20 7, 195, 76
-	unknownnoise0x20 8, 161, 92
+	noisenote 7, 214, 92
+	noisenote 8, 230, 76
+	noisenote 4, 212, 92
+	noisenote 4, 212, 76
+	noisenote 7, 195, 76
+	noisenote 8, 161, 92
 	endchannel

--- a/audio/sfx/cry04_3.asm
+++ b/audio/sfx/cry04_3.asm
@@ -1,32 +1,32 @@
 SFX_Cry04_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 247, 160, 6
-	unknownsfx0x20 8, 230, 164, 6
-	unknownsfx0x20 4, 214, 160, 6
-	unknownsfx0x20 12, 211, 32, 6
-	unknownsfx0x20 8, 195, 36, 6
-	unknownsfx0x20 4, 194, 32, 6
-	unknownsfx0x20 8, 177, 16, 6
+	squarenote 4, 247, 160, 6
+	squarenote 8, 230, 164, 6
+	squarenote 4, 214, 160, 6
+	squarenote 12, 211, 32, 6
+	squarenote 8, 195, 36, 6
+	squarenote 4, 194, 32, 6
+	squarenote 8, 177, 16, 6
 	endchannel
 
 
 SFX_Cry04_3_Ch5:
 	dutycycle 90
-	unknownsfx0x20 4, 231, 1, 6
-	unknownsfx0x20 8, 214, 3, 6
-	unknownsfx0x20 4, 198, 1, 6
-	unknownsfx0x20 12, 195, 129, 5
-	unknownsfx0x20 8, 179, 131, 5
-	unknownsfx0x20 4, 178, 130, 5
-	unknownsfx0x20 8, 161, 113, 5
+	squarenote 4, 231, 1, 6
+	squarenote 8, 214, 3, 6
+	squarenote 4, 198, 1, 6
+	squarenote 12, 195, 129, 5
+	squarenote 8, 179, 131, 5
+	squarenote 4, 178, 130, 5
+	squarenote 8, 161, 113, 5
 	endchannel
 
 
 SFX_Cry04_3_Ch7:
-	unknownnoise0x20 7, 214, 92
-	unknownnoise0x20 8, 230, 76
-	unknownnoise0x20 4, 212, 92
-	unknownnoise0x20 4, 212, 76
-	unknownnoise0x20 7, 195, 76
-	unknownnoise0x20 8, 161, 92
+	noisenote 7, 214, 92
+	noisenote 8, 230, 76
+	noisenote 4, 212, 92
+	noisenote 4, 212, 76
+	noisenote 7, 195, 76
+	noisenote 8, 161, 92
 	endchannel

--- a/audio/sfx/cry05_1.asm
+++ b/audio/sfx/cry05_1.asm
@@ -1,18 +1,18 @@
 SFX_Cry05_1_Ch4:
 	dutycycle 10
-	unknownsfx0x20 6, 226, 0, 5
-	unknownsfx0x20 6, 227, 128, 5
-	unknownsfx0x20 6, 211, 112, 5
-	unknownsfx0x20 8, 161, 96, 5
+	squarenote 6, 226, 0, 5
+	squarenote 6, 227, 128, 5
+	squarenote 6, 211, 112, 5
+	squarenote 8, 161, 96, 5
 	endchannel
 
 
 SFX_Cry05_1_Ch5:
 	dutycycle 245
-	unknownsfx0x20 6, 226, 130, 4
-	unknownsfx0x20 6, 211, 1, 5
-	unknownsfx0x20 6, 178, 226, 4
-	unknownsfx0x20 8, 129, 193, 4
+	squarenote 6, 226, 130, 4
+	squarenote 6, 211, 1, 5
+	squarenote 6, 178, 226, 4
+	squarenote 8, 129, 193, 4
 
 
 SFX_Cry05_1_Ch7:

--- a/audio/sfx/cry05_2.asm
+++ b/audio/sfx/cry05_2.asm
@@ -1,18 +1,18 @@
 SFX_Cry05_2_Ch4:
 	dutycycle 10
-	unknownsfx0x20 6, 226, 0, 5
-	unknownsfx0x20 6, 227, 128, 5
-	unknownsfx0x20 6, 211, 112, 5
-	unknownsfx0x20 8, 161, 96, 5
+	squarenote 6, 226, 0, 5
+	squarenote 6, 227, 128, 5
+	squarenote 6, 211, 112, 5
+	squarenote 8, 161, 96, 5
 	endchannel
 
 
 SFX_Cry05_2_Ch5:
 	dutycycle 245
-	unknownsfx0x20 6, 226, 130, 4
-	unknownsfx0x20 6, 211, 1, 5
-	unknownsfx0x20 6, 178, 226, 4
-	unknownsfx0x20 8, 129, 193, 4
+	squarenote 6, 226, 130, 4
+	squarenote 6, 211, 1, 5
+	squarenote 6, 178, 226, 4
+	squarenote 8, 129, 193, 4
 
 
 SFX_Cry05_2_Ch7:

--- a/audio/sfx/cry05_3.asm
+++ b/audio/sfx/cry05_3.asm
@@ -1,18 +1,18 @@
 SFX_Cry05_3_Ch4:
 	dutycycle 10
-	unknownsfx0x20 6, 226, 0, 5
-	unknownsfx0x20 6, 227, 128, 5
-	unknownsfx0x20 6, 211, 112, 5
-	unknownsfx0x20 8, 161, 96, 5
+	squarenote 6, 226, 0, 5
+	squarenote 6, 227, 128, 5
+	squarenote 6, 211, 112, 5
+	squarenote 8, 161, 96, 5
 	endchannel
 
 
 SFX_Cry05_3_Ch5:
 	dutycycle 245
-	unknownsfx0x20 6, 226, 130, 4
-	unknownsfx0x20 6, 211, 1, 5
-	unknownsfx0x20 6, 178, 226, 4
-	unknownsfx0x20 8, 129, 193, 4
+	squarenote 6, 226, 130, 4
+	squarenote 6, 211, 1, 5
+	squarenote 6, 178, 226, 4
+	squarenote 8, 129, 193, 4
 
 
 SFX_Cry05_3_Ch7:

--- a/audio/sfx/cry06_1.asm
+++ b/audio/sfx/cry06_1.asm
@@ -1,11 +1,11 @@
 SFX_Cry06_1_Ch4:
 	dutycycle 250
-	unknownsfx0x20 6, 131, 71, 2
-	unknownsfx0x20 15, 98, 38, 2
-	unknownsfx0x20 4, 82, 69, 2
-	unknownsfx0x20 9, 99, 6, 2
-	unknownsfx0x20 15, 130, 37, 2
-	unknownsfx0x20 15, 66, 7, 2
+	squarenote 6, 131, 71, 2
+	squarenote 15, 98, 38, 2
+	squarenote 4, 82, 69, 2
+	squarenote 9, 99, 6, 2
+	squarenote 15, 130, 37, 2
+	squarenote 15, 66, 7, 2
 
 
 SFX_Cry06_1_Ch5:
@@ -13,10 +13,10 @@ SFX_Cry06_1_Ch5:
 
 
 SFX_Cry06_1_Ch7:
-	unknownnoise0x20 8, 212, 140
-	unknownnoise0x20 4, 226, 156
-	unknownnoise0x20 15, 198, 140
-	unknownnoise0x20 8, 228, 172
-	unknownnoise0x20 15, 215, 156
-	unknownnoise0x20 15, 242, 172
+	noisenote 8, 212, 140
+	noisenote 4, 226, 156
+	noisenote 15, 198, 140
+	noisenote 8, 228, 172
+	noisenote 15, 215, 156
+	noisenote 15, 242, 172
 	endchannel

--- a/audio/sfx/cry06_2.asm
+++ b/audio/sfx/cry06_2.asm
@@ -1,11 +1,11 @@
 SFX_Cry06_2_Ch4:
 	dutycycle 250
-	unknownsfx0x20 6, 131, 71, 2
-	unknownsfx0x20 15, 98, 38, 2
-	unknownsfx0x20 4, 82, 69, 2
-	unknownsfx0x20 9, 99, 6, 2
-	unknownsfx0x20 15, 130, 37, 2
-	unknownsfx0x20 15, 66, 7, 2
+	squarenote 6, 131, 71, 2
+	squarenote 15, 98, 38, 2
+	squarenote 4, 82, 69, 2
+	squarenote 9, 99, 6, 2
+	squarenote 15, 130, 37, 2
+	squarenote 15, 66, 7, 2
 
 
 SFX_Cry06_2_Ch5:
@@ -13,10 +13,10 @@ SFX_Cry06_2_Ch5:
 
 
 SFX_Cry06_2_Ch7:
-	unknownnoise0x20 8, 212, 140
-	unknownnoise0x20 4, 226, 156
-	unknownnoise0x20 15, 198, 140
-	unknownnoise0x20 8, 228, 172
-	unknownnoise0x20 15, 215, 156
-	unknownnoise0x20 15, 242, 172
+	noisenote 8, 212, 140
+	noisenote 4, 226, 156
+	noisenote 15, 198, 140
+	noisenote 8, 228, 172
+	noisenote 15, 215, 156
+	noisenote 15, 242, 172
 	endchannel

--- a/audio/sfx/cry06_3.asm
+++ b/audio/sfx/cry06_3.asm
@@ -1,11 +1,11 @@
 SFX_Cry06_3_Ch4:
 	dutycycle 250
-	unknownsfx0x20 6, 131, 71, 2
-	unknownsfx0x20 15, 98, 38, 2
-	unknownsfx0x20 4, 82, 69, 2
-	unknownsfx0x20 9, 99, 6, 2
-	unknownsfx0x20 15, 130, 37, 2
-	unknownsfx0x20 15, 66, 7, 2
+	squarenote 6, 131, 71, 2
+	squarenote 15, 98, 38, 2
+	squarenote 4, 82, 69, 2
+	squarenote 9, 99, 6, 2
+	squarenote 15, 130, 37, 2
+	squarenote 15, 66, 7, 2
 
 
 SFX_Cry06_3_Ch5:
@@ -13,10 +13,10 @@ SFX_Cry06_3_Ch5:
 
 
 SFX_Cry06_3_Ch7:
-	unknownnoise0x20 8, 212, 140
-	unknownnoise0x20 4, 226, 156
-	unknownnoise0x20 15, 198, 140
-	unknownnoise0x20 8, 228, 172
-	unknownnoise0x20 15, 215, 156
-	unknownnoise0x20 15, 242, 172
+	noisenote 8, 212, 140
+	noisenote 4, 226, 156
+	noisenote 15, 198, 140
+	noisenote 8, 228, 172
+	noisenote 15, 215, 156
+	noisenote 15, 242, 172
 	endchannel

--- a/audio/sfx/cry07_1.asm
+++ b/audio/sfx/cry07_1.asm
@@ -1,21 +1,21 @@
 SFX_Cry07_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 243, 224, 6
-	unknownsfx0x20 15, 228, 64, 6
-	unknownsfx0x20 8, 193, 32, 6
+	squarenote 4, 243, 224, 6
+	squarenote 15, 228, 64, 6
+	squarenote 8, 193, 32, 6
 	endchannel
 
 
 SFX_Cry07_1_Ch5:
 	dutycycle 10
-	unknownsfx0x20 3, 195, 131, 6
-	unknownsfx0x20 14, 180, 2, 6
-	unknownsfx0x20 8, 161, 1, 6
+	squarenote 3, 195, 131, 6
+	squarenote 14, 180, 2, 6
+	squarenote 8, 161, 1, 6
 	endchannel
 
 
 SFX_Cry07_1_Ch7:
-	unknownnoise0x20 4, 211, 92
-	unknownnoise0x20 15, 230, 76
-	unknownnoise0x20 8, 177, 92
+	noisenote 4, 211, 92
+	noisenote 15, 230, 76
+	noisenote 8, 177, 92
 	endchannel

--- a/audio/sfx/cry07_2.asm
+++ b/audio/sfx/cry07_2.asm
@@ -1,21 +1,21 @@
 SFX_Cry07_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 243, 224, 6
-	unknownsfx0x20 15, 228, 64, 6
-	unknownsfx0x20 8, 193, 32, 6
+	squarenote 4, 243, 224, 6
+	squarenote 15, 228, 64, 6
+	squarenote 8, 193, 32, 6
 	endchannel
 
 
 SFX_Cry07_2_Ch5:
 	dutycycle 10
-	unknownsfx0x20 3, 195, 131, 6
-	unknownsfx0x20 14, 180, 2, 6
-	unknownsfx0x20 8, 161, 1, 6
+	squarenote 3, 195, 131, 6
+	squarenote 14, 180, 2, 6
+	squarenote 8, 161, 1, 6
 	endchannel
 
 
 SFX_Cry07_2_Ch7:
-	unknownnoise0x20 4, 211, 92
-	unknownnoise0x20 15, 230, 76
-	unknownnoise0x20 8, 177, 92
+	noisenote 4, 211, 92
+	noisenote 15, 230, 76
+	noisenote 8, 177, 92
 	endchannel

--- a/audio/sfx/cry07_3.asm
+++ b/audio/sfx/cry07_3.asm
@@ -1,21 +1,21 @@
 SFX_Cry07_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 243, 224, 6
-	unknownsfx0x20 15, 228, 64, 6
-	unknownsfx0x20 8, 193, 32, 6
+	squarenote 4, 243, 224, 6
+	squarenote 15, 228, 64, 6
+	squarenote 8, 193, 32, 6
 	endchannel
 
 
 SFX_Cry07_3_Ch5:
 	dutycycle 10
-	unknownsfx0x20 3, 195, 131, 6
-	unknownsfx0x20 14, 180, 2, 6
-	unknownsfx0x20 8, 161, 1, 6
+	squarenote 3, 195, 131, 6
+	squarenote 14, 180, 2, 6
+	squarenote 8, 161, 1, 6
 	endchannel
 
 
 SFX_Cry07_3_Ch7:
-	unknownnoise0x20 4, 211, 92
-	unknownnoise0x20 15, 230, 76
-	unknownnoise0x20 8, 177, 92
+	noisenote 4, 211, 92
+	noisenote 15, 230, 76
+	noisenote 8, 177, 92
 	endchannel

--- a/audio/sfx/cry08_1.asm
+++ b/audio/sfx/cry08_1.asm
@@ -1,23 +1,23 @@
 SFX_Cry08_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 246, 101, 5
-	unknownsfx0x20 10, 228, 124, 5
-	unknownsfx0x20 3, 194, 92, 5
-	unknownsfx0x20 15, 178, 60, 5
+	squarenote 15, 246, 101, 5
+	squarenote 10, 228, 124, 5
+	squarenote 3, 194, 92, 5
+	squarenote 15, 178, 60, 5
 	endchannel
 
 
 SFX_Cry08_1_Ch5:
 	dutycycle 90
-	unknownsfx0x20 14, 214, 3, 5
-	unknownsfx0x20 9, 180, 27, 5
-	unknownsfx0x20 4, 146, 250, 4
-	unknownsfx0x20 15, 162, 219, 4
+	squarenote 14, 214, 3, 5
+	squarenote 9, 180, 27, 5
+	squarenote 4, 146, 250, 4
+	squarenote 15, 162, 219, 4
 	endchannel
 
 
 SFX_Cry08_1_Ch7:
-	unknownnoise0x20 12, 230, 76
-	unknownnoise0x20 11, 215, 92
-	unknownnoise0x20 15, 194, 76
+	noisenote 12, 230, 76
+	noisenote 11, 215, 92
+	noisenote 15, 194, 76
 	endchannel

--- a/audio/sfx/cry08_2.asm
+++ b/audio/sfx/cry08_2.asm
@@ -1,23 +1,23 @@
 SFX_Cry08_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 246, 101, 5
-	unknownsfx0x20 10, 228, 124, 5
-	unknownsfx0x20 3, 194, 92, 5
-	unknownsfx0x20 15, 178, 60, 5
+	squarenote 15, 246, 101, 5
+	squarenote 10, 228, 124, 5
+	squarenote 3, 194, 92, 5
+	squarenote 15, 178, 60, 5
 	endchannel
 
 
 SFX_Cry08_2_Ch5:
 	dutycycle 90
-	unknownsfx0x20 14, 214, 3, 5
-	unknownsfx0x20 9, 180, 27, 5
-	unknownsfx0x20 4, 146, 250, 4
-	unknownsfx0x20 15, 162, 219, 4
+	squarenote 14, 214, 3, 5
+	squarenote 9, 180, 27, 5
+	squarenote 4, 146, 250, 4
+	squarenote 15, 162, 219, 4
 	endchannel
 
 
 SFX_Cry08_2_Ch7:
-	unknownnoise0x20 12, 230, 76
-	unknownnoise0x20 11, 215, 92
-	unknownnoise0x20 15, 194, 76
+	noisenote 12, 230, 76
+	noisenote 11, 215, 92
+	noisenote 15, 194, 76
 	endchannel

--- a/audio/sfx/cry08_3.asm
+++ b/audio/sfx/cry08_3.asm
@@ -1,23 +1,23 @@
 SFX_Cry08_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 246, 101, 5
-	unknownsfx0x20 10, 228, 124, 5
-	unknownsfx0x20 3, 194, 92, 5
-	unknownsfx0x20 15, 178, 60, 5
+	squarenote 15, 246, 101, 5
+	squarenote 10, 228, 124, 5
+	squarenote 3, 194, 92, 5
+	squarenote 15, 178, 60, 5
 	endchannel
 
 
 SFX_Cry08_3_Ch5:
 	dutycycle 90
-	unknownsfx0x20 14, 214, 3, 5
-	unknownsfx0x20 9, 180, 27, 5
-	unknownsfx0x20 4, 146, 250, 4
-	unknownsfx0x20 15, 162, 219, 4
+	squarenote 14, 214, 3, 5
+	squarenote 9, 180, 27, 5
+	squarenote 4, 146, 250, 4
+	squarenote 15, 162, 219, 4
 	endchannel
 
 
 SFX_Cry08_3_Ch7:
-	unknownnoise0x20 12, 230, 76
-	unknownnoise0x20 11, 215, 92
-	unknownnoise0x20 15, 194, 76
+	noisenote 12, 230, 76
+	noisenote 11, 215, 92
+	noisenote 15, 194, 76
 	endchannel

--- a/audio/sfx/cry09_1.asm
+++ b/audio/sfx/cry09_1.asm
@@ -1,35 +1,35 @@
 SFX_Cry09_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 247, 160, 7
-	unknownsfx0x20 6, 230, 163, 7
-	unknownsfx0x20 10, 244, 160, 7
+	squarenote 15, 247, 160, 7
+	squarenote 6, 230, 163, 7
+	squarenote 10, 244, 160, 7
 	dutycycle 165
-	unknownsfx0x20 10, 246, 216, 7
-	unknownsfx0x20 4, 227, 215, 7
-	unknownsfx0x20 15, 242, 216, 7
+	squarenote 10, 246, 216, 7
+	squarenote 4, 227, 215, 7
+	squarenote 15, 242, 216, 7
 	endchannel
 
 
 SFX_Cry09_1_Ch5:
 	dutycycle 5
-	unknownsfx0x20 2, 8, 0, 0
-	unknownsfx0x20 15, 167, 161, 6
-	unknownsfx0x20 6, 134, 162, 6
-	unknownsfx0x20 10, 116, 161, 6
+	squarenote 2, 8, 0, 0
+	squarenote 15, 167, 161, 6
+	squarenote 6, 134, 162, 6
+	squarenote 10, 116, 161, 6
 	dutycycle 95
-	unknownsfx0x20 10, 118, 214, 6
-	unknownsfx0x20 4, 131, 217, 6
-	unknownsfx0x20 15, 162, 215, 6
+	squarenote 10, 118, 214, 6
+	squarenote 4, 131, 217, 6
+	squarenote 15, 162, 215, 6
 	endchannel
 
 
 SFX_Cry09_1_Ch7:
-	unknownnoise0x20 2, 242, 60
-	unknownnoise0x20 8, 228, 62
-	unknownnoise0x20 15, 215, 60
-	unknownnoise0x20 6, 197, 59
-	unknownnoise0x20 6, 228, 61
-	unknownnoise0x20 8, 182, 60
-	unknownnoise0x20 6, 212, 61
-	unknownnoise0x20 8, 193, 59
+	noisenote 2, 242, 60
+	noisenote 8, 228, 62
+	noisenote 15, 215, 60
+	noisenote 6, 197, 59
+	noisenote 6, 228, 61
+	noisenote 8, 182, 60
+	noisenote 6, 212, 61
+	noisenote 8, 193, 59
 	endchannel

--- a/audio/sfx/cry09_2.asm
+++ b/audio/sfx/cry09_2.asm
@@ -1,35 +1,35 @@
 SFX_Cry09_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 247, 160, 7
-	unknownsfx0x20 6, 230, 163, 7
-	unknownsfx0x20 10, 244, 160, 7
+	squarenote 15, 247, 160, 7
+	squarenote 6, 230, 163, 7
+	squarenote 10, 244, 160, 7
 	dutycycle 165
-	unknownsfx0x20 10, 246, 216, 7
-	unknownsfx0x20 4, 227, 215, 7
-	unknownsfx0x20 15, 242, 216, 7
+	squarenote 10, 246, 216, 7
+	squarenote 4, 227, 215, 7
+	squarenote 15, 242, 216, 7
 	endchannel
 
 
 SFX_Cry09_2_Ch5:
 	dutycycle 5
-	unknownsfx0x20 2, 8, 0, 0
-	unknownsfx0x20 15, 167, 161, 6
-	unknownsfx0x20 6, 134, 162, 6
-	unknownsfx0x20 10, 116, 161, 6
+	squarenote 2, 8, 0, 0
+	squarenote 15, 167, 161, 6
+	squarenote 6, 134, 162, 6
+	squarenote 10, 116, 161, 6
 	dutycycle 95
-	unknownsfx0x20 10, 118, 214, 6
-	unknownsfx0x20 4, 131, 217, 6
-	unknownsfx0x20 15, 162, 215, 6
+	squarenote 10, 118, 214, 6
+	squarenote 4, 131, 217, 6
+	squarenote 15, 162, 215, 6
 	endchannel
 
 
 SFX_Cry09_2_Ch7:
-	unknownnoise0x20 2, 242, 60
-	unknownnoise0x20 8, 228, 62
-	unknownnoise0x20 15, 215, 60
-	unknownnoise0x20 6, 197, 59
-	unknownnoise0x20 6, 228, 61
-	unknownnoise0x20 8, 182, 60
-	unknownnoise0x20 6, 212, 61
-	unknownnoise0x20 8, 193, 59
+	noisenote 2, 242, 60
+	noisenote 8, 228, 62
+	noisenote 15, 215, 60
+	noisenote 6, 197, 59
+	noisenote 6, 228, 61
+	noisenote 8, 182, 60
+	noisenote 6, 212, 61
+	noisenote 8, 193, 59
 	endchannel

--- a/audio/sfx/cry09_3.asm
+++ b/audio/sfx/cry09_3.asm
@@ -1,35 +1,35 @@
 SFX_Cry09_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 247, 160, 7
-	unknownsfx0x20 6, 230, 163, 7
-	unknownsfx0x20 10, 244, 160, 7
+	squarenote 15, 247, 160, 7
+	squarenote 6, 230, 163, 7
+	squarenote 10, 244, 160, 7
 	dutycycle 165
-	unknownsfx0x20 10, 246, 216, 7
-	unknownsfx0x20 4, 227, 215, 7
-	unknownsfx0x20 15, 242, 216, 7
+	squarenote 10, 246, 216, 7
+	squarenote 4, 227, 215, 7
+	squarenote 15, 242, 216, 7
 	endchannel
 
 
 SFX_Cry09_3_Ch5:
 	dutycycle 5
-	unknownsfx0x20 2, 8, 0, 0
-	unknownsfx0x20 15, 167, 161, 6
-	unknownsfx0x20 6, 134, 162, 6
-	unknownsfx0x20 10, 116, 161, 6
+	squarenote 2, 8, 0, 0
+	squarenote 15, 167, 161, 6
+	squarenote 6, 134, 162, 6
+	squarenote 10, 116, 161, 6
 	dutycycle 95
-	unknownsfx0x20 10, 118, 214, 6
-	unknownsfx0x20 4, 131, 217, 6
-	unknownsfx0x20 15, 162, 215, 6
+	squarenote 10, 118, 214, 6
+	squarenote 4, 131, 217, 6
+	squarenote 15, 162, 215, 6
 	endchannel
 
 
 SFX_Cry09_3_Ch7:
-	unknownnoise0x20 2, 242, 60
-	unknownnoise0x20 8, 228, 62
-	unknownnoise0x20 15, 215, 60
-	unknownnoise0x20 6, 197, 59
-	unknownnoise0x20 6, 228, 61
-	unknownnoise0x20 8, 182, 60
-	unknownnoise0x20 6, 212, 61
-	unknownnoise0x20 8, 193, 59
+	noisenote 2, 242, 60
+	noisenote 8, 228, 62
+	noisenote 15, 215, 60
+	noisenote 6, 197, 59
+	noisenote 6, 228, 61
+	noisenote 8, 182, 60
+	noisenote 6, 212, 61
+	noisenote 8, 193, 59
 	endchannel

--- a/audio/sfx/cry0a_1.asm
+++ b/audio/sfx/cry0a_1.asm
@@ -1,35 +1,35 @@
 SFX_Cry0A_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 8, 247, 224, 6
-	unknownsfx0x20 6, 230, 229, 6
-	unknownsfx0x20 3, 244, 224, 6
-	unknownsfx0x20 3, 246, 208, 6
-	unknownsfx0x20 3, 227, 192, 6
-	unknownsfx0x20 4, 242, 176, 6
-	unknownsfx0x20 15, 162, 200, 6
+	squarenote 8, 247, 224, 6
+	squarenote 6, 230, 229, 6
+	squarenote 3, 244, 224, 6
+	squarenote 3, 246, 208, 6
+	squarenote 3, 227, 192, 6
+	squarenote 4, 242, 176, 6
+	squarenote 15, 162, 200, 6
 	endchannel
 
 
 SFX_Cry0A_1_Ch5:
 	dutycycle 5
-	unknownsfx0x20 3, 8, 0, 0
-	unknownsfx0x20 8, 167, 161, 6
-	unknownsfx0x20 6, 134, 163, 6
-	unknownsfx0x20 3, 116, 161, 6
-	unknownsfx0x20 3, 118, 145, 6
-	unknownsfx0x20 3, 131, 130, 6
-	unknownsfx0x20 4, 162, 113, 6
-	unknownsfx0x20 15, 114, 137, 6
+	squarenote 3, 8, 0, 0
+	squarenote 8, 167, 161, 6
+	squarenote 6, 134, 163, 6
+	squarenote 3, 116, 161, 6
+	squarenote 3, 118, 145, 6
+	squarenote 3, 131, 130, 6
+	squarenote 4, 162, 113, 6
+	squarenote 15, 114, 137, 6
 	endchannel
 
 
 SFX_Cry0A_1_Ch7:
-	unknownnoise0x20 2, 242, 60
-	unknownnoise0x20 8, 228, 62
-	unknownnoise0x20 8, 215, 60
-	unknownnoise0x20 5, 197, 59
-	unknownnoise0x20 3, 212, 44
-	unknownnoise0x20 2, 182, 60
-	unknownnoise0x20 3, 164, 44
-	unknownnoise0x20 8, 145, 60
+	noisenote 2, 242, 60
+	noisenote 8, 228, 62
+	noisenote 8, 215, 60
+	noisenote 5, 197, 59
+	noisenote 3, 212, 44
+	noisenote 2, 182, 60
+	noisenote 3, 164, 44
+	noisenote 8, 145, 60
 	endchannel

--- a/audio/sfx/cry0a_2.asm
+++ b/audio/sfx/cry0a_2.asm
@@ -1,35 +1,35 @@
 SFX_Cry0A_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 8, 247, 224, 6
-	unknownsfx0x20 6, 230, 229, 6
-	unknownsfx0x20 3, 244, 224, 6
-	unknownsfx0x20 3, 246, 208, 6
-	unknownsfx0x20 3, 227, 192, 6
-	unknownsfx0x20 4, 242, 176, 6
-	unknownsfx0x20 15, 162, 200, 6
+	squarenote 8, 247, 224, 6
+	squarenote 6, 230, 229, 6
+	squarenote 3, 244, 224, 6
+	squarenote 3, 246, 208, 6
+	squarenote 3, 227, 192, 6
+	squarenote 4, 242, 176, 6
+	squarenote 15, 162, 200, 6
 	endchannel
 
 
 SFX_Cry0A_2_Ch5:
 	dutycycle 5
-	unknownsfx0x20 3, 8, 0, 0
-	unknownsfx0x20 8, 167, 161, 6
-	unknownsfx0x20 6, 134, 163, 6
-	unknownsfx0x20 3, 116, 161, 6
-	unknownsfx0x20 3, 118, 145, 6
-	unknownsfx0x20 3, 131, 130, 6
-	unknownsfx0x20 4, 162, 113, 6
-	unknownsfx0x20 15, 114, 137, 6
+	squarenote 3, 8, 0, 0
+	squarenote 8, 167, 161, 6
+	squarenote 6, 134, 163, 6
+	squarenote 3, 116, 161, 6
+	squarenote 3, 118, 145, 6
+	squarenote 3, 131, 130, 6
+	squarenote 4, 162, 113, 6
+	squarenote 15, 114, 137, 6
 	endchannel
 
 
 SFX_Cry0A_2_Ch7:
-	unknownnoise0x20 2, 242, 60
-	unknownnoise0x20 8, 228, 62
-	unknownnoise0x20 8, 215, 60
-	unknownnoise0x20 5, 197, 59
-	unknownnoise0x20 3, 212, 44
-	unknownnoise0x20 2, 182, 60
-	unknownnoise0x20 3, 164, 44
-	unknownnoise0x20 8, 145, 60
+	noisenote 2, 242, 60
+	noisenote 8, 228, 62
+	noisenote 8, 215, 60
+	noisenote 5, 197, 59
+	noisenote 3, 212, 44
+	noisenote 2, 182, 60
+	noisenote 3, 164, 44
+	noisenote 8, 145, 60
 	endchannel

--- a/audio/sfx/cry0a_3.asm
+++ b/audio/sfx/cry0a_3.asm
@@ -1,35 +1,35 @@
 SFX_Cry0A_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 8, 247, 224, 6
-	unknownsfx0x20 6, 230, 229, 6
-	unknownsfx0x20 3, 244, 224, 6
-	unknownsfx0x20 3, 246, 208, 6
-	unknownsfx0x20 3, 227, 192, 6
-	unknownsfx0x20 4, 242, 176, 6
-	unknownsfx0x20 15, 162, 200, 6
+	squarenote 8, 247, 224, 6
+	squarenote 6, 230, 229, 6
+	squarenote 3, 244, 224, 6
+	squarenote 3, 246, 208, 6
+	squarenote 3, 227, 192, 6
+	squarenote 4, 242, 176, 6
+	squarenote 15, 162, 200, 6
 	endchannel
 
 
 SFX_Cry0A_3_Ch5:
 	dutycycle 5
-	unknownsfx0x20 3, 8, 0, 0
-	unknownsfx0x20 8, 167, 161, 6
-	unknownsfx0x20 6, 134, 163, 6
-	unknownsfx0x20 3, 116, 161, 6
-	unknownsfx0x20 3, 118, 145, 6
-	unknownsfx0x20 3, 131, 130, 6
-	unknownsfx0x20 4, 162, 113, 6
-	unknownsfx0x20 15, 114, 137, 6
+	squarenote 3, 8, 0, 0
+	squarenote 8, 167, 161, 6
+	squarenote 6, 134, 163, 6
+	squarenote 3, 116, 161, 6
+	squarenote 3, 118, 145, 6
+	squarenote 3, 131, 130, 6
+	squarenote 4, 162, 113, 6
+	squarenote 15, 114, 137, 6
 	endchannel
 
 
 SFX_Cry0A_3_Ch7:
-	unknownnoise0x20 2, 242, 60
-	unknownnoise0x20 8, 228, 62
-	unknownnoise0x20 8, 215, 60
-	unknownnoise0x20 5, 197, 59
-	unknownnoise0x20 3, 212, 44
-	unknownnoise0x20 2, 182, 60
-	unknownnoise0x20 3, 164, 44
-	unknownnoise0x20 8, 145, 60
+	noisenote 2, 242, 60
+	noisenote 8, 228, 62
+	noisenote 8, 215, 60
+	noisenote 5, 197, 59
+	noisenote 3, 212, 44
+	noisenote 2, 182, 60
+	noisenote 3, 164, 44
+	noisenote 8, 145, 60
 	endchannel

--- a/audio/sfx/cry0b_1.asm
+++ b/audio/sfx/cry0b_1.asm
@@ -1,37 +1,37 @@
 SFX_Cry0B_1_Ch4:
 	dutycycle 204
-	unknownsfx0x20 4, 241, 0, 7
-	unknownsfx0x20 4, 225, 128, 7
-	unknownsfx0x20 4, 209, 64, 7
-	unknownsfx0x20 4, 225, 64, 7
-	unknownsfx0x20 4, 241, 128, 7
-	unknownsfx0x20 4, 209, 0, 7
-	unknownsfx0x20 4, 241, 1, 7
-	unknownsfx0x20 4, 209, 130, 7
-	unknownsfx0x20 4, 193, 66, 7
-	unknownsfx0x20 8, 177, 65, 7
+	squarenote 4, 241, 0, 7
+	squarenote 4, 225, 128, 7
+	squarenote 4, 209, 64, 7
+	squarenote 4, 225, 64, 7
+	squarenote 4, 241, 128, 7
+	squarenote 4, 209, 0, 7
+	squarenote 4, 241, 1, 7
+	squarenote 4, 209, 130, 7
+	squarenote 4, 193, 66, 7
+	squarenote 8, 177, 65, 7
 	endchannel
 
 
 SFX_Cry0B_1_Ch5:
 	dutycycle 68
-	unknownsfx0x20 12, 8, 0, 0
-	unknownsfx0x20 4, 241, 1, 7
-	unknownsfx0x20 4, 225, 130, 7
-	unknownsfx0x20 4, 209, 65, 7
-	unknownsfx0x20 4, 225, 65, 7
-	unknownsfx0x20 4, 241, 130, 7
-	unknownsfx0x20 8, 209, 1, 7
+	squarenote 12, 8, 0, 0
+	squarenote 4, 241, 1, 7
+	squarenote 4, 225, 130, 7
+	squarenote 4, 209, 65, 7
+	squarenote 4, 225, 65, 7
+	squarenote 4, 241, 130, 7
+	squarenote 8, 209, 1, 7
 	endchannel
 
 
 SFX_Cry0B_1_Ch7:
-	unknownnoise0x20 15, 8, 0
-	unknownnoise0x20 4, 8, 0
-	unknownnoise0x20 4, 209, 76
-	unknownnoise0x20 4, 177, 44
-	unknownnoise0x20 4, 209, 60
-	unknownnoise0x20 4, 177, 60
-	unknownnoise0x20 4, 193, 44
-	unknownnoise0x20 8, 161, 76
+	noisenote 15, 8, 0
+	noisenote 4, 8, 0
+	noisenote 4, 209, 76
+	noisenote 4, 177, 44
+	noisenote 4, 209, 60
+	noisenote 4, 177, 60
+	noisenote 4, 193, 44
+	noisenote 8, 161, 76
 	endchannel

--- a/audio/sfx/cry0b_2.asm
+++ b/audio/sfx/cry0b_2.asm
@@ -1,37 +1,37 @@
 SFX_Cry0B_2_Ch4:
 	dutycycle 204
-	unknownsfx0x20 4, 241, 0, 7
-	unknownsfx0x20 4, 225, 128, 7
-	unknownsfx0x20 4, 209, 64, 7
-	unknownsfx0x20 4, 225, 64, 7
-	unknownsfx0x20 4, 241, 128, 7
-	unknownsfx0x20 4, 209, 0, 7
-	unknownsfx0x20 4, 241, 1, 7
-	unknownsfx0x20 4, 209, 130, 7
-	unknownsfx0x20 4, 193, 66, 7
-	unknownsfx0x20 8, 177, 65, 7
+	squarenote 4, 241, 0, 7
+	squarenote 4, 225, 128, 7
+	squarenote 4, 209, 64, 7
+	squarenote 4, 225, 64, 7
+	squarenote 4, 241, 128, 7
+	squarenote 4, 209, 0, 7
+	squarenote 4, 241, 1, 7
+	squarenote 4, 209, 130, 7
+	squarenote 4, 193, 66, 7
+	squarenote 8, 177, 65, 7
 	endchannel
 
 
 SFX_Cry0B_2_Ch5:
 	dutycycle 68
-	unknownsfx0x20 12, 8, 0, 0
-	unknownsfx0x20 4, 241, 1, 7
-	unknownsfx0x20 4, 225, 130, 7
-	unknownsfx0x20 4, 209, 65, 7
-	unknownsfx0x20 4, 225, 65, 7
-	unknownsfx0x20 4, 241, 130, 7
-	unknownsfx0x20 8, 209, 1, 7
+	squarenote 12, 8, 0, 0
+	squarenote 4, 241, 1, 7
+	squarenote 4, 225, 130, 7
+	squarenote 4, 209, 65, 7
+	squarenote 4, 225, 65, 7
+	squarenote 4, 241, 130, 7
+	squarenote 8, 209, 1, 7
 	endchannel
 
 
 SFX_Cry0B_2_Ch7:
-	unknownnoise0x20 15, 8, 0
-	unknownnoise0x20 4, 8, 0
-	unknownnoise0x20 4, 209, 76
-	unknownnoise0x20 4, 177, 44
-	unknownnoise0x20 4, 209, 60
-	unknownnoise0x20 4, 177, 60
-	unknownnoise0x20 4, 193, 44
-	unknownnoise0x20 8, 161, 76
+	noisenote 15, 8, 0
+	noisenote 4, 8, 0
+	noisenote 4, 209, 76
+	noisenote 4, 177, 44
+	noisenote 4, 209, 60
+	noisenote 4, 177, 60
+	noisenote 4, 193, 44
+	noisenote 8, 161, 76
 	endchannel

--- a/audio/sfx/cry0b_3.asm
+++ b/audio/sfx/cry0b_3.asm
@@ -1,37 +1,37 @@
 SFX_Cry0B_3_Ch4:
 	dutycycle 204
-	unknownsfx0x20 4, 241, 0, 7
-	unknownsfx0x20 4, 225, 128, 7
-	unknownsfx0x20 4, 209, 64, 7
-	unknownsfx0x20 4, 225, 64, 7
-	unknownsfx0x20 4, 241, 128, 7
-	unknownsfx0x20 4, 209, 0, 7
-	unknownsfx0x20 4, 241, 1, 7
-	unknownsfx0x20 4, 209, 130, 7
-	unknownsfx0x20 4, 193, 66, 7
-	unknownsfx0x20 8, 177, 65, 7
+	squarenote 4, 241, 0, 7
+	squarenote 4, 225, 128, 7
+	squarenote 4, 209, 64, 7
+	squarenote 4, 225, 64, 7
+	squarenote 4, 241, 128, 7
+	squarenote 4, 209, 0, 7
+	squarenote 4, 241, 1, 7
+	squarenote 4, 209, 130, 7
+	squarenote 4, 193, 66, 7
+	squarenote 8, 177, 65, 7
 	endchannel
 
 
 SFX_Cry0B_3_Ch5:
 	dutycycle 68
-	unknownsfx0x20 12, 8, 0, 0
-	unknownsfx0x20 4, 241, 1, 7
-	unknownsfx0x20 4, 225, 130, 7
-	unknownsfx0x20 4, 209, 65, 7
-	unknownsfx0x20 4, 225, 65, 7
-	unknownsfx0x20 4, 241, 130, 7
-	unknownsfx0x20 8, 209, 1, 7
+	squarenote 12, 8, 0, 0
+	squarenote 4, 241, 1, 7
+	squarenote 4, 225, 130, 7
+	squarenote 4, 209, 65, 7
+	squarenote 4, 225, 65, 7
+	squarenote 4, 241, 130, 7
+	squarenote 8, 209, 1, 7
 	endchannel
 
 
 SFX_Cry0B_3_Ch7:
-	unknownnoise0x20 15, 8, 0
-	unknownnoise0x20 4, 8, 0
-	unknownnoise0x20 4, 209, 76
-	unknownnoise0x20 4, 177, 44
-	unknownnoise0x20 4, 209, 60
-	unknownnoise0x20 4, 177, 60
-	unknownnoise0x20 4, 193, 44
-	unknownnoise0x20 8, 161, 76
+	noisenote 15, 8, 0
+	noisenote 4, 8, 0
+	noisenote 4, 209, 76
+	noisenote 4, 177, 44
+	noisenote 4, 209, 60
+	noisenote 4, 177, 60
+	noisenote 4, 193, 44
+	noisenote 8, 161, 76
 	endchannel

--- a/audio/sfx/cry0c_1.asm
+++ b/audio/sfx/cry0c_1.asm
@@ -1,28 +1,28 @@
 SFX_Cry0C_1_Ch4:
 	dutycycle 204
-	unknownsfx0x20 8, 245, 0, 6
-	unknownsfx0x20 2, 210, 56, 6
-	unknownsfx0x20 2, 194, 48, 6
-	unknownsfx0x20 2, 194, 40, 6
-	unknownsfx0x20 2, 178, 32, 6
-	unknownsfx0x20 2, 178, 16, 6
-	unknownsfx0x20 2, 162, 24, 6
-	unknownsfx0x20 2, 178, 16, 6
-	unknownsfx0x20 8, 193, 32, 6
+	squarenote 8, 245, 0, 6
+	squarenote 2, 210, 56, 6
+	squarenote 2, 194, 48, 6
+	squarenote 2, 194, 40, 6
+	squarenote 2, 178, 32, 6
+	squarenote 2, 178, 16, 6
+	squarenote 2, 162, 24, 6
+	squarenote 2, 178, 16, 6
+	squarenote 8, 193, 32, 6
 	endchannel
 
 
 SFX_Cry0C_1_Ch5:
 	dutycycle 68
-	unknownsfx0x20 12, 195, 192, 5
-	unknownsfx0x20 3, 177, 249, 5
-	unknownsfx0x20 2, 161, 241, 5
-	unknownsfx0x20 2, 161, 233, 5
-	unknownsfx0x20 2, 145, 225, 5
-	unknownsfx0x20 2, 145, 217, 5
-	unknownsfx0x20 2, 129, 209, 5
-	unknownsfx0x20 2, 145, 217, 5
-	unknownsfx0x20 8, 145, 225, 5
+	squarenote 12, 195, 192, 5
+	squarenote 3, 177, 249, 5
+	squarenote 2, 161, 241, 5
+	squarenote 2, 161, 233, 5
+	squarenote 2, 145, 225, 5
+	squarenote 2, 145, 217, 5
+	squarenote 2, 129, 209, 5
+	squarenote 2, 145, 217, 5
+	squarenote 8, 145, 225, 5
 
 
 SFX_Cry0C_1_Ch7:

--- a/audio/sfx/cry0c_2.asm
+++ b/audio/sfx/cry0c_2.asm
@@ -1,28 +1,28 @@
 SFX_Cry0C_2_Ch4:
 	dutycycle 204
-	unknownsfx0x20 8, 245, 0, 6
-	unknownsfx0x20 2, 210, 56, 6
-	unknownsfx0x20 2, 194, 48, 6
-	unknownsfx0x20 2, 194, 40, 6
-	unknownsfx0x20 2, 178, 32, 6
-	unknownsfx0x20 2, 178, 16, 6
-	unknownsfx0x20 2, 162, 24, 6
-	unknownsfx0x20 2, 178, 16, 6
-	unknownsfx0x20 8, 193, 32, 6
+	squarenote 8, 245, 0, 6
+	squarenote 2, 210, 56, 6
+	squarenote 2, 194, 48, 6
+	squarenote 2, 194, 40, 6
+	squarenote 2, 178, 32, 6
+	squarenote 2, 178, 16, 6
+	squarenote 2, 162, 24, 6
+	squarenote 2, 178, 16, 6
+	squarenote 8, 193, 32, 6
 	endchannel
 
 
 SFX_Cry0C_2_Ch5:
 	dutycycle 68
-	unknownsfx0x20 12, 195, 192, 5
-	unknownsfx0x20 3, 177, 249, 5
-	unknownsfx0x20 2, 161, 241, 5
-	unknownsfx0x20 2, 161, 233, 5
-	unknownsfx0x20 2, 145, 225, 5
-	unknownsfx0x20 2, 145, 217, 5
-	unknownsfx0x20 2, 129, 209, 5
-	unknownsfx0x20 2, 145, 217, 5
-	unknownsfx0x20 8, 145, 225, 5
+	squarenote 12, 195, 192, 5
+	squarenote 3, 177, 249, 5
+	squarenote 2, 161, 241, 5
+	squarenote 2, 161, 233, 5
+	squarenote 2, 145, 225, 5
+	squarenote 2, 145, 217, 5
+	squarenote 2, 129, 209, 5
+	squarenote 2, 145, 217, 5
+	squarenote 8, 145, 225, 5
 
 
 SFX_Cry0C_2_Ch7:

--- a/audio/sfx/cry0c_3.asm
+++ b/audio/sfx/cry0c_3.asm
@@ -1,28 +1,28 @@
 SFX_Cry0C_3_Ch4:
 	dutycycle 204
-	unknownsfx0x20 8, 245, 0, 6
-	unknownsfx0x20 2, 210, 56, 6
-	unknownsfx0x20 2, 194, 48, 6
-	unknownsfx0x20 2, 194, 40, 6
-	unknownsfx0x20 2, 178, 32, 6
-	unknownsfx0x20 2, 178, 16, 6
-	unknownsfx0x20 2, 162, 24, 6
-	unknownsfx0x20 2, 178, 16, 6
-	unknownsfx0x20 8, 193, 32, 6
+	squarenote 8, 245, 0, 6
+	squarenote 2, 210, 56, 6
+	squarenote 2, 194, 48, 6
+	squarenote 2, 194, 40, 6
+	squarenote 2, 178, 32, 6
+	squarenote 2, 178, 16, 6
+	squarenote 2, 162, 24, 6
+	squarenote 2, 178, 16, 6
+	squarenote 8, 193, 32, 6
 	endchannel
 
 
 SFX_Cry0C_3_Ch5:
 	dutycycle 68
-	unknownsfx0x20 12, 195, 192, 5
-	unknownsfx0x20 3, 177, 249, 5
-	unknownsfx0x20 2, 161, 241, 5
-	unknownsfx0x20 2, 161, 233, 5
-	unknownsfx0x20 2, 145, 225, 5
-	unknownsfx0x20 2, 145, 217, 5
-	unknownsfx0x20 2, 129, 209, 5
-	unknownsfx0x20 2, 145, 217, 5
-	unknownsfx0x20 8, 145, 225, 5
+	squarenote 12, 195, 192, 5
+	squarenote 3, 177, 249, 5
+	squarenote 2, 161, 241, 5
+	squarenote 2, 161, 233, 5
+	squarenote 2, 145, 225, 5
+	squarenote 2, 145, 217, 5
+	squarenote 2, 129, 209, 5
+	squarenote 2, 145, 217, 5
+	squarenote 8, 145, 225, 5
 
 
 SFX_Cry0C_3_Ch7:

--- a/audio/sfx/cry0d_1.asm
+++ b/audio/sfx/cry0d_1.asm
@@ -1,40 +1,40 @@
 SFX_Cry0D_1_Ch4:
 	dutycycle 136
-	unknownsfx0x20 5, 242, 80, 6
-	unknownsfx0x20 9, 209, 96, 6
-	unknownsfx0x20 5, 226, 18, 6
-	unknownsfx0x20 9, 193, 34, 6
-	unknownsfx0x20 5, 242, 16, 6
-	unknownsfx0x20 6, 209, 32, 6
+	squarenote 5, 242, 80, 6
+	squarenote 9, 209, 96, 6
+	squarenote 5, 226, 18, 6
+	squarenote 9, 193, 34, 6
+	squarenote 5, 242, 16, 6
+	squarenote 6, 209, 32, 6
 	loopchannel 2, SFX_Cry0D_1_Ch4
 	endchannel
 
 
 SFX_Cry0D_1_Ch5:
 	dutycycle 64
-	unknownsfx0x20 4, 8, 0, 0
-	unknownsfx0x20 5, 242, 81, 6
-	unknownsfx0x20 9, 209, 97, 6
-	unknownsfx0x20 5, 226, 20, 6
-	unknownsfx0x20 8, 193, 36, 6
-	unknownsfx0x20 5, 242, 17, 6
-	unknownsfx0x20 12, 209, 33, 6
-	unknownsfx0x20 5, 226, 20, 6
-	unknownsfx0x20 8, 193, 36, 6
-	unknownsfx0x20 5, 242, 17, 6
-	unknownsfx0x20 4, 209, 33, 6
+	squarenote 4, 8, 0, 0
+	squarenote 5, 242, 81, 6
+	squarenote 9, 209, 97, 6
+	squarenote 5, 226, 20, 6
+	squarenote 8, 193, 36, 6
+	squarenote 5, 242, 17, 6
+	squarenote 12, 209, 33, 6
+	squarenote 5, 226, 20, 6
+	squarenote 8, 193, 36, 6
+	squarenote 5, 242, 17, 6
+	squarenote 4, 209, 33, 6
 	endchannel
 
 
 SFX_Cry0D_1_Ch7:
-	unknownnoise0x20 6, 210, 28
-	unknownnoise0x20 9, 177, 44
-	unknownnoise0x20 8, 194, 44
-	unknownnoise0x20 9, 177, 60
-	unknownnoise0x20 6, 194, 44
-	unknownnoise0x20 9, 162, 60
-	unknownnoise0x20 7, 194, 44
-	unknownnoise0x20 5, 161, 60
-	unknownnoise0x20 9, 194, 44
-	unknownnoise0x20 4, 161, 60
+	noisenote 6, 210, 28
+	noisenote 9, 177, 44
+	noisenote 8, 194, 44
+	noisenote 9, 177, 60
+	noisenote 6, 194, 44
+	noisenote 9, 162, 60
+	noisenote 7, 194, 44
+	noisenote 5, 161, 60
+	noisenote 9, 194, 44
+	noisenote 4, 161, 60
 	endchannel

--- a/audio/sfx/cry0d_2.asm
+++ b/audio/sfx/cry0d_2.asm
@@ -1,40 +1,40 @@
 SFX_Cry0D_2_Ch4:
 	dutycycle 136
-	unknownsfx0x20 5, 242, 80, 6
-	unknownsfx0x20 9, 209, 96, 6
-	unknownsfx0x20 5, 226, 18, 6
-	unknownsfx0x20 9, 193, 34, 6
-	unknownsfx0x20 5, 242, 16, 6
-	unknownsfx0x20 6, 209, 32, 6
+	squarenote 5, 242, 80, 6
+	squarenote 9, 209, 96, 6
+	squarenote 5, 226, 18, 6
+	squarenote 9, 193, 34, 6
+	squarenote 5, 242, 16, 6
+	squarenote 6, 209, 32, 6
 	loopchannel 2, SFX_Cry0D_2_Ch4
 	endchannel
 
 
 SFX_Cry0D_2_Ch5:
 	dutycycle 64
-	unknownsfx0x20 4, 8, 0, 0
-	unknownsfx0x20 5, 242, 81, 6
-	unknownsfx0x20 9, 209, 97, 6
-	unknownsfx0x20 5, 226, 20, 6
-	unknownsfx0x20 8, 193, 36, 6
-	unknownsfx0x20 5, 242, 17, 6
-	unknownsfx0x20 12, 209, 33, 6
-	unknownsfx0x20 5, 226, 20, 6
-	unknownsfx0x20 8, 193, 36, 6
-	unknownsfx0x20 5, 242, 17, 6
-	unknownsfx0x20 4, 209, 33, 6
+	squarenote 4, 8, 0, 0
+	squarenote 5, 242, 81, 6
+	squarenote 9, 209, 97, 6
+	squarenote 5, 226, 20, 6
+	squarenote 8, 193, 36, 6
+	squarenote 5, 242, 17, 6
+	squarenote 12, 209, 33, 6
+	squarenote 5, 226, 20, 6
+	squarenote 8, 193, 36, 6
+	squarenote 5, 242, 17, 6
+	squarenote 4, 209, 33, 6
 	endchannel
 
 
 SFX_Cry0D_2_Ch7:
-	unknownnoise0x20 6, 210, 28
-	unknownnoise0x20 9, 177, 44
-	unknownnoise0x20 8, 194, 44
-	unknownnoise0x20 9, 177, 60
-	unknownnoise0x20 6, 194, 44
-	unknownnoise0x20 9, 162, 60
-	unknownnoise0x20 7, 194, 44
-	unknownnoise0x20 5, 161, 60
-	unknownnoise0x20 9, 194, 44
-	unknownnoise0x20 4, 161, 60
+	noisenote 6, 210, 28
+	noisenote 9, 177, 44
+	noisenote 8, 194, 44
+	noisenote 9, 177, 60
+	noisenote 6, 194, 44
+	noisenote 9, 162, 60
+	noisenote 7, 194, 44
+	noisenote 5, 161, 60
+	noisenote 9, 194, 44
+	noisenote 4, 161, 60
 	endchannel

--- a/audio/sfx/cry0d_3.asm
+++ b/audio/sfx/cry0d_3.asm
@@ -1,40 +1,40 @@
 SFX_Cry0D_3_Ch4:
 	dutycycle 136
-	unknownsfx0x20 5, 242, 80, 6
-	unknownsfx0x20 9, 209, 96, 6
-	unknownsfx0x20 5, 226, 18, 6
-	unknownsfx0x20 9, 193, 34, 6
-	unknownsfx0x20 5, 242, 16, 6
-	unknownsfx0x20 6, 209, 32, 6
+	squarenote 5, 242, 80, 6
+	squarenote 9, 209, 96, 6
+	squarenote 5, 226, 18, 6
+	squarenote 9, 193, 34, 6
+	squarenote 5, 242, 16, 6
+	squarenote 6, 209, 32, 6
 	loopchannel 2, SFX_Cry0D_3_Ch4
 	endchannel
 
 
 SFX_Cry0D_3_Ch5:
 	dutycycle 64
-	unknownsfx0x20 4, 8, 0, 0
-	unknownsfx0x20 5, 242, 81, 6
-	unknownsfx0x20 9, 209, 97, 6
-	unknownsfx0x20 5, 226, 20, 6
-	unknownsfx0x20 8, 193, 36, 6
-	unknownsfx0x20 5, 242, 17, 6
-	unknownsfx0x20 12, 209, 33, 6
-	unknownsfx0x20 5, 226, 20, 6
-	unknownsfx0x20 8, 193, 36, 6
-	unknownsfx0x20 5, 242, 17, 6
-	unknownsfx0x20 4, 209, 33, 6
+	squarenote 4, 8, 0, 0
+	squarenote 5, 242, 81, 6
+	squarenote 9, 209, 97, 6
+	squarenote 5, 226, 20, 6
+	squarenote 8, 193, 36, 6
+	squarenote 5, 242, 17, 6
+	squarenote 12, 209, 33, 6
+	squarenote 5, 226, 20, 6
+	squarenote 8, 193, 36, 6
+	squarenote 5, 242, 17, 6
+	squarenote 4, 209, 33, 6
 	endchannel
 
 
 SFX_Cry0D_3_Ch7:
-	unknownnoise0x20 6, 210, 28
-	unknownnoise0x20 9, 177, 44
-	unknownnoise0x20 8, 194, 44
-	unknownnoise0x20 9, 177, 60
-	unknownnoise0x20 6, 194, 44
-	unknownnoise0x20 9, 162, 60
-	unknownnoise0x20 7, 194, 44
-	unknownnoise0x20 5, 161, 60
-	unknownnoise0x20 9, 194, 44
-	unknownnoise0x20 4, 161, 60
+	noisenote 6, 210, 28
+	noisenote 9, 177, 44
+	noisenote 8, 194, 44
+	noisenote 9, 177, 60
+	noisenote 6, 194, 44
+	noisenote 9, 162, 60
+	noisenote 7, 194, 44
+	noisenote 5, 161, 60
+	noisenote 9, 194, 44
+	noisenote 4, 161, 60
 	endchannel

--- a/audio/sfx/cry0e_1.asm
+++ b/audio/sfx/cry0e_1.asm
@@ -1,23 +1,23 @@
 SFX_Cry0E_1_Ch4:
 	dutycycle 165
-	unknownsfx0x20 4, 225, 0, 7
-	unknownsfx0x20 4, 242, 128, 7
-	unknownsfx0x20 2, 146, 64, 7
-	unknownsfx0x20 8, 225, 0, 6
+	squarenote 4, 225, 0, 7
+	squarenote 4, 242, 128, 7
+	squarenote 2, 146, 64, 7
+	squarenote 8, 225, 0, 6
 	endchannel
 
 
 SFX_Cry0E_1_Ch5:
 	dutycycle 10
-	unknownsfx0x20 4, 177, 225, 6
-	unknownsfx0x20 3, 194, 225, 6
-	unknownsfx0x20 3, 98, 129, 6
-	unknownsfx0x20 8, 177, 225, 5
+	squarenote 4, 177, 225, 6
+	squarenote 3, 194, 225, 6
+	squarenote 3, 98, 129, 6
+	squarenote 8, 177, 225, 5
 	endchannel
 
 
 SFX_Cry0E_1_Ch7:
-	unknownnoise0x20 2, 97, 50
-	unknownnoise0x20 2, 97, 33
-	unknownnoise0x20 8, 97, 17
+	noisenote 2, 97, 50
+	noisenote 2, 97, 33
+	noisenote 8, 97, 17
 	endchannel

--- a/audio/sfx/cry0e_2.asm
+++ b/audio/sfx/cry0e_2.asm
@@ -1,23 +1,23 @@
 SFX_Cry0E_2_Ch4:
 	dutycycle 165
-	unknownsfx0x20 4, 225, 0, 7
-	unknownsfx0x20 4, 242, 128, 7
-	unknownsfx0x20 2, 146, 64, 7
-	unknownsfx0x20 8, 225, 0, 6
+	squarenote 4, 225, 0, 7
+	squarenote 4, 242, 128, 7
+	squarenote 2, 146, 64, 7
+	squarenote 8, 225, 0, 6
 	endchannel
 
 
 SFX_Cry0E_2_Ch5:
 	dutycycle 10
-	unknownsfx0x20 4, 177, 225, 6
-	unknownsfx0x20 3, 194, 225, 6
-	unknownsfx0x20 3, 98, 129, 6
-	unknownsfx0x20 8, 177, 225, 5
+	squarenote 4, 177, 225, 6
+	squarenote 3, 194, 225, 6
+	squarenote 3, 98, 129, 6
+	squarenote 8, 177, 225, 5
 	endchannel
 
 
 SFX_Cry0E_2_Ch7:
-	unknownnoise0x20 2, 97, 50
-	unknownnoise0x20 2, 97, 33
-	unknownnoise0x20 8, 97, 17
+	noisenote 2, 97, 50
+	noisenote 2, 97, 33
+	noisenote 8, 97, 17
 	endchannel

--- a/audio/sfx/cry0e_3.asm
+++ b/audio/sfx/cry0e_3.asm
@@ -1,23 +1,23 @@
 SFX_Cry0E_3_Ch4:
 	dutycycle 165
-	unknownsfx0x20 4, 225, 0, 7
-	unknownsfx0x20 4, 242, 128, 7
-	unknownsfx0x20 2, 146, 64, 7
-	unknownsfx0x20 8, 225, 0, 6
+	squarenote 4, 225, 0, 7
+	squarenote 4, 242, 128, 7
+	squarenote 2, 146, 64, 7
+	squarenote 8, 225, 0, 6
 	endchannel
 
 
 SFX_Cry0E_3_Ch5:
 	dutycycle 10
-	unknownsfx0x20 4, 177, 225, 6
-	unknownsfx0x20 3, 194, 225, 6
-	unknownsfx0x20 3, 98, 129, 6
-	unknownsfx0x20 8, 177, 225, 5
+	squarenote 4, 177, 225, 6
+	squarenote 3, 194, 225, 6
+	squarenote 3, 98, 129, 6
+	squarenote 8, 177, 225, 5
 	endchannel
 
 
 SFX_Cry0E_3_Ch7:
-	unknownnoise0x20 2, 97, 50
-	unknownnoise0x20 2, 97, 33
-	unknownnoise0x20 8, 97, 17
+	noisenote 2, 97, 50
+	noisenote 2, 97, 33
+	noisenote 8, 97, 17
 	endchannel

--- a/audio/sfx/cry0f_1.asm
+++ b/audio/sfx/cry0f_1.asm
@@ -1,29 +1,29 @@
 SFX_Cry0F_1_Ch4:
 	dutycycle 241
-	unknownsfx0x20 4, 247, 192, 7
-	unknownsfx0x20 12, 230, 194, 7
-	unknownsfx0x20 6, 181, 128, 6
-	unknownsfx0x20 4, 196, 112, 6
-	unknownsfx0x20 4, 181, 96, 6
-	unknownsfx0x20 8, 193, 64, 6
+	squarenote 4, 247, 192, 7
+	squarenote 12, 230, 194, 7
+	squarenote 6, 181, 128, 6
+	squarenote 4, 196, 112, 6
+	squarenote 4, 181, 96, 6
+	squarenote 8, 193, 64, 6
 	endchannel
 
 
 SFX_Cry0F_1_Ch5:
 	dutycycle 204
-	unknownsfx0x20 3, 199, 129, 7
-	unknownsfx0x20 12, 182, 128, 7
-	unknownsfx0x20 6, 165, 65, 6
-	unknownsfx0x20 4, 196, 50, 6
-	unknownsfx0x20 6, 181, 33, 6
-	unknownsfx0x20 8, 161, 2, 6
+	squarenote 3, 199, 129, 7
+	squarenote 12, 182, 128, 7
+	squarenote 6, 165, 65, 6
+	squarenote 4, 196, 50, 6
+	squarenote 6, 181, 33, 6
+	squarenote 8, 161, 2, 6
 	endchannel
 
 
 SFX_Cry0F_1_Ch7:
-	unknownnoise0x20 3, 228, 60
-	unknownnoise0x20 12, 214, 44
-	unknownnoise0x20 4, 228, 60
-	unknownnoise0x20 8, 183, 92
-	unknownnoise0x20 15, 194, 93
+	noisenote 3, 228, 60
+	noisenote 12, 214, 44
+	noisenote 4, 228, 60
+	noisenote 8, 183, 92
+	noisenote 15, 194, 93
 	endchannel

--- a/audio/sfx/cry0f_2.asm
+++ b/audio/sfx/cry0f_2.asm
@@ -1,29 +1,29 @@
 SFX_Cry0F_2_Ch4:
 	dutycycle 241
-	unknownsfx0x20 4, 247, 192, 7
-	unknownsfx0x20 12, 230, 194, 7
-	unknownsfx0x20 6, 181, 128, 6
-	unknownsfx0x20 4, 196, 112, 6
-	unknownsfx0x20 4, 181, 96, 6
-	unknownsfx0x20 8, 193, 64, 6
+	squarenote 4, 247, 192, 7
+	squarenote 12, 230, 194, 7
+	squarenote 6, 181, 128, 6
+	squarenote 4, 196, 112, 6
+	squarenote 4, 181, 96, 6
+	squarenote 8, 193, 64, 6
 	endchannel
 
 
 SFX_Cry0F_2_Ch5:
 	dutycycle 204
-	unknownsfx0x20 3, 199, 129, 7
-	unknownsfx0x20 12, 182, 128, 7
-	unknownsfx0x20 6, 165, 65, 6
-	unknownsfx0x20 4, 196, 50, 6
-	unknownsfx0x20 6, 181, 33, 6
-	unknownsfx0x20 8, 161, 2, 6
+	squarenote 3, 199, 129, 7
+	squarenote 12, 182, 128, 7
+	squarenote 6, 165, 65, 6
+	squarenote 4, 196, 50, 6
+	squarenote 6, 181, 33, 6
+	squarenote 8, 161, 2, 6
 	endchannel
 
 
 SFX_Cry0F_2_Ch7:
-	unknownnoise0x20 3, 228, 60
-	unknownnoise0x20 12, 214, 44
-	unknownnoise0x20 4, 228, 60
-	unknownnoise0x20 8, 183, 92
-	unknownnoise0x20 15, 194, 93
+	noisenote 3, 228, 60
+	noisenote 12, 214, 44
+	noisenote 4, 228, 60
+	noisenote 8, 183, 92
+	noisenote 15, 194, 93
 	endchannel

--- a/audio/sfx/cry0f_3.asm
+++ b/audio/sfx/cry0f_3.asm
@@ -1,29 +1,29 @@
 SFX_Cry0F_3_Ch4:
 	dutycycle 241
-	unknownsfx0x20 4, 247, 192, 7
-	unknownsfx0x20 12, 230, 194, 7
-	unknownsfx0x20 6, 181, 128, 6
-	unknownsfx0x20 4, 196, 112, 6
-	unknownsfx0x20 4, 181, 96, 6
-	unknownsfx0x20 8, 193, 64, 6
+	squarenote 4, 247, 192, 7
+	squarenote 12, 230, 194, 7
+	squarenote 6, 181, 128, 6
+	squarenote 4, 196, 112, 6
+	squarenote 4, 181, 96, 6
+	squarenote 8, 193, 64, 6
 	endchannel
 
 
 SFX_Cry0F_3_Ch5:
 	dutycycle 204
-	unknownsfx0x20 3, 199, 129, 7
-	unknownsfx0x20 12, 182, 128, 7
-	unknownsfx0x20 6, 165, 65, 6
-	unknownsfx0x20 4, 196, 50, 6
-	unknownsfx0x20 6, 181, 33, 6
-	unknownsfx0x20 8, 161, 2, 6
+	squarenote 3, 199, 129, 7
+	squarenote 12, 182, 128, 7
+	squarenote 6, 165, 65, 6
+	squarenote 4, 196, 50, 6
+	squarenote 6, 181, 33, 6
+	squarenote 8, 161, 2, 6
 	endchannel
 
 
 SFX_Cry0F_3_Ch7:
-	unknownnoise0x20 3, 228, 60
-	unknownnoise0x20 12, 214, 44
-	unknownnoise0x20 4, 228, 60
-	unknownnoise0x20 8, 183, 92
-	unknownnoise0x20 15, 194, 93
+	noisenote 3, 228, 60
+	noisenote 12, 214, 44
+	noisenote 4, 228, 60
+	noisenote 8, 183, 92
+	noisenote 15, 194, 93
 	endchannel

--- a/audio/sfx/cry10_1.asm
+++ b/audio/sfx/cry10_1.asm
@@ -1,31 +1,31 @@
 SFX_Cry10_1_Ch4:
 	dutycycle 201
-	unknownsfx0x20 8, 247, 128, 6
-	unknownsfx0x20 2, 247, 96, 6
-	unknownsfx0x20 1, 231, 64, 6
-	unknownsfx0x20 1, 231, 32, 6
-	unknownsfx0x20 15, 209, 0, 6
-	unknownsfx0x20 4, 199, 64, 7
-	unknownsfx0x20 4, 167, 48, 7
-	unknownsfx0x20 15, 145, 32, 7
+	squarenote 8, 247, 128, 6
+	squarenote 2, 247, 96, 6
+	squarenote 1, 231, 64, 6
+	squarenote 1, 231, 32, 6
+	squarenote 15, 209, 0, 6
+	squarenote 4, 199, 64, 7
+	squarenote 4, 167, 48, 7
+	squarenote 15, 145, 32, 7
 	endchannel
 
 
 SFX_Cry10_1_Ch5:
 	dutycycle 121
-	unknownsfx0x20 10, 231, 130, 6
-	unknownsfx0x20 2, 231, 98, 6
-	unknownsfx0x20 1, 215, 66, 6
-	unknownsfx0x20 1, 215, 34, 6
-	unknownsfx0x20 15, 193, 2, 6
-	unknownsfx0x20 4, 183, 66, 7
-	unknownsfx0x20 2, 151, 50, 7
-	unknownsfx0x20 15, 129, 34, 7
+	squarenote 10, 231, 130, 6
+	squarenote 2, 231, 98, 6
+	squarenote 1, 215, 66, 6
+	squarenote 1, 215, 34, 6
+	squarenote 15, 193, 2, 6
+	squarenote 4, 183, 66, 7
+	squarenote 2, 151, 50, 7
+	squarenote 15, 129, 34, 7
 	endchannel
 
 
 SFX_Cry10_1_Ch7:
-	unknownnoise0x20 4, 116, 33
-	unknownnoise0x20 4, 116, 16
-	unknownnoise0x20 4, 113, 32
+	noisenote 4, 116, 33
+	noisenote 4, 116, 16
+	noisenote 4, 113, 32
 	endchannel

--- a/audio/sfx/cry10_2.asm
+++ b/audio/sfx/cry10_2.asm
@@ -1,31 +1,31 @@
 SFX_Cry10_2_Ch4:
 	dutycycle 201
-	unknownsfx0x20 8, 247, 128, 6
-	unknownsfx0x20 2, 247, 96, 6
-	unknownsfx0x20 1, 231, 64, 6
-	unknownsfx0x20 1, 231, 32, 6
-	unknownsfx0x20 15, 209, 0, 6
-	unknownsfx0x20 4, 199, 64, 7
-	unknownsfx0x20 4, 167, 48, 7
-	unknownsfx0x20 15, 145, 32, 7
+	squarenote 8, 247, 128, 6
+	squarenote 2, 247, 96, 6
+	squarenote 1, 231, 64, 6
+	squarenote 1, 231, 32, 6
+	squarenote 15, 209, 0, 6
+	squarenote 4, 199, 64, 7
+	squarenote 4, 167, 48, 7
+	squarenote 15, 145, 32, 7
 	endchannel
 
 
 SFX_Cry10_2_Ch5:
 	dutycycle 121
-	unknownsfx0x20 10, 231, 130, 6
-	unknownsfx0x20 2, 231, 98, 6
-	unknownsfx0x20 1, 215, 66, 6
-	unknownsfx0x20 1, 215, 34, 6
-	unknownsfx0x20 15, 193, 2, 6
-	unknownsfx0x20 4, 183, 66, 7
-	unknownsfx0x20 2, 151, 50, 7
-	unknownsfx0x20 15, 129, 34, 7
+	squarenote 10, 231, 130, 6
+	squarenote 2, 231, 98, 6
+	squarenote 1, 215, 66, 6
+	squarenote 1, 215, 34, 6
+	squarenote 15, 193, 2, 6
+	squarenote 4, 183, 66, 7
+	squarenote 2, 151, 50, 7
+	squarenote 15, 129, 34, 7
 	endchannel
 
 
 SFX_Cry10_2_Ch7:
-	unknownnoise0x20 4, 116, 33
-	unknownnoise0x20 4, 116, 16
-	unknownnoise0x20 4, 113, 32
+	noisenote 4, 116, 33
+	noisenote 4, 116, 16
+	noisenote 4, 113, 32
 	endchannel

--- a/audio/sfx/cry10_3.asm
+++ b/audio/sfx/cry10_3.asm
@@ -1,31 +1,31 @@
 SFX_Cry10_3_Ch4:
 	dutycycle 201
-	unknownsfx0x20 8, 247, 128, 6
-	unknownsfx0x20 2, 247, 96, 6
-	unknownsfx0x20 1, 231, 64, 6
-	unknownsfx0x20 1, 231, 32, 6
-	unknownsfx0x20 15, 209, 0, 6
-	unknownsfx0x20 4, 199, 64, 7
-	unknownsfx0x20 4, 167, 48, 7
-	unknownsfx0x20 15, 145, 32, 7
+	squarenote 8, 247, 128, 6
+	squarenote 2, 247, 96, 6
+	squarenote 1, 231, 64, 6
+	squarenote 1, 231, 32, 6
+	squarenote 15, 209, 0, 6
+	squarenote 4, 199, 64, 7
+	squarenote 4, 167, 48, 7
+	squarenote 15, 145, 32, 7
 	endchannel
 
 
 SFX_Cry10_3_Ch5:
 	dutycycle 121
-	unknownsfx0x20 10, 231, 130, 6
-	unknownsfx0x20 2, 231, 98, 6
-	unknownsfx0x20 1, 215, 66, 6
-	unknownsfx0x20 1, 215, 34, 6
-	unknownsfx0x20 15, 193, 2, 6
-	unknownsfx0x20 4, 183, 66, 7
-	unknownsfx0x20 2, 151, 50, 7
-	unknownsfx0x20 15, 129, 34, 7
+	squarenote 10, 231, 130, 6
+	squarenote 2, 231, 98, 6
+	squarenote 1, 215, 66, 6
+	squarenote 1, 215, 34, 6
+	squarenote 15, 193, 2, 6
+	squarenote 4, 183, 66, 7
+	squarenote 2, 151, 50, 7
+	squarenote 15, 129, 34, 7
 	endchannel
 
 
 SFX_Cry10_3_Ch7:
-	unknownnoise0x20 4, 116, 33
-	unknownnoise0x20 4, 116, 16
-	unknownnoise0x20 4, 113, 32
+	noisenote 4, 116, 33
+	noisenote 4, 116, 16
+	noisenote 4, 113, 32
 	endchannel

--- a/audio/sfx/cry11_1.asm
+++ b/audio/sfx/cry11_1.asm
@@ -1,34 +1,34 @@
 SFX_Cry11_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 247, 160, 7
-	unknownsfx0x20 8, 230, 164, 7
-	unknownsfx0x20 4, 214, 160, 7
-	unknownsfx0x20 15, 211, 32, 7
-	unknownsfx0x20 8, 195, 35, 7
-	unknownsfx0x20 2, 194, 40, 7
-	unknownsfx0x20 8, 177, 48, 7
+	squarenote 6, 247, 160, 7
+	squarenote 8, 230, 164, 7
+	squarenote 4, 214, 160, 7
+	squarenote 15, 211, 32, 7
+	squarenote 8, 195, 35, 7
+	squarenote 2, 194, 40, 7
+	squarenote 8, 177, 48, 7
 	endchannel
 
 
 SFX_Cry11_1_Ch5:
 	dutycycle 10
-	unknownsfx0x20 4, 8, 0, 0
-	unknownsfx0x20 6, 167, 65, 7
-	unknownsfx0x20 8, 134, 67, 7
-	unknownsfx0x20 4, 118, 65, 7
-	unknownsfx0x20 13, 131, 194, 6
-	unknownsfx0x20 7, 115, 193, 6
-	unknownsfx0x20 3, 130, 204, 6
-	unknownsfx0x20 8, 113, 216, 6
+	squarenote 4, 8, 0, 0
+	squarenote 6, 167, 65, 7
+	squarenote 8, 134, 67, 7
+	squarenote 4, 118, 65, 7
+	squarenote 13, 131, 194, 6
+	squarenote 7, 115, 193, 6
+	squarenote 3, 130, 204, 6
+	squarenote 8, 113, 216, 6
 	endchannel
 
 
 SFX_Cry11_1_Ch7:
-	unknownnoise0x20 2, 242, 76
-	unknownnoise0x20 6, 230, 58
-	unknownnoise0x20 4, 215, 58
-	unknownnoise0x20 6, 214, 44
-	unknownnoise0x20 8, 229, 60
-	unknownnoise0x20 12, 210, 61
-	unknownnoise0x20 8, 209, 44
+	noisenote 2, 242, 76
+	noisenote 6, 230, 58
+	noisenote 4, 215, 58
+	noisenote 6, 214, 44
+	noisenote 8, 229, 60
+	noisenote 12, 210, 61
+	noisenote 8, 209, 44
 	endchannel

--- a/audio/sfx/cry11_2.asm
+++ b/audio/sfx/cry11_2.asm
@@ -1,34 +1,34 @@
 SFX_Cry11_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 247, 160, 7
-	unknownsfx0x20 8, 230, 164, 7
-	unknownsfx0x20 4, 214, 160, 7
-	unknownsfx0x20 15, 211, 32, 7
-	unknownsfx0x20 8, 195, 35, 7
-	unknownsfx0x20 2, 194, 40, 7
-	unknownsfx0x20 8, 177, 48, 7
+	squarenote 6, 247, 160, 7
+	squarenote 8, 230, 164, 7
+	squarenote 4, 214, 160, 7
+	squarenote 15, 211, 32, 7
+	squarenote 8, 195, 35, 7
+	squarenote 2, 194, 40, 7
+	squarenote 8, 177, 48, 7
 	endchannel
 
 
 SFX_Cry11_2_Ch5:
 	dutycycle 10
-	unknownsfx0x20 4, 8, 0, 0
-	unknownsfx0x20 6, 167, 65, 7
-	unknownsfx0x20 8, 134, 67, 7
-	unknownsfx0x20 4, 118, 65, 7
-	unknownsfx0x20 13, 131, 194, 6
-	unknownsfx0x20 7, 115, 193, 6
-	unknownsfx0x20 3, 130, 204, 6
-	unknownsfx0x20 8, 113, 216, 6
+	squarenote 4, 8, 0, 0
+	squarenote 6, 167, 65, 7
+	squarenote 8, 134, 67, 7
+	squarenote 4, 118, 65, 7
+	squarenote 13, 131, 194, 6
+	squarenote 7, 115, 193, 6
+	squarenote 3, 130, 204, 6
+	squarenote 8, 113, 216, 6
 	endchannel
 
 
 SFX_Cry11_2_Ch7:
-	unknownnoise0x20 2, 242, 76
-	unknownnoise0x20 6, 230, 58
-	unknownnoise0x20 4, 215, 58
-	unknownnoise0x20 6, 214, 44
-	unknownnoise0x20 8, 229, 60
-	unknownnoise0x20 12, 210, 61
-	unknownnoise0x20 8, 209, 44
+	noisenote 2, 242, 76
+	noisenote 6, 230, 58
+	noisenote 4, 215, 58
+	noisenote 6, 214, 44
+	noisenote 8, 229, 60
+	noisenote 12, 210, 61
+	noisenote 8, 209, 44
 	endchannel

--- a/audio/sfx/cry11_3.asm
+++ b/audio/sfx/cry11_3.asm
@@ -1,34 +1,34 @@
 SFX_Cry11_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 247, 160, 7
-	unknownsfx0x20 8, 230, 164, 7
-	unknownsfx0x20 4, 214, 160, 7
-	unknownsfx0x20 15, 211, 32, 7
-	unknownsfx0x20 8, 195, 35, 7
-	unknownsfx0x20 2, 194, 40, 7
-	unknownsfx0x20 8, 177, 48, 7
+	squarenote 6, 247, 160, 7
+	squarenote 8, 230, 164, 7
+	squarenote 4, 214, 160, 7
+	squarenote 15, 211, 32, 7
+	squarenote 8, 195, 35, 7
+	squarenote 2, 194, 40, 7
+	squarenote 8, 177, 48, 7
 	endchannel
 
 
 SFX_Cry11_3_Ch5:
 	dutycycle 10
-	unknownsfx0x20 4, 8, 0, 0
-	unknownsfx0x20 6, 167, 65, 7
-	unknownsfx0x20 8, 134, 67, 7
-	unknownsfx0x20 4, 118, 65, 7
-	unknownsfx0x20 13, 131, 194, 6
-	unknownsfx0x20 7, 115, 193, 6
-	unknownsfx0x20 3, 130, 204, 6
-	unknownsfx0x20 8, 113, 216, 6
+	squarenote 4, 8, 0, 0
+	squarenote 6, 167, 65, 7
+	squarenote 8, 134, 67, 7
+	squarenote 4, 118, 65, 7
+	squarenote 13, 131, 194, 6
+	squarenote 7, 115, 193, 6
+	squarenote 3, 130, 204, 6
+	squarenote 8, 113, 216, 6
 	endchannel
 
 
 SFX_Cry11_3_Ch7:
-	unknownnoise0x20 2, 242, 76
-	unknownnoise0x20 6, 230, 58
-	unknownnoise0x20 4, 215, 58
-	unknownnoise0x20 6, 214, 44
-	unknownnoise0x20 8, 229, 60
-	unknownnoise0x20 12, 210, 61
-	unknownnoise0x20 8, 209, 44
+	noisenote 2, 242, 76
+	noisenote 6, 230, 58
+	noisenote 4, 215, 58
+	noisenote 6, 214, 44
+	noisenote 8, 229, 60
+	noisenote 12, 210, 61
+	noisenote 8, 209, 44
 	endchannel

--- a/audio/sfx/cry12_1.asm
+++ b/audio/sfx/cry12_1.asm
@@ -1,24 +1,24 @@
 SFX_Cry12_1_Ch4:
 	dutycycle 165
-	unknownsfx0x20 12, 242, 64, 4
-	unknownsfx0x20 15, 227, 160, 4
-	unknownsfx0x20 4, 210, 144, 4
-	unknownsfx0x20 8, 209, 128, 4
+	squarenote 12, 242, 64, 4
+	squarenote 15, 227, 160, 4
+	squarenote 4, 210, 144, 4
+	squarenote 8, 209, 128, 4
 	endchannel
 
 
 SFX_Cry12_1_Ch5:
 	dutycycle 238
-	unknownsfx0x20 11, 210, 56, 4
-	unknownsfx0x20 14, 198, 152, 4
-	unknownsfx0x20 3, 178, 136, 4
-	unknownsfx0x20 8, 177, 120, 4
+	squarenote 11, 210, 56, 4
+	squarenote 14, 198, 152, 4
+	squarenote 3, 178, 136, 4
+	squarenote 8, 177, 120, 4
 	endchannel
 
 
 SFX_Cry12_1_Ch7:
-	unknownnoise0x20 10, 230, 108
-	unknownnoise0x20 15, 210, 92
-	unknownnoise0x20 3, 194, 108
-	unknownnoise0x20 8, 209, 92
+	noisenote 10, 230, 108
+	noisenote 15, 210, 92
+	noisenote 3, 194, 108
+	noisenote 8, 209, 92
 	endchannel

--- a/audio/sfx/cry12_2.asm
+++ b/audio/sfx/cry12_2.asm
@@ -1,24 +1,24 @@
 SFX_Cry12_2_Ch4:
 	dutycycle 165
-	unknownsfx0x20 12, 242, 64, 4
-	unknownsfx0x20 15, 227, 160, 4
-	unknownsfx0x20 4, 210, 144, 4
-	unknownsfx0x20 8, 209, 128, 4
+	squarenote 12, 242, 64, 4
+	squarenote 15, 227, 160, 4
+	squarenote 4, 210, 144, 4
+	squarenote 8, 209, 128, 4
 	endchannel
 
 
 SFX_Cry12_2_Ch5:
 	dutycycle 238
-	unknownsfx0x20 11, 210, 56, 4
-	unknownsfx0x20 14, 198, 152, 4
-	unknownsfx0x20 3, 178, 136, 4
-	unknownsfx0x20 8, 177, 120, 4
+	squarenote 11, 210, 56, 4
+	squarenote 14, 198, 152, 4
+	squarenote 3, 178, 136, 4
+	squarenote 8, 177, 120, 4
 	endchannel
 
 
 SFX_Cry12_2_Ch7:
-	unknownnoise0x20 10, 230, 108
-	unknownnoise0x20 15, 210, 92
-	unknownnoise0x20 3, 194, 108
-	unknownnoise0x20 8, 209, 92
+	noisenote 10, 230, 108
+	noisenote 15, 210, 92
+	noisenote 3, 194, 108
+	noisenote 8, 209, 92
 	endchannel

--- a/audio/sfx/cry12_3.asm
+++ b/audio/sfx/cry12_3.asm
@@ -1,24 +1,24 @@
 SFX_Cry12_3_Ch4:
 	dutycycle 165
-	unknownsfx0x20 12, 242, 64, 4
-	unknownsfx0x20 15, 227, 160, 4
-	unknownsfx0x20 4, 210, 144, 4
-	unknownsfx0x20 8, 209, 128, 4
+	squarenote 12, 242, 64, 4
+	squarenote 15, 227, 160, 4
+	squarenote 4, 210, 144, 4
+	squarenote 8, 209, 128, 4
 	endchannel
 
 
 SFX_Cry12_3_Ch5:
 	dutycycle 238
-	unknownsfx0x20 11, 210, 56, 4
-	unknownsfx0x20 14, 198, 152, 4
-	unknownsfx0x20 3, 178, 136, 4
-	unknownsfx0x20 8, 177, 120, 4
+	squarenote 11, 210, 56, 4
+	squarenote 14, 198, 152, 4
+	squarenote 3, 178, 136, 4
+	squarenote 8, 177, 120, 4
 	endchannel
 
 
 SFX_Cry12_3_Ch7:
-	unknownnoise0x20 10, 230, 108
-	unknownnoise0x20 15, 210, 92
-	unknownnoise0x20 3, 194, 108
-	unknownnoise0x20 8, 209, 92
+	noisenote 10, 230, 108
+	noisenote 15, 210, 92
+	noisenote 3, 194, 108
+	noisenote 8, 209, 92
 	endchannel

--- a/audio/sfx/cry13_1.asm
+++ b/audio/sfx/cry13_1.asm
@@ -1,30 +1,30 @@
 SFX_Cry13_1_Ch4:
 	dutycycle 51
-	unknownsfx0x20 15, 246, 192, 5
-	unknownsfx0x20 8, 227, 188, 5
-	unknownsfx0x20 6, 210, 208, 5
-	unknownsfx0x20 6, 178, 224, 5
-	unknownsfx0x20 6, 194, 240, 5
-	unknownsfx0x20 8, 177, 0, 6
+	squarenote 15, 246, 192, 5
+	squarenote 8, 227, 188, 5
+	squarenote 6, 210, 208, 5
+	squarenote 6, 178, 224, 5
+	squarenote 6, 194, 240, 5
+	squarenote 8, 177, 0, 6
 	endchannel
 
 
 SFX_Cry13_1_Ch5:
 	dutycycle 153
-	unknownsfx0x20 14, 198, 177, 4
-	unknownsfx0x20 7, 195, 173, 4
-	unknownsfx0x20 5, 178, 193, 4
-	unknownsfx0x20 8, 146, 209, 4
-	unknownsfx0x20 6, 162, 225, 4
-	unknownsfx0x20 8, 145, 241, 4
+	squarenote 14, 198, 177, 4
+	squarenote 7, 195, 173, 4
+	squarenote 5, 178, 193, 4
+	squarenote 8, 146, 209, 4
+	squarenote 6, 162, 225, 4
+	squarenote 8, 145, 241, 4
 	endchannel
 
 
 SFX_Cry13_1_Ch7:
-	unknownnoise0x20 10, 230, 92
-	unknownnoise0x20 10, 214, 108
-	unknownnoise0x20 4, 194, 76
-	unknownnoise0x20 6, 211, 92
-	unknownnoise0x20 8, 179, 76
-	unknownnoise0x20 8, 161, 92
+	noisenote 10, 230, 92
+	noisenote 10, 214, 108
+	noisenote 4, 194, 76
+	noisenote 6, 211, 92
+	noisenote 8, 179, 76
+	noisenote 8, 161, 92
 	endchannel

--- a/audio/sfx/cry13_2.asm
+++ b/audio/sfx/cry13_2.asm
@@ -1,30 +1,30 @@
 SFX_Cry13_2_Ch4:
 	dutycycle 51
-	unknownsfx0x20 15, 246, 192, 5
-	unknownsfx0x20 8, 227, 188, 5
-	unknownsfx0x20 6, 210, 208, 5
-	unknownsfx0x20 6, 178, 224, 5
-	unknownsfx0x20 6, 194, 240, 5
-	unknownsfx0x20 8, 177, 0, 6
+	squarenote 15, 246, 192, 5
+	squarenote 8, 227, 188, 5
+	squarenote 6, 210, 208, 5
+	squarenote 6, 178, 224, 5
+	squarenote 6, 194, 240, 5
+	squarenote 8, 177, 0, 6
 	endchannel
 
 
 SFX_Cry13_2_Ch5:
 	dutycycle 153
-	unknownsfx0x20 14, 198, 177, 4
-	unknownsfx0x20 7, 195, 173, 4
-	unknownsfx0x20 5, 178, 193, 4
-	unknownsfx0x20 8, 146, 209, 4
-	unknownsfx0x20 6, 162, 225, 4
-	unknownsfx0x20 8, 145, 241, 4
+	squarenote 14, 198, 177, 4
+	squarenote 7, 195, 173, 4
+	squarenote 5, 178, 193, 4
+	squarenote 8, 146, 209, 4
+	squarenote 6, 162, 225, 4
+	squarenote 8, 145, 241, 4
 	endchannel
 
 
 SFX_Cry13_2_Ch7:
-	unknownnoise0x20 10, 230, 92
-	unknownnoise0x20 10, 214, 108
-	unknownnoise0x20 4, 194, 76
-	unknownnoise0x20 6, 211, 92
-	unknownnoise0x20 8, 179, 76
-	unknownnoise0x20 8, 161, 92
+	noisenote 10, 230, 92
+	noisenote 10, 214, 108
+	noisenote 4, 194, 76
+	noisenote 6, 211, 92
+	noisenote 8, 179, 76
+	noisenote 8, 161, 92
 	endchannel

--- a/audio/sfx/cry13_3.asm
+++ b/audio/sfx/cry13_3.asm
@@ -1,30 +1,30 @@
 SFX_Cry13_3_Ch4:
 	dutycycle 51
-	unknownsfx0x20 15, 246, 192, 5
-	unknownsfx0x20 8, 227, 188, 5
-	unknownsfx0x20 6, 210, 208, 5
-	unknownsfx0x20 6, 178, 224, 5
-	unknownsfx0x20 6, 194, 240, 5
-	unknownsfx0x20 8, 177, 0, 6
+	squarenote 15, 246, 192, 5
+	squarenote 8, 227, 188, 5
+	squarenote 6, 210, 208, 5
+	squarenote 6, 178, 224, 5
+	squarenote 6, 194, 240, 5
+	squarenote 8, 177, 0, 6
 	endchannel
 
 
 SFX_Cry13_3_Ch5:
 	dutycycle 153
-	unknownsfx0x20 14, 198, 177, 4
-	unknownsfx0x20 7, 195, 173, 4
-	unknownsfx0x20 5, 178, 193, 4
-	unknownsfx0x20 8, 146, 209, 4
-	unknownsfx0x20 6, 162, 225, 4
-	unknownsfx0x20 8, 145, 241, 4
+	squarenote 14, 198, 177, 4
+	squarenote 7, 195, 173, 4
+	squarenote 5, 178, 193, 4
+	squarenote 8, 146, 209, 4
+	squarenote 6, 162, 225, 4
+	squarenote 8, 145, 241, 4
 	endchannel
 
 
 SFX_Cry13_3_Ch7:
-	unknownnoise0x20 10, 230, 92
-	unknownnoise0x20 10, 214, 108
-	unknownnoise0x20 4, 194, 76
-	unknownnoise0x20 6, 211, 92
-	unknownnoise0x20 8, 179, 76
-	unknownnoise0x20 8, 161, 92
+	noisenote 10, 230, 92
+	noisenote 10, 214, 108
+	noisenote 4, 194, 76
+	noisenote 6, 211, 92
+	noisenote 8, 179, 76
+	noisenote 8, 161, 92
 	endchannel

--- a/audio/sfx/cry14_1.asm
+++ b/audio/sfx/cry14_1.asm
@@ -1,21 +1,21 @@
 SFX_Cry14_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 8, 228, 144, 7
-	unknownsfx0x20 15, 245, 192, 7
-	unknownsfx0x20 8, 209, 216, 7
+	squarenote 8, 228, 144, 7
+	squarenote 15, 245, 192, 7
+	squarenote 8, 209, 216, 7
 	endchannel
 
 
 SFX_Cry14_1_Ch5:
 	dutycycle 165
-	unknownsfx0x20 10, 196, 113, 7
-	unknownsfx0x20 15, 182, 162, 7
-	unknownsfx0x20 8, 161, 183, 7
+	squarenote 10, 196, 113, 7
+	squarenote 15, 182, 162, 7
+	squarenote 8, 161, 183, 7
 	endchannel
 
 
 SFX_Cry14_1_Ch7:
-	unknownnoise0x20 8, 228, 76
-	unknownnoise0x20 14, 196, 60
-	unknownnoise0x20 8, 209, 44
+	noisenote 8, 228, 76
+	noisenote 14, 196, 60
+	noisenote 8, 209, 44
 	endchannel

--- a/audio/sfx/cry14_2.asm
+++ b/audio/sfx/cry14_2.asm
@@ -1,21 +1,21 @@
 SFX_Cry14_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 8, 228, 144, 7
-	unknownsfx0x20 15, 245, 192, 7
-	unknownsfx0x20 8, 209, 216, 7
+	squarenote 8, 228, 144, 7
+	squarenote 15, 245, 192, 7
+	squarenote 8, 209, 216, 7
 	endchannel
 
 
 SFX_Cry14_2_Ch5:
 	dutycycle 165
-	unknownsfx0x20 10, 196, 113, 7
-	unknownsfx0x20 15, 182, 162, 7
-	unknownsfx0x20 8, 161, 183, 7
+	squarenote 10, 196, 113, 7
+	squarenote 15, 182, 162, 7
+	squarenote 8, 161, 183, 7
 	endchannel
 
 
 SFX_Cry14_2_Ch7:
-	unknownnoise0x20 8, 228, 76
-	unknownnoise0x20 14, 196, 60
-	unknownnoise0x20 8, 209, 44
+	noisenote 8, 228, 76
+	noisenote 14, 196, 60
+	noisenote 8, 209, 44
 	endchannel

--- a/audio/sfx/cry14_3.asm
+++ b/audio/sfx/cry14_3.asm
@@ -1,21 +1,21 @@
 SFX_Cry14_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 8, 228, 144, 7
-	unknownsfx0x20 15, 245, 192, 7
-	unknownsfx0x20 8, 209, 216, 7
+	squarenote 8, 228, 144, 7
+	squarenote 15, 245, 192, 7
+	squarenote 8, 209, 216, 7
 	endchannel
 
 
 SFX_Cry14_3_Ch5:
 	dutycycle 165
-	unknownsfx0x20 10, 196, 113, 7
-	unknownsfx0x20 15, 182, 162, 7
-	unknownsfx0x20 8, 161, 183, 7
+	squarenote 10, 196, 113, 7
+	squarenote 15, 182, 162, 7
+	squarenote 8, 161, 183, 7
 	endchannel
 
 
 SFX_Cry14_3_Ch7:
-	unknownnoise0x20 8, 228, 76
-	unknownnoise0x20 14, 196, 60
-	unknownnoise0x20 8, 209, 44
+	noisenote 8, 228, 76
+	noisenote 14, 196, 60
+	noisenote 8, 209, 44
 	endchannel

--- a/audio/sfx/cry15_1.asm
+++ b/audio/sfx/cry15_1.asm
@@ -1,30 +1,30 @@
 SFX_Cry15_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 243, 128, 7
-	unknownsfx0x20 15, 231, 0, 7
-	unknownsfx0x20 8, 211, 16, 7
-	unknownsfx0x20 4, 194, 0, 7
-	unknownsfx0x20 4, 210, 240, 6
-	unknownsfx0x20 8, 193, 224, 6
+	squarenote 4, 243, 128, 7
+	squarenote 15, 231, 0, 7
+	squarenote 8, 211, 16, 7
+	squarenote 4, 194, 0, 7
+	squarenote 4, 210, 240, 6
+	squarenote 8, 193, 224, 6
 	endchannel
 
 
 SFX_Cry15_1_Ch5:
 	dutycycle 90
-	unknownsfx0x20 6, 195, 1, 7
-	unknownsfx0x20 14, 183, 129, 6
-	unknownsfx0x20 7, 179, 146, 6
-	unknownsfx0x20 3, 162, 129, 6
-	unknownsfx0x20 4, 178, 114, 6
-	unknownsfx0x20 8, 161, 97, 6
+	squarenote 6, 195, 1, 7
+	squarenote 14, 183, 129, 6
+	squarenote 7, 179, 146, 6
+	squarenote 3, 162, 129, 6
+	squarenote 4, 178, 114, 6
+	squarenote 8, 161, 97, 6
 	endchannel
 
 
 SFX_Cry15_1_Ch7:
-	unknownnoise0x20 6, 227, 92
-	unknownnoise0x20 14, 214, 76
-	unknownnoise0x20 6, 198, 60
-	unknownnoise0x20 3, 179, 76
-	unknownnoise0x20 3, 162, 92
-	unknownnoise0x20 8, 177, 108
+	noisenote 6, 227, 92
+	noisenote 14, 214, 76
+	noisenote 6, 198, 60
+	noisenote 3, 179, 76
+	noisenote 3, 162, 92
+	noisenote 8, 177, 108
 	endchannel

--- a/audio/sfx/cry15_2.asm
+++ b/audio/sfx/cry15_2.asm
@@ -1,30 +1,30 @@
 SFX_Cry15_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 243, 128, 7
-	unknownsfx0x20 15, 231, 0, 7
-	unknownsfx0x20 8, 211, 16, 7
-	unknownsfx0x20 4, 194, 0, 7
-	unknownsfx0x20 4, 210, 240, 6
-	unknownsfx0x20 8, 193, 224, 6
+	squarenote 4, 243, 128, 7
+	squarenote 15, 231, 0, 7
+	squarenote 8, 211, 16, 7
+	squarenote 4, 194, 0, 7
+	squarenote 4, 210, 240, 6
+	squarenote 8, 193, 224, 6
 	endchannel
 
 
 SFX_Cry15_2_Ch5:
 	dutycycle 90
-	unknownsfx0x20 6, 195, 1, 7
-	unknownsfx0x20 14, 183, 129, 6
-	unknownsfx0x20 7, 179, 146, 6
-	unknownsfx0x20 3, 162, 129, 6
-	unknownsfx0x20 4, 178, 114, 6
-	unknownsfx0x20 8, 161, 97, 6
+	squarenote 6, 195, 1, 7
+	squarenote 14, 183, 129, 6
+	squarenote 7, 179, 146, 6
+	squarenote 3, 162, 129, 6
+	squarenote 4, 178, 114, 6
+	squarenote 8, 161, 97, 6
 	endchannel
 
 
 SFX_Cry15_2_Ch7:
-	unknownnoise0x20 6, 227, 92
-	unknownnoise0x20 14, 214, 76
-	unknownnoise0x20 6, 198, 60
-	unknownnoise0x20 3, 179, 76
-	unknownnoise0x20 3, 162, 92
-	unknownnoise0x20 8, 177, 108
+	noisenote 6, 227, 92
+	noisenote 14, 214, 76
+	noisenote 6, 198, 60
+	noisenote 3, 179, 76
+	noisenote 3, 162, 92
+	noisenote 8, 177, 108
 	endchannel

--- a/audio/sfx/cry15_3.asm
+++ b/audio/sfx/cry15_3.asm
@@ -1,30 +1,30 @@
 SFX_Cry15_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 4, 243, 128, 7
-	unknownsfx0x20 15, 231, 0, 7
-	unknownsfx0x20 8, 211, 16, 7
-	unknownsfx0x20 4, 194, 0, 7
-	unknownsfx0x20 4, 210, 240, 6
-	unknownsfx0x20 8, 193, 224, 6
+	squarenote 4, 243, 128, 7
+	squarenote 15, 231, 0, 7
+	squarenote 8, 211, 16, 7
+	squarenote 4, 194, 0, 7
+	squarenote 4, 210, 240, 6
+	squarenote 8, 193, 224, 6
 	endchannel
 
 
 SFX_Cry15_3_Ch5:
 	dutycycle 90
-	unknownsfx0x20 6, 195, 1, 7
-	unknownsfx0x20 14, 183, 129, 6
-	unknownsfx0x20 7, 179, 146, 6
-	unknownsfx0x20 3, 162, 129, 6
-	unknownsfx0x20 4, 178, 114, 6
-	unknownsfx0x20 8, 161, 97, 6
+	squarenote 6, 195, 1, 7
+	squarenote 14, 183, 129, 6
+	squarenote 7, 179, 146, 6
+	squarenote 3, 162, 129, 6
+	squarenote 4, 178, 114, 6
+	squarenote 8, 161, 97, 6
 	endchannel
 
 
 SFX_Cry15_3_Ch7:
-	unknownnoise0x20 6, 227, 92
-	unknownnoise0x20 14, 214, 76
-	unknownnoise0x20 6, 198, 60
-	unknownnoise0x20 3, 179, 76
-	unknownnoise0x20 3, 162, 92
-	unknownnoise0x20 8, 177, 108
+	noisenote 6, 227, 92
+	noisenote 14, 214, 76
+	noisenote 6, 198, 60
+	noisenote 3, 179, 76
+	noisenote 3, 162, 92
+	noisenote 8, 177, 108
 	endchannel

--- a/audio/sfx/cry16_1.asm
+++ b/audio/sfx/cry16_1.asm
@@ -1,21 +1,21 @@
 SFX_Cry16_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 215, 128, 7
-	unknownsfx0x20 4, 230, 160, 7
-	unknownsfx0x20 15, 210, 64, 7
+	squarenote 15, 215, 128, 7
+	squarenote 4, 230, 160, 7
+	squarenote 15, 210, 64, 7
 	endchannel
 
 
 SFX_Cry16_1_Ch5:
 	dutycycle 90
-	unknownsfx0x20 15, 199, 83, 7
-	unknownsfx0x20 5, 182, 114, 7
-	unknownsfx0x20 15, 194, 17, 7
+	squarenote 15, 199, 83, 7
+	squarenote 5, 182, 114, 7
+	squarenote 15, 194, 17, 7
 	endchannel
 
 
 SFX_Cry16_1_Ch7:
-	unknownnoise0x20 13, 246, 76
-	unknownnoise0x20 4, 230, 60
-	unknownnoise0x20 15, 242, 76
+	noisenote 13, 246, 76
+	noisenote 4, 230, 60
+	noisenote 15, 242, 76
 	endchannel

--- a/audio/sfx/cry16_2.asm
+++ b/audio/sfx/cry16_2.asm
@@ -1,21 +1,21 @@
 SFX_Cry16_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 215, 128, 7
-	unknownsfx0x20 4, 230, 160, 7
-	unknownsfx0x20 15, 210, 64, 7
+	squarenote 15, 215, 128, 7
+	squarenote 4, 230, 160, 7
+	squarenote 15, 210, 64, 7
 	endchannel
 
 
 SFX_Cry16_2_Ch5:
 	dutycycle 90
-	unknownsfx0x20 15, 199, 83, 7
-	unknownsfx0x20 5, 182, 114, 7
-	unknownsfx0x20 15, 194, 17, 7
+	squarenote 15, 199, 83, 7
+	squarenote 5, 182, 114, 7
+	squarenote 15, 194, 17, 7
 	endchannel
 
 
 SFX_Cry16_2_Ch7:
-	unknownnoise0x20 13, 246, 76
-	unknownnoise0x20 4, 230, 60
-	unknownnoise0x20 15, 242, 76
+	noisenote 13, 246, 76
+	noisenote 4, 230, 60
+	noisenote 15, 242, 76
 	endchannel

--- a/audio/sfx/cry16_3.asm
+++ b/audio/sfx/cry16_3.asm
@@ -1,21 +1,21 @@
 SFX_Cry16_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 215, 128, 7
-	unknownsfx0x20 4, 230, 160, 7
-	unknownsfx0x20 15, 210, 64, 7
+	squarenote 15, 215, 128, 7
+	squarenote 4, 230, 160, 7
+	squarenote 15, 210, 64, 7
 	endchannel
 
 
 SFX_Cry16_3_Ch5:
 	dutycycle 90
-	unknownsfx0x20 15, 199, 83, 7
-	unknownsfx0x20 5, 182, 114, 7
-	unknownsfx0x20 15, 194, 17, 7
+	squarenote 15, 199, 83, 7
+	squarenote 5, 182, 114, 7
+	squarenote 15, 194, 17, 7
 	endchannel
 
 
 SFX_Cry16_3_Ch7:
-	unknownnoise0x20 13, 246, 76
-	unknownnoise0x20 4, 230, 60
-	unknownnoise0x20 15, 242, 76
+	noisenote 13, 246, 76
+	noisenote 4, 230, 60
+	noisenote 15, 242, 76
 	endchannel

--- a/audio/sfx/cry17_1.asm
+++ b/audio/sfx/cry17_1.asm
@@ -1,24 +1,24 @@
 SFX_Cry17_1_Ch4:
 	dutycycle 15
-	unknownsfx0x20 15, 247, 0, 5
-	unknownsfx0x20 15, 231, 8, 5
-	unknownsfx0x20 8, 180, 128, 4
-	unknownsfx0x20 15, 162, 96, 4
+	squarenote 15, 247, 0, 5
+	squarenote 15, 231, 8, 5
+	squarenote 8, 180, 128, 4
+	squarenote 15, 162, 96, 4
 	endchannel
 
 
 SFX_Cry17_1_Ch5:
 	dutycycle 68
-	unknownsfx0x20 14, 215, 129, 4
-	unknownsfx0x20 14, 199, 137, 4
-	unknownsfx0x20 10, 180, 1, 4
-	unknownsfx0x20 15, 194, 225, 3
+	squarenote 14, 215, 129, 4
+	squarenote 14, 199, 137, 4
+	squarenote 10, 180, 1, 4
+	squarenote 15, 194, 225, 3
 	endchannel
 
 
 SFX_Cry17_1_Ch7:
-	unknownnoise0x20 14, 247, 124
-	unknownnoise0x20 12, 246, 108
-	unknownnoise0x20 9, 228, 124
-	unknownnoise0x20 15, 226, 108
+	noisenote 14, 247, 124
+	noisenote 12, 246, 108
+	noisenote 9, 228, 124
+	noisenote 15, 226, 108
 	endchannel

--- a/audio/sfx/cry17_2.asm
+++ b/audio/sfx/cry17_2.asm
@@ -1,24 +1,24 @@
 SFX_Cry17_2_Ch4:
 	dutycycle 15
-	unknownsfx0x20 15, 247, 0, 5
-	unknownsfx0x20 15, 231, 8, 5
-	unknownsfx0x20 8, 180, 128, 4
-	unknownsfx0x20 15, 162, 96, 4
+	squarenote 15, 247, 0, 5
+	squarenote 15, 231, 8, 5
+	squarenote 8, 180, 128, 4
+	squarenote 15, 162, 96, 4
 	endchannel
 
 
 SFX_Cry17_2_Ch5:
 	dutycycle 68
-	unknownsfx0x20 14, 215, 129, 4
-	unknownsfx0x20 14, 199, 137, 4
-	unknownsfx0x20 10, 180, 1, 4
-	unknownsfx0x20 15, 194, 225, 3
+	squarenote 14, 215, 129, 4
+	squarenote 14, 199, 137, 4
+	squarenote 10, 180, 1, 4
+	squarenote 15, 194, 225, 3
 	endchannel
 
 
 SFX_Cry17_2_Ch7:
-	unknownnoise0x20 14, 247, 124
-	unknownnoise0x20 12, 246, 108
-	unknownnoise0x20 9, 228, 124
-	unknownnoise0x20 15, 226, 108
+	noisenote 14, 247, 124
+	noisenote 12, 246, 108
+	noisenote 9, 228, 124
+	noisenote 15, 226, 108
 	endchannel

--- a/audio/sfx/cry17_3.asm
+++ b/audio/sfx/cry17_3.asm
@@ -1,24 +1,24 @@
 SFX_Cry17_3_Ch4:
 	dutycycle 15
-	unknownsfx0x20 15, 247, 0, 5
-	unknownsfx0x20 15, 231, 8, 5
-	unknownsfx0x20 8, 180, 128, 4
-	unknownsfx0x20 15, 162, 96, 4
+	squarenote 15, 247, 0, 5
+	squarenote 15, 231, 8, 5
+	squarenote 8, 180, 128, 4
+	squarenote 15, 162, 96, 4
 	endchannel
 
 
 SFX_Cry17_3_Ch5:
 	dutycycle 68
-	unknownsfx0x20 14, 215, 129, 4
-	unknownsfx0x20 14, 199, 137, 4
-	unknownsfx0x20 10, 180, 1, 4
-	unknownsfx0x20 15, 194, 225, 3
+	squarenote 14, 215, 129, 4
+	squarenote 14, 199, 137, 4
+	squarenote 10, 180, 1, 4
+	squarenote 15, 194, 225, 3
 	endchannel
 
 
 SFX_Cry17_3_Ch7:
-	unknownnoise0x20 14, 247, 124
-	unknownnoise0x20 12, 246, 108
-	unknownnoise0x20 9, 228, 124
-	unknownnoise0x20 15, 226, 108
+	noisenote 14, 247, 124
+	noisenote 12, 246, 108
+	noisenote 9, 228, 124
+	noisenote 15, 226, 108
 	endchannel

--- a/audio/sfx/cry18_1.asm
+++ b/audio/sfx/cry18_1.asm
@@ -1,34 +1,34 @@
 SFX_Cry18_1_Ch4:
 	dutycycle 80
-	unknownsfx0x20 10, 245, 128, 6
-	unknownsfx0x20 3, 226, 160, 6
-	unknownsfx0x20 3, 242, 192, 6
-	unknownsfx0x20 3, 226, 224, 6
-	unknownsfx0x20 3, 210, 0, 7
-	unknownsfx0x20 3, 194, 224, 6
-	unknownsfx0x20 3, 210, 192, 6
-	unknownsfx0x20 8, 193, 160, 6
+	squarenote 10, 245, 128, 6
+	squarenote 3, 226, 160, 6
+	squarenote 3, 242, 192, 6
+	squarenote 3, 226, 224, 6
+	squarenote 3, 210, 0, 7
+	squarenote 3, 194, 224, 6
+	squarenote 3, 210, 192, 6
+	squarenote 8, 193, 160, 6
 	endchannel
 
 
 SFX_Cry18_1_Ch5:
 	dutycycle 15
-	unknownsfx0x20 9, 213, 49, 6
-	unknownsfx0x20 3, 210, 82, 6
-	unknownsfx0x20 3, 226, 113, 6
-	unknownsfx0x20 3, 178, 145, 6
-	unknownsfx0x20 3, 194, 178, 6
-	unknownsfx0x20 3, 178, 145, 6
-	unknownsfx0x20 3, 194, 113, 6
-	unknownsfx0x20 8, 177, 81, 6
+	squarenote 9, 213, 49, 6
+	squarenote 3, 210, 82, 6
+	squarenote 3, 226, 113, 6
+	squarenote 3, 178, 145, 6
+	squarenote 3, 194, 178, 6
+	squarenote 3, 178, 145, 6
+	squarenote 3, 194, 113, 6
+	squarenote 8, 177, 81, 6
 	endchannel
 
 
 SFX_Cry18_1_Ch7:
-	unknownnoise0x20 6, 227, 76
-	unknownnoise0x20 4, 195, 60
-	unknownnoise0x20 5, 212, 60
-	unknownnoise0x20 4, 196, 44
-	unknownnoise0x20 6, 180, 60
-	unknownnoise0x20 8, 193, 44
+	noisenote 6, 227, 76
+	noisenote 4, 195, 60
+	noisenote 5, 212, 60
+	noisenote 4, 196, 44
+	noisenote 6, 180, 60
+	noisenote 8, 193, 44
 	endchannel

--- a/audio/sfx/cry18_2.asm
+++ b/audio/sfx/cry18_2.asm
@@ -1,34 +1,34 @@
 SFX_Cry18_2_Ch4:
 	dutycycle 80
-	unknownsfx0x20 10, 245, 128, 6
-	unknownsfx0x20 3, 226, 160, 6
-	unknownsfx0x20 3, 242, 192, 6
-	unknownsfx0x20 3, 226, 224, 6
-	unknownsfx0x20 3, 210, 0, 7
-	unknownsfx0x20 3, 194, 224, 6
-	unknownsfx0x20 3, 210, 192, 6
-	unknownsfx0x20 8, 193, 160, 6
+	squarenote 10, 245, 128, 6
+	squarenote 3, 226, 160, 6
+	squarenote 3, 242, 192, 6
+	squarenote 3, 226, 224, 6
+	squarenote 3, 210, 0, 7
+	squarenote 3, 194, 224, 6
+	squarenote 3, 210, 192, 6
+	squarenote 8, 193, 160, 6
 	endchannel
 
 
 SFX_Cry18_2_Ch5:
 	dutycycle 15
-	unknownsfx0x20 9, 213, 49, 6
-	unknownsfx0x20 3, 210, 82, 6
-	unknownsfx0x20 3, 226, 113, 6
-	unknownsfx0x20 3, 178, 145, 6
-	unknownsfx0x20 3, 194, 178, 6
-	unknownsfx0x20 3, 178, 145, 6
-	unknownsfx0x20 3, 194, 113, 6
-	unknownsfx0x20 8, 177, 81, 6
+	squarenote 9, 213, 49, 6
+	squarenote 3, 210, 82, 6
+	squarenote 3, 226, 113, 6
+	squarenote 3, 178, 145, 6
+	squarenote 3, 194, 178, 6
+	squarenote 3, 178, 145, 6
+	squarenote 3, 194, 113, 6
+	squarenote 8, 177, 81, 6
 	endchannel
 
 
 SFX_Cry18_2_Ch7:
-	unknownnoise0x20 6, 227, 76
-	unknownnoise0x20 4, 195, 60
-	unknownnoise0x20 5, 212, 60
-	unknownnoise0x20 4, 196, 44
-	unknownnoise0x20 6, 180, 60
-	unknownnoise0x20 8, 193, 44
+	noisenote 6, 227, 76
+	noisenote 4, 195, 60
+	noisenote 5, 212, 60
+	noisenote 4, 196, 44
+	noisenote 6, 180, 60
+	noisenote 8, 193, 44
 	endchannel

--- a/audio/sfx/cry18_3.asm
+++ b/audio/sfx/cry18_3.asm
@@ -1,34 +1,34 @@
 SFX_Cry18_3_Ch4:
 	dutycycle 80
-	unknownsfx0x20 10, 245, 128, 6
-	unknownsfx0x20 3, 226, 160, 6
-	unknownsfx0x20 3, 242, 192, 6
-	unknownsfx0x20 3, 226, 224, 6
-	unknownsfx0x20 3, 210, 0, 7
-	unknownsfx0x20 3, 194, 224, 6
-	unknownsfx0x20 3, 210, 192, 6
-	unknownsfx0x20 8, 193, 160, 6
+	squarenote 10, 245, 128, 6
+	squarenote 3, 226, 160, 6
+	squarenote 3, 242, 192, 6
+	squarenote 3, 226, 224, 6
+	squarenote 3, 210, 0, 7
+	squarenote 3, 194, 224, 6
+	squarenote 3, 210, 192, 6
+	squarenote 8, 193, 160, 6
 	endchannel
 
 
 SFX_Cry18_3_Ch5:
 	dutycycle 15
-	unknownsfx0x20 9, 213, 49, 6
-	unknownsfx0x20 3, 210, 82, 6
-	unknownsfx0x20 3, 226, 113, 6
-	unknownsfx0x20 3, 178, 145, 6
-	unknownsfx0x20 3, 194, 178, 6
-	unknownsfx0x20 3, 178, 145, 6
-	unknownsfx0x20 3, 194, 113, 6
-	unknownsfx0x20 8, 177, 81, 6
+	squarenote 9, 213, 49, 6
+	squarenote 3, 210, 82, 6
+	squarenote 3, 226, 113, 6
+	squarenote 3, 178, 145, 6
+	squarenote 3, 194, 178, 6
+	squarenote 3, 178, 145, 6
+	squarenote 3, 194, 113, 6
+	squarenote 8, 177, 81, 6
 	endchannel
 
 
 SFX_Cry18_3_Ch7:
-	unknownnoise0x20 6, 227, 76
-	unknownnoise0x20 4, 195, 60
-	unknownnoise0x20 5, 212, 60
-	unknownnoise0x20 4, 196, 44
-	unknownnoise0x20 6, 180, 60
-	unknownnoise0x20 8, 193, 44
+	noisenote 6, 227, 76
+	noisenote 4, 195, 60
+	noisenote 5, 212, 60
+	noisenote 4, 196, 44
+	noisenote 6, 180, 60
+	noisenote 8, 193, 44
 	endchannel

--- a/audio/sfx/cry19_1.asm
+++ b/audio/sfx/cry19_1.asm
@@ -1,17 +1,17 @@
 SFX_Cry19_1_Ch4:
 	dutycycle 27
-	unknownsfx0x20 7, 210, 64, 7
-	unknownsfx0x20 15, 229, 96, 7
-	unknownsfx0x20 15, 193, 48, 7
+	squarenote 7, 210, 64, 7
+	squarenote 15, 229, 96, 7
+	squarenote 15, 193, 48, 7
 	endchannel
 
 
 SFX_Cry19_1_Ch5:
 	dutycycle 129
-	unknownsfx0x20 2, 194, 1, 7
-	unknownsfx0x20 4, 194, 8, 7
-	unknownsfx0x20 15, 215, 65, 7
-	unknownsfx0x20 15, 162, 1, 7
+	squarenote 2, 194, 1, 7
+	squarenote 4, 194, 8, 7
+	squarenote 15, 215, 65, 7
+	squarenote 15, 162, 1, 7
 
 
 SFX_Cry19_1_Ch7:

--- a/audio/sfx/cry19_2.asm
+++ b/audio/sfx/cry19_2.asm
@@ -1,17 +1,17 @@
 SFX_Cry19_2_Ch4:
 	dutycycle 27
-	unknownsfx0x20 7, 210, 64, 7
-	unknownsfx0x20 15, 229, 96, 7
-	unknownsfx0x20 15, 193, 48, 7
+	squarenote 7, 210, 64, 7
+	squarenote 15, 229, 96, 7
+	squarenote 15, 193, 48, 7
 	endchannel
 
 
 SFX_Cry19_2_Ch5:
 	dutycycle 129
-	unknownsfx0x20 2, 194, 1, 7
-	unknownsfx0x20 4, 194, 8, 7
-	unknownsfx0x20 15, 215, 65, 7
-	unknownsfx0x20 15, 162, 1, 7
+	squarenote 2, 194, 1, 7
+	squarenote 4, 194, 8, 7
+	squarenote 15, 215, 65, 7
+	squarenote 15, 162, 1, 7
 
 
 SFX_Cry19_2_Ch7:

--- a/audio/sfx/cry19_3.asm
+++ b/audio/sfx/cry19_3.asm
@@ -1,17 +1,17 @@
 SFX_Cry19_3_Ch4:
 	dutycycle 27
-	unknownsfx0x20 7, 210, 64, 7
-	unknownsfx0x20 15, 229, 96, 7
-	unknownsfx0x20 15, 193, 48, 7
+	squarenote 7, 210, 64, 7
+	squarenote 15, 229, 96, 7
+	squarenote 15, 193, 48, 7
 	endchannel
 
 
 SFX_Cry19_3_Ch5:
 	dutycycle 129
-	unknownsfx0x20 2, 194, 1, 7
-	unknownsfx0x20 4, 194, 8, 7
-	unknownsfx0x20 15, 215, 65, 7
-	unknownsfx0x20 15, 162, 1, 7
+	squarenote 2, 194, 1, 7
+	squarenote 4, 194, 8, 7
+	squarenote 15, 215, 65, 7
+	squarenote 15, 162, 1, 7
 
 
 SFX_Cry19_3_Ch7:

--- a/audio/sfx/cry1a_1.asm
+++ b/audio/sfx/cry1a_1.asm
@@ -1,30 +1,30 @@
 SFX_Cry1A_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 247, 64, 7
-	unknownsfx0x20 12, 230, 68, 7
-	unknownsfx0x20 6, 213, 80, 7
-	unknownsfx0x20 4, 195, 96, 7
-	unknownsfx0x20 3, 195, 128, 7
-	unknownsfx0x20 8, 209, 160, 7
+	squarenote 6, 247, 64, 7
+	squarenote 12, 230, 68, 7
+	squarenote 6, 213, 80, 7
+	squarenote 4, 195, 96, 7
+	squarenote 3, 195, 128, 7
+	squarenote 8, 209, 160, 7
 	endchannel
 
 
 SFX_Cry1A_1_Ch5:
 	dutycycle 10
-	unknownsfx0x20 6, 199, 1, 7
-	unknownsfx0x20 11, 182, 2, 7
-	unknownsfx0x20 6, 165, 17, 7
-	unknownsfx0x20 4, 147, 33, 7
-	unknownsfx0x20 3, 163, 65, 7
-	unknownsfx0x20 8, 145, 98, 7
+	squarenote 6, 199, 1, 7
+	squarenote 11, 182, 2, 7
+	squarenote 6, 165, 17, 7
+	squarenote 4, 147, 33, 7
+	squarenote 3, 163, 65, 7
+	squarenote 8, 145, 98, 7
 	endchannel
 
 
 SFX_Cry1A_1_Ch7:
-	unknownnoise0x20 3, 226, 60
-	unknownnoise0x20 8, 214, 76
-	unknownnoise0x20 5, 212, 60
-	unknownnoise0x20 12, 199, 76
-	unknownnoise0x20 2, 226, 60
-	unknownnoise0x20 8, 209, 44
+	noisenote 3, 226, 60
+	noisenote 8, 214, 76
+	noisenote 5, 212, 60
+	noisenote 12, 199, 76
+	noisenote 2, 226, 60
+	noisenote 8, 209, 44
 	endchannel

--- a/audio/sfx/cry1a_2.asm
+++ b/audio/sfx/cry1a_2.asm
@@ -1,30 +1,30 @@
 SFX_Cry1A_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 247, 64, 7
-	unknownsfx0x20 12, 230, 68, 7
-	unknownsfx0x20 6, 213, 80, 7
-	unknownsfx0x20 4, 195, 96, 7
-	unknownsfx0x20 3, 195, 128, 7
-	unknownsfx0x20 8, 209, 160, 7
+	squarenote 6, 247, 64, 7
+	squarenote 12, 230, 68, 7
+	squarenote 6, 213, 80, 7
+	squarenote 4, 195, 96, 7
+	squarenote 3, 195, 128, 7
+	squarenote 8, 209, 160, 7
 	endchannel
 
 
 SFX_Cry1A_2_Ch5:
 	dutycycle 10
-	unknownsfx0x20 6, 199, 1, 7
-	unknownsfx0x20 11, 182, 2, 7
-	unknownsfx0x20 6, 165, 17, 7
-	unknownsfx0x20 4, 147, 33, 7
-	unknownsfx0x20 3, 163, 65, 7
-	unknownsfx0x20 8, 145, 98, 7
+	squarenote 6, 199, 1, 7
+	squarenote 11, 182, 2, 7
+	squarenote 6, 165, 17, 7
+	squarenote 4, 147, 33, 7
+	squarenote 3, 163, 65, 7
+	squarenote 8, 145, 98, 7
 	endchannel
 
 
 SFX_Cry1A_2_Ch7:
-	unknownnoise0x20 3, 226, 60
-	unknownnoise0x20 8, 214, 76
-	unknownnoise0x20 5, 212, 60
-	unknownnoise0x20 12, 199, 76
-	unknownnoise0x20 2, 226, 60
-	unknownnoise0x20 8, 209, 44
+	noisenote 3, 226, 60
+	noisenote 8, 214, 76
+	noisenote 5, 212, 60
+	noisenote 12, 199, 76
+	noisenote 2, 226, 60
+	noisenote 8, 209, 44
 	endchannel

--- a/audio/sfx/cry1a_3.asm
+++ b/audio/sfx/cry1a_3.asm
@@ -1,30 +1,30 @@
 SFX_Cry1A_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 247, 64, 7
-	unknownsfx0x20 12, 230, 68, 7
-	unknownsfx0x20 6, 213, 80, 7
-	unknownsfx0x20 4, 195, 96, 7
-	unknownsfx0x20 3, 195, 128, 7
-	unknownsfx0x20 8, 209, 160, 7
+	squarenote 6, 247, 64, 7
+	squarenote 12, 230, 68, 7
+	squarenote 6, 213, 80, 7
+	squarenote 4, 195, 96, 7
+	squarenote 3, 195, 128, 7
+	squarenote 8, 209, 160, 7
 	endchannel
 
 
 SFX_Cry1A_3_Ch5:
 	dutycycle 10
-	unknownsfx0x20 6, 199, 1, 7
-	unknownsfx0x20 11, 182, 2, 7
-	unknownsfx0x20 6, 165, 17, 7
-	unknownsfx0x20 4, 147, 33, 7
-	unknownsfx0x20 3, 163, 65, 7
-	unknownsfx0x20 8, 145, 98, 7
+	squarenote 6, 199, 1, 7
+	squarenote 11, 182, 2, 7
+	squarenote 6, 165, 17, 7
+	squarenote 4, 147, 33, 7
+	squarenote 3, 163, 65, 7
+	squarenote 8, 145, 98, 7
 	endchannel
 
 
 SFX_Cry1A_3_Ch7:
-	unknownnoise0x20 3, 226, 60
-	unknownnoise0x20 8, 214, 76
-	unknownnoise0x20 5, 212, 60
-	unknownnoise0x20 12, 199, 76
-	unknownnoise0x20 2, 226, 60
-	unknownnoise0x20 8, 209, 44
+	noisenote 3, 226, 60
+	noisenote 8, 214, 76
+	noisenote 5, 212, 60
+	noisenote 12, 199, 76
+	noisenote 2, 226, 60
+	noisenote 8, 209, 44
 	endchannel

--- a/audio/sfx/cry1b_1.asm
+++ b/audio/sfx/cry1b_1.asm
@@ -1,26 +1,26 @@
 SFX_Cry1B_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 247, 192, 6
-	unknownsfx0x20 15, 231, 0, 7
-	unknownsfx0x20 4, 244, 240, 6
-	unknownsfx0x20 4, 228, 224, 6
-	unknownsfx0x20 8, 209, 208, 6
+	squarenote 6, 247, 192, 6
+	squarenote 15, 231, 0, 7
+	squarenote 4, 244, 240, 6
+	squarenote 4, 228, 224, 6
+	squarenote 8, 209, 208, 6
 	endchannel
 
 
 SFX_Cry1B_1_Ch5:
 	dutycycle 10
-	unknownsfx0x20 7, 230, 129, 6
-	unknownsfx0x20 14, 213, 193, 6
-	unknownsfx0x20 4, 196, 177, 6
-	unknownsfx0x20 4, 212, 161, 6
-	unknownsfx0x20 8, 193, 145, 6
+	squarenote 7, 230, 129, 6
+	squarenote 14, 213, 193, 6
+	squarenote 4, 196, 177, 6
+	squarenote 4, 212, 161, 6
+	squarenote 8, 193, 145, 6
 	endchannel
 
 
 SFX_Cry1B_1_Ch7:
-	unknownnoise0x20 10, 166, 60
-	unknownnoise0x20 14, 148, 44
-	unknownnoise0x20 5, 163, 60
-	unknownnoise0x20 8, 145, 44
+	noisenote 10, 166, 60
+	noisenote 14, 148, 44
+	noisenote 5, 163, 60
+	noisenote 8, 145, 44
 	endchannel

--- a/audio/sfx/cry1b_2.asm
+++ b/audio/sfx/cry1b_2.asm
@@ -1,26 +1,26 @@
 SFX_Cry1B_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 247, 192, 6
-	unknownsfx0x20 15, 231, 0, 7
-	unknownsfx0x20 4, 244, 240, 6
-	unknownsfx0x20 4, 228, 224, 6
-	unknownsfx0x20 8, 209, 208, 6
+	squarenote 6, 247, 192, 6
+	squarenote 15, 231, 0, 7
+	squarenote 4, 244, 240, 6
+	squarenote 4, 228, 224, 6
+	squarenote 8, 209, 208, 6
 	endchannel
 
 
 SFX_Cry1B_2_Ch5:
 	dutycycle 10
-	unknownsfx0x20 7, 230, 129, 6
-	unknownsfx0x20 14, 213, 193, 6
-	unknownsfx0x20 4, 196, 177, 6
-	unknownsfx0x20 4, 212, 161, 6
-	unknownsfx0x20 8, 193, 145, 6
+	squarenote 7, 230, 129, 6
+	squarenote 14, 213, 193, 6
+	squarenote 4, 196, 177, 6
+	squarenote 4, 212, 161, 6
+	squarenote 8, 193, 145, 6
 	endchannel
 
 
 SFX_Cry1B_2_Ch7:
-	unknownnoise0x20 10, 166, 60
-	unknownnoise0x20 14, 148, 44
-	unknownnoise0x20 5, 163, 60
-	unknownnoise0x20 8, 145, 44
+	noisenote 10, 166, 60
+	noisenote 14, 148, 44
+	noisenote 5, 163, 60
+	noisenote 8, 145, 44
 	endchannel

--- a/audio/sfx/cry1b_3.asm
+++ b/audio/sfx/cry1b_3.asm
@@ -1,26 +1,26 @@
 SFX_Cry1B_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 247, 192, 6
-	unknownsfx0x20 15, 231, 0, 7
-	unknownsfx0x20 4, 244, 240, 6
-	unknownsfx0x20 4, 228, 224, 6
-	unknownsfx0x20 8, 209, 208, 6
+	squarenote 6, 247, 192, 6
+	squarenote 15, 231, 0, 7
+	squarenote 4, 244, 240, 6
+	squarenote 4, 228, 224, 6
+	squarenote 8, 209, 208, 6
 	endchannel
 
 
 SFX_Cry1B_3_Ch5:
 	dutycycle 10
-	unknownsfx0x20 7, 230, 129, 6
-	unknownsfx0x20 14, 213, 193, 6
-	unknownsfx0x20 4, 196, 177, 6
-	unknownsfx0x20 4, 212, 161, 6
-	unknownsfx0x20 8, 193, 145, 6
+	squarenote 7, 230, 129, 6
+	squarenote 14, 213, 193, 6
+	squarenote 4, 196, 177, 6
+	squarenote 4, 212, 161, 6
+	squarenote 8, 193, 145, 6
 	endchannel
 
 
 SFX_Cry1B_3_Ch7:
-	unknownnoise0x20 10, 166, 60
-	unknownnoise0x20 14, 148, 44
-	unknownnoise0x20 5, 163, 60
-	unknownnoise0x20 8, 145, 44
+	noisenote 10, 166, 60
+	noisenote 14, 148, 44
+	noisenote 5, 163, 60
+	noisenote 8, 145, 44
 	endchannel

--- a/audio/sfx/cry1c_1.asm
+++ b/audio/sfx/cry1c_1.asm
@@ -1,31 +1,31 @@
 SFX_Cry1C_1_Ch4:
 	dutycycle 245
-	unknownsfx0x20 7, 214, 225, 7
-	unknownsfx0x20 6, 198, 226, 7
-	unknownsfx0x20 9, 214, 225, 7
-	unknownsfx0x20 7, 198, 224, 7
-	unknownsfx0x20 5, 182, 226, 7
-	unknownsfx0x20 7, 198, 225, 7
-	unknownsfx0x20 6, 182, 224, 7
-	unknownsfx0x20 8, 161, 223, 7
+	squarenote 7, 214, 225, 7
+	squarenote 6, 198, 226, 7
+	squarenote 9, 214, 225, 7
+	squarenote 7, 198, 224, 7
+	squarenote 5, 182, 226, 7
+	squarenote 7, 198, 225, 7
+	squarenote 6, 182, 224, 7
+	squarenote 8, 161, 223, 7
 	endchannel
 
 
 SFX_Cry1C_1_Ch5:
 	dutycycle 68
-	unknownsfx0x20 6, 195, 201, 7
-	unknownsfx0x20 6, 179, 199, 7
-	unknownsfx0x20 10, 196, 195, 7
-	unknownsfx0x20 8, 180, 199, 7
-	unknownsfx0x20 6, 195, 201, 7
-	unknownsfx0x20 15, 162, 197, 7
+	squarenote 6, 195, 201, 7
+	squarenote 6, 179, 199, 7
+	squarenote 10, 196, 195, 7
+	squarenote 8, 180, 199, 7
+	squarenote 6, 195, 201, 7
+	squarenote 15, 162, 197, 7
 	endchannel
 
 
 SFX_Cry1C_1_Ch7:
-	unknownnoise0x20 13, 25, 124
-	unknownnoise0x20 13, 247, 140
-	unknownnoise0x20 12, 214, 124
-	unknownnoise0x20 8, 196, 108
-	unknownnoise0x20 15, 179, 92
+	noisenote 13, 25, 124
+	noisenote 13, 247, 140
+	noisenote 12, 214, 124
+	noisenote 8, 196, 108
+	noisenote 15, 179, 92
 	endchannel

--- a/audio/sfx/cry1c_2.asm
+++ b/audio/sfx/cry1c_2.asm
@@ -1,31 +1,31 @@
 SFX_Cry1C_2_Ch4:
 	dutycycle 245
-	unknownsfx0x20 7, 214, 225, 7
-	unknownsfx0x20 6, 198, 226, 7
-	unknownsfx0x20 9, 214, 225, 7
-	unknownsfx0x20 7, 198, 224, 7
-	unknownsfx0x20 5, 182, 226, 7
-	unknownsfx0x20 7, 198, 225, 7
-	unknownsfx0x20 6, 182, 224, 7
-	unknownsfx0x20 8, 161, 223, 7
+	squarenote 7, 214, 225, 7
+	squarenote 6, 198, 226, 7
+	squarenote 9, 214, 225, 7
+	squarenote 7, 198, 224, 7
+	squarenote 5, 182, 226, 7
+	squarenote 7, 198, 225, 7
+	squarenote 6, 182, 224, 7
+	squarenote 8, 161, 223, 7
 	endchannel
 
 
 SFX_Cry1C_2_Ch5:
 	dutycycle 68
-	unknownsfx0x20 6, 195, 201, 7
-	unknownsfx0x20 6, 179, 199, 7
-	unknownsfx0x20 10, 196, 195, 7
-	unknownsfx0x20 8, 180, 199, 7
-	unknownsfx0x20 6, 195, 201, 7
-	unknownsfx0x20 15, 162, 197, 7
+	squarenote 6, 195, 201, 7
+	squarenote 6, 179, 199, 7
+	squarenote 10, 196, 195, 7
+	squarenote 8, 180, 199, 7
+	squarenote 6, 195, 201, 7
+	squarenote 15, 162, 197, 7
 	endchannel
 
 
 SFX_Cry1C_2_Ch7:
-	unknownnoise0x20 13, 25, 124
-	unknownnoise0x20 13, 247, 140
-	unknownnoise0x20 12, 214, 124
-	unknownnoise0x20 8, 196, 108
-	unknownnoise0x20 15, 179, 92
+	noisenote 13, 25, 124
+	noisenote 13, 247, 140
+	noisenote 12, 214, 124
+	noisenote 8, 196, 108
+	noisenote 15, 179, 92
 	endchannel

--- a/audio/sfx/cry1c_3.asm
+++ b/audio/sfx/cry1c_3.asm
@@ -1,31 +1,31 @@
 SFX_Cry1C_3_Ch4:
 	dutycycle 245
-	unknownsfx0x20 7, 214, 225, 7
-	unknownsfx0x20 6, 198, 226, 7
-	unknownsfx0x20 9, 214, 225, 7
-	unknownsfx0x20 7, 198, 224, 7
-	unknownsfx0x20 5, 182, 226, 7
-	unknownsfx0x20 7, 198, 225, 7
-	unknownsfx0x20 6, 182, 224, 7
-	unknownsfx0x20 8, 161, 223, 7
+	squarenote 7, 214, 225, 7
+	squarenote 6, 198, 226, 7
+	squarenote 9, 214, 225, 7
+	squarenote 7, 198, 224, 7
+	squarenote 5, 182, 226, 7
+	squarenote 7, 198, 225, 7
+	squarenote 6, 182, 224, 7
+	squarenote 8, 161, 223, 7
 	endchannel
 
 
 SFX_Cry1C_3_Ch5:
 	dutycycle 68
-	unknownsfx0x20 6, 195, 201, 7
-	unknownsfx0x20 6, 179, 199, 7
-	unknownsfx0x20 10, 196, 195, 7
-	unknownsfx0x20 8, 180, 199, 7
-	unknownsfx0x20 6, 195, 201, 7
-	unknownsfx0x20 15, 162, 197, 7
+	squarenote 6, 195, 201, 7
+	squarenote 6, 179, 199, 7
+	squarenote 10, 196, 195, 7
+	squarenote 8, 180, 199, 7
+	squarenote 6, 195, 201, 7
+	squarenote 15, 162, 197, 7
 	endchannel
 
 
 SFX_Cry1C_3_Ch7:
-	unknownnoise0x20 13, 25, 124
-	unknownnoise0x20 13, 247, 140
-	unknownnoise0x20 12, 214, 124
-	unknownnoise0x20 8, 196, 108
-	unknownnoise0x20 15, 179, 92
+	noisenote 13, 25, 124
+	noisenote 13, 247, 140
+	noisenote 12, 214, 124
+	noisenote 8, 196, 108
+	noisenote 15, 179, 92
 	endchannel

--- a/audio/sfx/cry1d_1.asm
+++ b/audio/sfx/cry1d_1.asm
@@ -1,29 +1,29 @@
 SFX_Cry1D_1_Ch4:
 	dutycycle 244
-	unknownsfx0x20 15, 240, 5, 7
-	unknownsfx0x20 10, 224, 0, 7
-	unknownsfx0x20 6, 180, 16, 7
-	unknownsfx0x20 4, 211, 0, 7
-	unknownsfx0x20 6, 178, 32, 6
-	unknownsfx0x20 8, 161, 36, 6
+	squarenote 15, 240, 5, 7
+	squarenote 10, 224, 0, 7
+	squarenote 6, 180, 16, 7
+	squarenote 4, 211, 0, 7
+	squarenote 6, 178, 32, 6
+	squarenote 8, 161, 36, 6
 	endchannel
 
 
 SFX_Cry1D_1_Ch5:
 	dutycycle 34
-	unknownsfx0x20 15, 176, 195, 6
-	unknownsfx0x20 10, 160, 193, 6
-	unknownsfx0x20 6, 132, 210, 6
-	unknownsfx0x20 4, 147, 193, 6
-	unknownsfx0x20 6, 130, 225, 5
-	unknownsfx0x20 8, 97, 232, 5
+	squarenote 15, 176, 195, 6
+	squarenote 10, 160, 193, 6
+	squarenote 6, 132, 210, 6
+	squarenote 4, 147, 193, 6
+	squarenote 6, 130, 225, 5
+	squarenote 8, 97, 232, 5
 	endchannel
 
 
 SFX_Cry1D_1_Ch7:
-	unknownnoise0x20 6, 230, 76
-	unknownnoise0x20 15, 214, 60
-	unknownnoise0x20 10, 197, 74
-	unknownnoise0x20 1, 178, 91
-	unknownnoise0x20 15, 194, 76
+	noisenote 6, 230, 76
+	noisenote 15, 214, 60
+	noisenote 10, 197, 74
+	noisenote 1, 178, 91
+	noisenote 15, 194, 76
 	endchannel

--- a/audio/sfx/cry1d_2.asm
+++ b/audio/sfx/cry1d_2.asm
@@ -1,29 +1,29 @@
 SFX_Cry1D_2_Ch4:
 	dutycycle 244
-	unknownsfx0x20 15, 240, 5, 7
-	unknownsfx0x20 10, 224, 0, 7
-	unknownsfx0x20 6, 180, 16, 7
-	unknownsfx0x20 4, 211, 0, 7
-	unknownsfx0x20 6, 178, 32, 6
-	unknownsfx0x20 8, 161, 36, 6
+	squarenote 15, 240, 5, 7
+	squarenote 10, 224, 0, 7
+	squarenote 6, 180, 16, 7
+	squarenote 4, 211, 0, 7
+	squarenote 6, 178, 32, 6
+	squarenote 8, 161, 36, 6
 	endchannel
 
 
 SFX_Cry1D_2_Ch5:
 	dutycycle 34
-	unknownsfx0x20 15, 176, 195, 6
-	unknownsfx0x20 10, 160, 193, 6
-	unknownsfx0x20 6, 132, 210, 6
-	unknownsfx0x20 4, 147, 193, 6
-	unknownsfx0x20 6, 130, 225, 5
-	unknownsfx0x20 8, 97, 232, 5
+	squarenote 15, 176, 195, 6
+	squarenote 10, 160, 193, 6
+	squarenote 6, 132, 210, 6
+	squarenote 4, 147, 193, 6
+	squarenote 6, 130, 225, 5
+	squarenote 8, 97, 232, 5
 	endchannel
 
 
 SFX_Cry1D_2_Ch7:
-	unknownnoise0x20 6, 230, 76
-	unknownnoise0x20 15, 214, 60
-	unknownnoise0x20 10, 197, 74
-	unknownnoise0x20 1, 178, 91
-	unknownnoise0x20 15, 194, 76
+	noisenote 6, 230, 76
+	noisenote 15, 214, 60
+	noisenote 10, 197, 74
+	noisenote 1, 178, 91
+	noisenote 15, 194, 76
 	endchannel

--- a/audio/sfx/cry1d_3.asm
+++ b/audio/sfx/cry1d_3.asm
@@ -1,29 +1,29 @@
 SFX_Cry1D_3_Ch4:
 	dutycycle 244
-	unknownsfx0x20 15, 240, 5, 7
-	unknownsfx0x20 10, 224, 0, 7
-	unknownsfx0x20 6, 180, 16, 7
-	unknownsfx0x20 4, 211, 0, 7
-	unknownsfx0x20 6, 178, 32, 6
-	unknownsfx0x20 8, 161, 36, 6
+	squarenote 15, 240, 5, 7
+	squarenote 10, 224, 0, 7
+	squarenote 6, 180, 16, 7
+	squarenote 4, 211, 0, 7
+	squarenote 6, 178, 32, 6
+	squarenote 8, 161, 36, 6
 	endchannel
 
 
 SFX_Cry1D_3_Ch5:
 	dutycycle 34
-	unknownsfx0x20 15, 176, 195, 6
-	unknownsfx0x20 10, 160, 193, 6
-	unknownsfx0x20 6, 132, 210, 6
-	unknownsfx0x20 4, 147, 193, 6
-	unknownsfx0x20 6, 130, 225, 5
-	unknownsfx0x20 8, 97, 232, 5
+	squarenote 15, 176, 195, 6
+	squarenote 10, 160, 193, 6
+	squarenote 6, 132, 210, 6
+	squarenote 4, 147, 193, 6
+	squarenote 6, 130, 225, 5
+	squarenote 8, 97, 232, 5
 	endchannel
 
 
 SFX_Cry1D_3_Ch7:
-	unknownnoise0x20 6, 230, 76
-	unknownnoise0x20 15, 214, 60
-	unknownnoise0x20 10, 197, 74
-	unknownnoise0x20 1, 178, 91
-	unknownnoise0x20 15, 194, 76
+	noisenote 6, 230, 76
+	noisenote 15, 214, 60
+	noisenote 10, 197, 74
+	noisenote 1, 178, 91
+	noisenote 15, 194, 76
 	endchannel

--- a/audio/sfx/cry1e_1.asm
+++ b/audio/sfx/cry1e_1.asm
@@ -1,38 +1,38 @@
 SFX_Cry1E_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 242, 0, 6
-	unknownsfx0x20 6, 226, 64, 6
-	unknownsfx0x20 6, 210, 128, 6
-	unknownsfx0x20 6, 226, 192, 6
-	unknownsfx0x20 6, 210, 0, 7
-	unknownsfx0x20 6, 194, 64, 7
-	unknownsfx0x20 6, 178, 128, 7
-	unknownsfx0x20 8, 161, 192, 7
+	squarenote 6, 242, 0, 6
+	squarenote 6, 226, 64, 6
+	squarenote 6, 210, 128, 6
+	squarenote 6, 226, 192, 6
+	squarenote 6, 210, 0, 7
+	squarenote 6, 194, 64, 7
+	squarenote 6, 178, 128, 7
+	squarenote 8, 161, 192, 7
 	endchannel
 
 
 SFX_Cry1E_1_Ch5:
 	dutycycle 17
-	unknownsfx0x20 3, 8, 1, 0
-	unknownsfx0x20 6, 194, 193, 5
-	unknownsfx0x20 6, 178, 2, 6
-	unknownsfx0x20 6, 162, 65, 6
-	unknownsfx0x20 6, 178, 130, 6
-	unknownsfx0x20 6, 162, 194, 6
-	unknownsfx0x20 6, 146, 1, 7
-	unknownsfx0x20 6, 162, 66, 7
-	unknownsfx0x20 8, 129, 129, 7
+	squarenote 3, 8, 1, 0
+	squarenote 6, 194, 193, 5
+	squarenote 6, 178, 2, 6
+	squarenote 6, 162, 65, 6
+	squarenote 6, 178, 130, 6
+	squarenote 6, 162, 194, 6
+	squarenote 6, 146, 1, 7
+	squarenote 6, 162, 66, 7
+	squarenote 8, 129, 129, 7
 	endchannel
 
 
 SFX_Cry1E_1_Ch7:
-	unknownnoise0x20 6, 8, 1
-	unknownnoise0x20 5, 226, 92
-	unknownnoise0x20 5, 194, 76
-	unknownnoise0x20 5, 210, 60
-	unknownnoise0x20 5, 178, 44
-	unknownnoise0x20 5, 194, 28
-	unknownnoise0x20 5, 162, 27
-	unknownnoise0x20 5, 146, 26
-	unknownnoise0x20 8, 129, 24
+	noisenote 6, 8, 1
+	noisenote 5, 226, 92
+	noisenote 5, 194, 76
+	noisenote 5, 210, 60
+	noisenote 5, 178, 44
+	noisenote 5, 194, 28
+	noisenote 5, 162, 27
+	noisenote 5, 146, 26
+	noisenote 8, 129, 24
 	endchannel

--- a/audio/sfx/cry1e_2.asm
+++ b/audio/sfx/cry1e_2.asm
@@ -1,38 +1,38 @@
 SFX_Cry1E_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 242, 0, 6
-	unknownsfx0x20 6, 226, 64, 6
-	unknownsfx0x20 6, 210, 128, 6
-	unknownsfx0x20 6, 226, 192, 6
-	unknownsfx0x20 6, 210, 0, 7
-	unknownsfx0x20 6, 194, 64, 7
-	unknownsfx0x20 6, 178, 128, 7
-	unknownsfx0x20 8, 161, 192, 7
+	squarenote 6, 242, 0, 6
+	squarenote 6, 226, 64, 6
+	squarenote 6, 210, 128, 6
+	squarenote 6, 226, 192, 6
+	squarenote 6, 210, 0, 7
+	squarenote 6, 194, 64, 7
+	squarenote 6, 178, 128, 7
+	squarenote 8, 161, 192, 7
 	endchannel
 
 
 SFX_Cry1E_2_Ch5:
 	dutycycle 17
-	unknownsfx0x20 3, 8, 1, 0
-	unknownsfx0x20 6, 194, 193, 5
-	unknownsfx0x20 6, 178, 2, 6
-	unknownsfx0x20 6, 162, 65, 6
-	unknownsfx0x20 6, 178, 130, 6
-	unknownsfx0x20 6, 162, 194, 6
-	unknownsfx0x20 6, 146, 1, 7
-	unknownsfx0x20 6, 162, 66, 7
-	unknownsfx0x20 8, 129, 129, 7
+	squarenote 3, 8, 1, 0
+	squarenote 6, 194, 193, 5
+	squarenote 6, 178, 2, 6
+	squarenote 6, 162, 65, 6
+	squarenote 6, 178, 130, 6
+	squarenote 6, 162, 194, 6
+	squarenote 6, 146, 1, 7
+	squarenote 6, 162, 66, 7
+	squarenote 8, 129, 129, 7
 	endchannel
 
 
 SFX_Cry1E_2_Ch7:
-	unknownnoise0x20 6, 8, 1
-	unknownnoise0x20 5, 226, 92
-	unknownnoise0x20 5, 194, 76
-	unknownnoise0x20 5, 210, 60
-	unknownnoise0x20 5, 178, 44
-	unknownnoise0x20 5, 194, 28
-	unknownnoise0x20 5, 162, 27
-	unknownnoise0x20 5, 146, 26
-	unknownnoise0x20 8, 129, 24
+	noisenote 6, 8, 1
+	noisenote 5, 226, 92
+	noisenote 5, 194, 76
+	noisenote 5, 210, 60
+	noisenote 5, 178, 44
+	noisenote 5, 194, 28
+	noisenote 5, 162, 27
+	noisenote 5, 146, 26
+	noisenote 8, 129, 24
 	endchannel

--- a/audio/sfx/cry1e_3.asm
+++ b/audio/sfx/cry1e_3.asm
@@ -1,38 +1,38 @@
 SFX_Cry1E_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 6, 242, 0, 6
-	unknownsfx0x20 6, 226, 64, 6
-	unknownsfx0x20 6, 210, 128, 6
-	unknownsfx0x20 6, 226, 192, 6
-	unknownsfx0x20 6, 210, 0, 7
-	unknownsfx0x20 6, 194, 64, 7
-	unknownsfx0x20 6, 178, 128, 7
-	unknownsfx0x20 8, 161, 192, 7
+	squarenote 6, 242, 0, 6
+	squarenote 6, 226, 64, 6
+	squarenote 6, 210, 128, 6
+	squarenote 6, 226, 192, 6
+	squarenote 6, 210, 0, 7
+	squarenote 6, 194, 64, 7
+	squarenote 6, 178, 128, 7
+	squarenote 8, 161, 192, 7
 	endchannel
 
 
 SFX_Cry1E_3_Ch5:
 	dutycycle 17
-	unknownsfx0x20 3, 8, 1, 0
-	unknownsfx0x20 6, 194, 193, 5
-	unknownsfx0x20 6, 178, 2, 6
-	unknownsfx0x20 6, 162, 65, 6
-	unknownsfx0x20 6, 178, 130, 6
-	unknownsfx0x20 6, 162, 194, 6
-	unknownsfx0x20 6, 146, 1, 7
-	unknownsfx0x20 6, 162, 66, 7
-	unknownsfx0x20 8, 129, 129, 7
+	squarenote 3, 8, 1, 0
+	squarenote 6, 194, 193, 5
+	squarenote 6, 178, 2, 6
+	squarenote 6, 162, 65, 6
+	squarenote 6, 178, 130, 6
+	squarenote 6, 162, 194, 6
+	squarenote 6, 146, 1, 7
+	squarenote 6, 162, 66, 7
+	squarenote 8, 129, 129, 7
 	endchannel
 
 
 SFX_Cry1E_3_Ch7:
-	unknownnoise0x20 6, 8, 1
-	unknownnoise0x20 5, 226, 92
-	unknownnoise0x20 5, 194, 76
-	unknownnoise0x20 5, 210, 60
-	unknownnoise0x20 5, 178, 44
-	unknownnoise0x20 5, 194, 28
-	unknownnoise0x20 5, 162, 27
-	unknownnoise0x20 5, 146, 26
-	unknownnoise0x20 8, 129, 24
+	noisenote 6, 8, 1
+	noisenote 5, 226, 92
+	noisenote 5, 194, 76
+	noisenote 5, 210, 60
+	noisenote 5, 178, 44
+	noisenote 5, 194, 28
+	noisenote 5, 162, 27
+	noisenote 5, 146, 26
+	noisenote 8, 129, 24
 	endchannel

--- a/audio/sfx/cry1f_1.asm
+++ b/audio/sfx/cry1f_1.asm
@@ -1,24 +1,24 @@
 SFX_Cry1F_1_Ch4:
 	dutycycle 165
-	unknownsfx0x20 3, 244, 65, 6
-	unknownsfx0x20 13, 214, 33, 7
-	unknownsfx0x20 8, 244, 25, 7
-	unknownsfx0x20 8, 193, 26, 7
+	squarenote 3, 244, 65, 6
+	squarenote 13, 214, 33, 7
+	squarenote 8, 244, 25, 7
+	squarenote 8, 193, 26, 7
 	endchannel
 
 
 SFX_Cry1F_1_Ch5:
 	dutycycle 204
-	unknownsfx0x20 4, 244, 128, 5
-	unknownsfx0x20 14, 230, 224, 6
-	unknownsfx0x20 8, 213, 216, 6
-	unknownsfx0x20 8, 209, 220, 6
+	squarenote 4, 244, 128, 5
+	squarenote 14, 230, 224, 6
+	squarenote 8, 213, 216, 6
+	squarenote 8, 209, 220, 6
 	endchannel
 
 
 SFX_Cry1F_1_Ch7:
-	unknownnoise0x20 5, 196, 70
-	unknownnoise0x20 13, 165, 68
-	unknownnoise0x20 8, 196, 69
-	unknownnoise0x20 8, 177, 68
+	noisenote 5, 196, 70
+	noisenote 13, 165, 68
+	noisenote 8, 196, 69
+	noisenote 8, 177, 68
 	endchannel

--- a/audio/sfx/cry1f_2.asm
+++ b/audio/sfx/cry1f_2.asm
@@ -1,24 +1,24 @@
 SFX_Cry1F_2_Ch4:
 	dutycycle 165
-	unknownsfx0x20 3, 244, 65, 6
-	unknownsfx0x20 13, 214, 33, 7
-	unknownsfx0x20 8, 244, 25, 7
-	unknownsfx0x20 8, 193, 26, 7
+	squarenote 3, 244, 65, 6
+	squarenote 13, 214, 33, 7
+	squarenote 8, 244, 25, 7
+	squarenote 8, 193, 26, 7
 	endchannel
 
 
 SFX_Cry1F_2_Ch5:
 	dutycycle 204
-	unknownsfx0x20 4, 244, 128, 5
-	unknownsfx0x20 14, 230, 224, 6
-	unknownsfx0x20 8, 213, 216, 6
-	unknownsfx0x20 8, 209, 220, 6
+	squarenote 4, 244, 128, 5
+	squarenote 14, 230, 224, 6
+	squarenote 8, 213, 216, 6
+	squarenote 8, 209, 220, 6
 	endchannel
 
 
 SFX_Cry1F_2_Ch7:
-	unknownnoise0x20 5, 196, 70
-	unknownnoise0x20 13, 165, 68
-	unknownnoise0x20 8, 196, 69
-	unknownnoise0x20 8, 177, 68
+	noisenote 5, 196, 70
+	noisenote 13, 165, 68
+	noisenote 8, 196, 69
+	noisenote 8, 177, 68
 	endchannel

--- a/audio/sfx/cry1f_3.asm
+++ b/audio/sfx/cry1f_3.asm
@@ -1,24 +1,24 @@
 SFX_Cry1F_3_Ch4:
 	dutycycle 165
-	unknownsfx0x20 3, 244, 65, 6
-	unknownsfx0x20 13, 214, 33, 7
-	unknownsfx0x20 8, 244, 25, 7
-	unknownsfx0x20 8, 193, 26, 7
+	squarenote 3, 244, 65, 6
+	squarenote 13, 214, 33, 7
+	squarenote 8, 244, 25, 7
+	squarenote 8, 193, 26, 7
 	endchannel
 
 
 SFX_Cry1F_3_Ch5:
 	dutycycle 204
-	unknownsfx0x20 4, 244, 128, 5
-	unknownsfx0x20 14, 230, 224, 6
-	unknownsfx0x20 8, 213, 216, 6
-	unknownsfx0x20 8, 209, 220, 6
+	squarenote 4, 244, 128, 5
+	squarenote 14, 230, 224, 6
+	squarenote 8, 213, 216, 6
+	squarenote 8, 209, 220, 6
 	endchannel
 
 
 SFX_Cry1F_3_Ch7:
-	unknownnoise0x20 5, 196, 70
-	unknownnoise0x20 13, 165, 68
-	unknownnoise0x20 8, 196, 69
-	unknownnoise0x20 8, 177, 68
+	noisenote 5, 196, 70
+	noisenote 13, 165, 68
+	noisenote 8, 196, 69
+	noisenote 8, 177, 68
 	endchannel

--- a/audio/sfx/cry20_1.asm
+++ b/audio/sfx/cry20_1.asm
@@ -1,24 +1,24 @@
 SFX_Cry20_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 13, 241, 17, 5
-	unknownsfx0x20 13, 225, 21, 5
-	unknownsfx0x20 13, 225, 17, 5
-	unknownsfx0x20 8, 209, 17, 5
+	squarenote 13, 241, 17, 5
+	squarenote 13, 225, 21, 5
+	squarenote 13, 225, 17, 5
+	squarenote 8, 209, 17, 5
 	endchannel
 
 
 SFX_Cry20_1_Ch5:
 	dutycycle 21
-	unknownsfx0x20 12, 225, 12, 5
-	unknownsfx0x20 12, 209, 16, 5
-	unknownsfx0x20 14, 193, 12, 5
-	unknownsfx0x20 8, 193, 10, 5
+	squarenote 12, 225, 12, 5
+	squarenote 12, 209, 16, 5
+	squarenote 14, 193, 12, 5
+	squarenote 8, 193, 10, 5
 	endchannel
 
 
 SFX_Cry20_1_Ch7:
-	unknownnoise0x20 14, 242, 101
-	unknownnoise0x20 13, 226, 85
-	unknownnoise0x20 14, 210, 86
-	unknownnoise0x20 8, 209, 102
+	noisenote 14, 242, 101
+	noisenote 13, 226, 85
+	noisenote 14, 210, 86
+	noisenote 8, 209, 102
 	endchannel

--- a/audio/sfx/cry20_2.asm
+++ b/audio/sfx/cry20_2.asm
@@ -1,24 +1,24 @@
 SFX_Cry20_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 13, 241, 17, 5
-	unknownsfx0x20 13, 225, 21, 5
-	unknownsfx0x20 13, 225, 17, 5
-	unknownsfx0x20 8, 209, 17, 5
+	squarenote 13, 241, 17, 5
+	squarenote 13, 225, 21, 5
+	squarenote 13, 225, 17, 5
+	squarenote 8, 209, 17, 5
 	endchannel
 
 
 SFX_Cry20_2_Ch5:
 	dutycycle 21
-	unknownsfx0x20 12, 225, 12, 5
-	unknownsfx0x20 12, 209, 16, 5
-	unknownsfx0x20 14, 193, 12, 5
-	unknownsfx0x20 8, 193, 10, 5
+	squarenote 12, 225, 12, 5
+	squarenote 12, 209, 16, 5
+	squarenote 14, 193, 12, 5
+	squarenote 8, 193, 10, 5
 	endchannel
 
 
 SFX_Cry20_2_Ch7:
-	unknownnoise0x20 14, 242, 101
-	unknownnoise0x20 13, 226, 85
-	unknownnoise0x20 14, 210, 86
-	unknownnoise0x20 8, 209, 102
+	noisenote 14, 242, 101
+	noisenote 13, 226, 85
+	noisenote 14, 210, 86
+	noisenote 8, 209, 102
 	endchannel

--- a/audio/sfx/cry20_3.asm
+++ b/audio/sfx/cry20_3.asm
@@ -1,24 +1,24 @@
 SFX_Cry20_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 13, 241, 17, 5
-	unknownsfx0x20 13, 225, 21, 5
-	unknownsfx0x20 13, 225, 17, 5
-	unknownsfx0x20 8, 209, 17, 5
+	squarenote 13, 241, 17, 5
+	squarenote 13, 225, 21, 5
+	squarenote 13, 225, 17, 5
+	squarenote 8, 209, 17, 5
 	endchannel
 
 
 SFX_Cry20_3_Ch5:
 	dutycycle 21
-	unknownsfx0x20 12, 225, 12, 5
-	unknownsfx0x20 12, 209, 16, 5
-	unknownsfx0x20 14, 193, 12, 5
-	unknownsfx0x20 8, 193, 10, 5
+	squarenote 12, 225, 12, 5
+	squarenote 12, 209, 16, 5
+	squarenote 14, 193, 12, 5
+	squarenote 8, 193, 10, 5
 	endchannel
 
 
 SFX_Cry20_3_Ch7:
-	unknownnoise0x20 14, 242, 101
-	unknownnoise0x20 13, 226, 85
-	unknownnoise0x20 14, 210, 86
-	unknownnoise0x20 8, 209, 102
+	noisenote 14, 242, 101
+	noisenote 13, 226, 85
+	noisenote 14, 210, 86
+	noisenote 8, 209, 102
 	endchannel

--- a/audio/sfx/cry21_1.asm
+++ b/audio/sfx/cry21_1.asm
@@ -1,26 +1,26 @@
 SFX_Cry21_1_Ch4:
 	dutycycle 27
-	unknownsfx0x20 3, 243, 100, 5
-	unknownsfx0x20 2, 226, 68, 5
-	unknownsfx0x20 5, 209, 34, 5
-	unknownsfx0x20 2, 178, 132, 4
-	unknownsfx0x20 8, 209, 162, 4
-	unknownsfx0x20 3, 243, 36, 5
-	unknownsfx0x20 4, 228, 228, 4
-	unknownsfx0x20 8, 209, 2, 5
+	squarenote 3, 243, 100, 5
+	squarenote 2, 226, 68, 5
+	squarenote 5, 209, 34, 5
+	squarenote 2, 178, 132, 4
+	squarenote 8, 209, 162, 4
+	squarenote 3, 243, 36, 5
+	squarenote 4, 228, 228, 4
+	squarenote 8, 209, 2, 5
 	endchannel
 
 
 SFX_Cry21_1_Ch5:
 	dutycycle 204
-	unknownsfx0x20 3, 211, 96, 5
-	unknownsfx0x20 2, 194, 64, 5
-	unknownsfx0x20 5, 193, 32, 5
-	unknownsfx0x20 2, 146, 128, 4
-	unknownsfx0x20 8, 193, 160, 4
-	unknownsfx0x20 3, 211, 32, 5
-	unknownsfx0x20 3, 196, 224, 4
-	unknownsfx0x20 8, 193, 0, 5
+	squarenote 3, 211, 96, 5
+	squarenote 2, 194, 64, 5
+	squarenote 5, 193, 32, 5
+	squarenote 2, 146, 128, 4
+	squarenote 8, 193, 160, 4
+	squarenote 3, 211, 32, 5
+	squarenote 3, 196, 224, 4
+	squarenote 8, 193, 0, 5
 
 
 SFX_Cry21_1_Ch7:

--- a/audio/sfx/cry21_2.asm
+++ b/audio/sfx/cry21_2.asm
@@ -1,26 +1,26 @@
 SFX_Cry21_2_Ch4:
 	dutycycle 27
-	unknownsfx0x20 3, 243, 100, 5
-	unknownsfx0x20 2, 226, 68, 5
-	unknownsfx0x20 5, 209, 34, 5
-	unknownsfx0x20 2, 178, 132, 4
-	unknownsfx0x20 8, 209, 162, 4
-	unknownsfx0x20 3, 243, 36, 5
-	unknownsfx0x20 4, 228, 228, 4
-	unknownsfx0x20 8, 209, 2, 5
+	squarenote 3, 243, 100, 5
+	squarenote 2, 226, 68, 5
+	squarenote 5, 209, 34, 5
+	squarenote 2, 178, 132, 4
+	squarenote 8, 209, 162, 4
+	squarenote 3, 243, 36, 5
+	squarenote 4, 228, 228, 4
+	squarenote 8, 209, 2, 5
 	endchannel
 
 
 SFX_Cry21_2_Ch5:
 	dutycycle 204
-	unknownsfx0x20 3, 211, 96, 5
-	unknownsfx0x20 2, 194, 64, 5
-	unknownsfx0x20 5, 193, 32, 5
-	unknownsfx0x20 2, 146, 128, 4
-	unknownsfx0x20 8, 193, 160, 4
-	unknownsfx0x20 3, 211, 32, 5
-	unknownsfx0x20 3, 196, 224, 4
-	unknownsfx0x20 8, 193, 0, 5
+	squarenote 3, 211, 96, 5
+	squarenote 2, 194, 64, 5
+	squarenote 5, 193, 32, 5
+	squarenote 2, 146, 128, 4
+	squarenote 8, 193, 160, 4
+	squarenote 3, 211, 32, 5
+	squarenote 3, 196, 224, 4
+	squarenote 8, 193, 0, 5
 
 
 SFX_Cry21_2_Ch7:

--- a/audio/sfx/cry21_3.asm
+++ b/audio/sfx/cry21_3.asm
@@ -1,26 +1,26 @@
 SFX_Cry21_3_Ch4:
 	dutycycle 27
-	unknownsfx0x20 3, 243, 100, 5
-	unknownsfx0x20 2, 226, 68, 5
-	unknownsfx0x20 5, 209, 34, 5
-	unknownsfx0x20 2, 178, 132, 4
-	unknownsfx0x20 8, 209, 162, 4
-	unknownsfx0x20 3, 243, 36, 5
-	unknownsfx0x20 4, 228, 228, 4
-	unknownsfx0x20 8, 209, 2, 5
+	squarenote 3, 243, 100, 5
+	squarenote 2, 226, 68, 5
+	squarenote 5, 209, 34, 5
+	squarenote 2, 178, 132, 4
+	squarenote 8, 209, 162, 4
+	squarenote 3, 243, 36, 5
+	squarenote 4, 228, 228, 4
+	squarenote 8, 209, 2, 5
 	endchannel
 
 
 SFX_Cry21_3_Ch5:
 	dutycycle 204
-	unknownsfx0x20 3, 211, 96, 5
-	unknownsfx0x20 2, 194, 64, 5
-	unknownsfx0x20 5, 193, 32, 5
-	unknownsfx0x20 2, 146, 128, 4
-	unknownsfx0x20 8, 193, 160, 4
-	unknownsfx0x20 3, 211, 32, 5
-	unknownsfx0x20 3, 196, 224, 4
-	unknownsfx0x20 8, 193, 0, 5
+	squarenote 3, 211, 96, 5
+	squarenote 2, 194, 64, 5
+	squarenote 5, 193, 32, 5
+	squarenote 2, 146, 128, 4
+	squarenote 8, 193, 160, 4
+	squarenote 3, 211, 32, 5
+	squarenote 3, 196, 224, 4
+	squarenote 8, 193, 0, 5
 
 
 SFX_Cry21_3_Ch7:

--- a/audio/sfx/cry22_1.asm
+++ b/audio/sfx/cry22_1.asm
@@ -1,24 +1,24 @@
 SFX_Cry22_1_Ch4:
 	dutycycle 17
-	unknownsfx0x20 2, 61, 129, 3
-	unknownsfx0x20 7, 245, 1, 6
-	unknownsfx0x20 1, 194, 129, 4
-	unknownsfx0x20 8, 145, 129, 3
+	squarenote 2, 61, 129, 3
+	squarenote 7, 245, 1, 6
+	squarenote 1, 194, 129, 4
+	squarenote 8, 145, 129, 3
 	endchannel
 
 
 SFX_Cry22_1_Ch5:
 	dutycycle 238
-	unknownsfx0x20 2, 62, 176, 5
-	unknownsfx0x20 7, 213, 93, 7
-	unknownsfx0x20 1, 178, 176, 6
-	unknownsfx0x20 8, 97, 176, 5
+	squarenote 2, 62, 176, 5
+	squarenote 7, 213, 93, 7
+	squarenote 1, 178, 176, 6
+	squarenote 8, 97, 176, 5
 	endchannel
 
 
 SFX_Cry22_1_Ch7:
-	unknownnoise0x20 2, 146, 73
-	unknownnoise0x20 7, 181, 41
-	unknownnoise0x20 1, 162, 57
-	unknownnoise0x20 8, 145, 73
+	noisenote 2, 146, 73
+	noisenote 7, 181, 41
+	noisenote 1, 162, 57
+	noisenote 8, 145, 73
 	endchannel

--- a/audio/sfx/cry22_2.asm
+++ b/audio/sfx/cry22_2.asm
@@ -1,24 +1,24 @@
 SFX_Cry22_2_Ch4:
 	dutycycle 17
-	unknownsfx0x20 2, 61, 129, 3
-	unknownsfx0x20 7, 245, 1, 6
-	unknownsfx0x20 1, 194, 129, 4
-	unknownsfx0x20 8, 145, 129, 3
+	squarenote 2, 61, 129, 3
+	squarenote 7, 245, 1, 6
+	squarenote 1, 194, 129, 4
+	squarenote 8, 145, 129, 3
 	endchannel
 
 
 SFX_Cry22_2_Ch5:
 	dutycycle 238
-	unknownsfx0x20 2, 62, 176, 5
-	unknownsfx0x20 7, 213, 93, 7
-	unknownsfx0x20 1, 178, 176, 6
-	unknownsfx0x20 8, 97, 176, 5
+	squarenote 2, 62, 176, 5
+	squarenote 7, 213, 93, 7
+	squarenote 1, 178, 176, 6
+	squarenote 8, 97, 176, 5
 	endchannel
 
 
 SFX_Cry22_2_Ch7:
-	unknownnoise0x20 2, 146, 73
-	unknownnoise0x20 7, 181, 41
-	unknownnoise0x20 1, 162, 57
-	unknownnoise0x20 8, 145, 73
+	noisenote 2, 146, 73
+	noisenote 7, 181, 41
+	noisenote 1, 162, 57
+	noisenote 8, 145, 73
 	endchannel

--- a/audio/sfx/cry22_3.asm
+++ b/audio/sfx/cry22_3.asm
@@ -1,24 +1,24 @@
 SFX_Cry22_3_Ch4:
 	dutycycle 17
-	unknownsfx0x20 2, 61, 129, 3
-	unknownsfx0x20 7, 245, 1, 6
-	unknownsfx0x20 1, 194, 129, 4
-	unknownsfx0x20 8, 145, 129, 3
+	squarenote 2, 61, 129, 3
+	squarenote 7, 245, 1, 6
+	squarenote 1, 194, 129, 4
+	squarenote 8, 145, 129, 3
 	endchannel
 
 
 SFX_Cry22_3_Ch5:
 	dutycycle 238
-	unknownsfx0x20 2, 62, 176, 5
-	unknownsfx0x20 7, 213, 93, 7
-	unknownsfx0x20 1, 178, 176, 6
-	unknownsfx0x20 8, 97, 176, 5
+	squarenote 2, 62, 176, 5
+	squarenote 7, 213, 93, 7
+	squarenote 1, 178, 176, 6
+	squarenote 8, 97, 176, 5
 	endchannel
 
 
 SFX_Cry22_3_Ch7:
-	unknownnoise0x20 2, 146, 73
-	unknownnoise0x20 7, 181, 41
-	unknownnoise0x20 1, 162, 57
-	unknownnoise0x20 8, 145, 73
+	noisenote 2, 146, 73
+	noisenote 7, 181, 41
+	noisenote 1, 162, 57
+	noisenote 8, 145, 73
 	endchannel

--- a/audio/sfx/cry23_1.asm
+++ b/audio/sfx/cry23_1.asm
@@ -1,25 +1,25 @@
 SFX_Cry23_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 247, 192, 7
-	unknownsfx0x20 6, 228, 193, 7
-	unknownsfx0x20 10, 246, 192, 7
-	unknownsfx0x20 4, 211, 194, 7
-	unknownsfx0x20 8, 193, 192, 7
+	squarenote 15, 247, 192, 7
+	squarenote 6, 228, 193, 7
+	squarenote 10, 246, 192, 7
+	squarenote 4, 211, 194, 7
+	squarenote 8, 193, 192, 7
 	endchannel
 
 
 SFX_Cry23_1_Ch5:
 	dutycycle 95
-	unknownsfx0x20 15, 151, 129, 7
-	unknownsfx0x20 6, 132, 128, 7
-	unknownsfx0x20 10, 150, 129, 7
-	unknownsfx0x20 15, 131, 129, 7
+	squarenote 15, 151, 129, 7
+	squarenote 6, 132, 128, 7
+	squarenote 10, 150, 129, 7
+	squarenote 15, 131, 129, 7
 	endchannel
 
 
 SFX_Cry23_1_Ch7:
-	unknownnoise0x20 3, 242, 60
-	unknownnoise0x20 13, 230, 44
-	unknownnoise0x20 15, 215, 60
-	unknownnoise0x20 8, 193, 44
+	noisenote 3, 242, 60
+	noisenote 13, 230, 44
+	noisenote 15, 215, 60
+	noisenote 8, 193, 44
 	endchannel

--- a/audio/sfx/cry23_2.asm
+++ b/audio/sfx/cry23_2.asm
@@ -1,25 +1,25 @@
 SFX_Cry23_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 247, 192, 7
-	unknownsfx0x20 6, 228, 193, 7
-	unknownsfx0x20 10, 246, 192, 7
-	unknownsfx0x20 4, 211, 194, 7
-	unknownsfx0x20 8, 193, 192, 7
+	squarenote 15, 247, 192, 7
+	squarenote 6, 228, 193, 7
+	squarenote 10, 246, 192, 7
+	squarenote 4, 211, 194, 7
+	squarenote 8, 193, 192, 7
 	endchannel
 
 
 SFX_Cry23_2_Ch5:
 	dutycycle 95
-	unknownsfx0x20 15, 151, 129, 7
-	unknownsfx0x20 6, 132, 128, 7
-	unknownsfx0x20 10, 150, 129, 7
-	unknownsfx0x20 15, 131, 129, 7
+	squarenote 15, 151, 129, 7
+	squarenote 6, 132, 128, 7
+	squarenote 10, 150, 129, 7
+	squarenote 15, 131, 129, 7
 	endchannel
 
 
 SFX_Cry23_2_Ch7:
-	unknownnoise0x20 3, 242, 60
-	unknownnoise0x20 13, 230, 44
-	unknownnoise0x20 15, 215, 60
-	unknownnoise0x20 8, 193, 44
+	noisenote 3, 242, 60
+	noisenote 13, 230, 44
+	noisenote 15, 215, 60
+	noisenote 8, 193, 44
 	endchannel

--- a/audio/sfx/cry23_3.asm
+++ b/audio/sfx/cry23_3.asm
@@ -1,25 +1,25 @@
 SFX_Cry23_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 247, 192, 7
-	unknownsfx0x20 6, 228, 193, 7
-	unknownsfx0x20 10, 246, 192, 7
-	unknownsfx0x20 4, 211, 194, 7
-	unknownsfx0x20 8, 193, 192, 7
+	squarenote 15, 247, 192, 7
+	squarenote 6, 228, 193, 7
+	squarenote 10, 246, 192, 7
+	squarenote 4, 211, 194, 7
+	squarenote 8, 193, 192, 7
 	endchannel
 
 
 SFX_Cry23_3_Ch5:
 	dutycycle 95
-	unknownsfx0x20 15, 151, 129, 7
-	unknownsfx0x20 6, 132, 128, 7
-	unknownsfx0x20 10, 150, 129, 7
-	unknownsfx0x20 15, 131, 129, 7
+	squarenote 15, 151, 129, 7
+	squarenote 6, 132, 128, 7
+	squarenote 10, 150, 129, 7
+	squarenote 15, 131, 129, 7
 	endchannel
 
 
 SFX_Cry23_3_Ch7:
-	unknownnoise0x20 3, 242, 60
-	unknownnoise0x20 13, 230, 44
-	unknownnoise0x20 15, 215, 60
-	unknownnoise0x20 8, 193, 44
+	noisenote 3, 242, 60
+	noisenote 13, 230, 44
+	noisenote 15, 215, 60
+	noisenote 8, 193, 44
 	endchannel

--- a/audio/sfx/cry24_1.asm
+++ b/audio/sfx/cry24_1.asm
@@ -1,33 +1,33 @@
 SFX_Cry24_1_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 247, 128, 6
-	unknownsfx0x20 10, 230, 132, 6
-	unknownsfx0x20 15, 215, 144, 6
-	unknownsfx0x20 8, 213, 144, 6
-	unknownsfx0x20 6, 196, 136, 6
-	unknownsfx0x20 5, 211, 112, 6
-	unknownsfx0x20 4, 211, 96, 6
-	unknownsfx0x20 8, 193, 64, 6
+	squarenote 15, 247, 128, 6
+	squarenote 10, 230, 132, 6
+	squarenote 15, 215, 144, 6
+	squarenote 8, 213, 144, 6
+	squarenote 6, 196, 136, 6
+	squarenote 5, 211, 112, 6
+	squarenote 4, 211, 96, 6
+	squarenote 8, 193, 64, 6
 	endchannel
 
 
 SFX_Cry24_1_Ch5:
 	dutycycle 5
-	unknownsfx0x20 15, 183, 65, 6
-	unknownsfx0x20 10, 150, 66, 6
-	unknownsfx0x20 15, 167, 81, 6
-	unknownsfx0x20 8, 165, 81, 6
-	unknownsfx0x20 6, 148, 71, 6
-	unknownsfx0x20 5, 163, 49, 6
-	unknownsfx0x20 4, 147, 34, 6
-	unknownsfx0x20 8, 113, 1, 6
+	squarenote 15, 183, 65, 6
+	squarenote 10, 150, 66, 6
+	squarenote 15, 167, 81, 6
+	squarenote 8, 165, 81, 6
+	squarenote 6, 148, 71, 6
+	squarenote 5, 163, 49, 6
+	squarenote 4, 147, 34, 6
+	squarenote 8, 113, 1, 6
 	endchannel
 
 
 SFX_Cry24_1_Ch7:
-	unknownnoise0x20 15, 228, 60
-	unknownnoise0x20 10, 199, 76
-	unknownnoise0x20 10, 199, 60
-	unknownnoise0x20 12, 183, 76
-	unknownnoise0x20 15, 162, 92
+	noisenote 15, 228, 60
+	noisenote 10, 199, 76
+	noisenote 10, 199, 60
+	noisenote 12, 183, 76
+	noisenote 15, 162, 92
 	endchannel

--- a/audio/sfx/cry24_2.asm
+++ b/audio/sfx/cry24_2.asm
@@ -1,33 +1,33 @@
 SFX_Cry24_2_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 247, 128, 6
-	unknownsfx0x20 10, 230, 132, 6
-	unknownsfx0x20 15, 215, 144, 6
-	unknownsfx0x20 8, 213, 144, 6
-	unknownsfx0x20 6, 196, 136, 6
-	unknownsfx0x20 5, 211, 112, 6
-	unknownsfx0x20 4, 211, 96, 6
-	unknownsfx0x20 8, 193, 64, 6
+	squarenote 15, 247, 128, 6
+	squarenote 10, 230, 132, 6
+	squarenote 15, 215, 144, 6
+	squarenote 8, 213, 144, 6
+	squarenote 6, 196, 136, 6
+	squarenote 5, 211, 112, 6
+	squarenote 4, 211, 96, 6
+	squarenote 8, 193, 64, 6
 	endchannel
 
 
 SFX_Cry24_2_Ch5:
 	dutycycle 5
-	unknownsfx0x20 15, 183, 65, 6
-	unknownsfx0x20 10, 150, 66, 6
-	unknownsfx0x20 15, 167, 81, 6
-	unknownsfx0x20 8, 165, 81, 6
-	unknownsfx0x20 6, 148, 71, 6
-	unknownsfx0x20 5, 163, 49, 6
-	unknownsfx0x20 4, 147, 34, 6
-	unknownsfx0x20 8, 113, 1, 6
+	squarenote 15, 183, 65, 6
+	squarenote 10, 150, 66, 6
+	squarenote 15, 167, 81, 6
+	squarenote 8, 165, 81, 6
+	squarenote 6, 148, 71, 6
+	squarenote 5, 163, 49, 6
+	squarenote 4, 147, 34, 6
+	squarenote 8, 113, 1, 6
 	endchannel
 
 
 SFX_Cry24_2_Ch7:
-	unknownnoise0x20 15, 228, 60
-	unknownnoise0x20 10, 199, 76
-	unknownnoise0x20 10, 199, 60
-	unknownnoise0x20 12, 183, 76
-	unknownnoise0x20 15, 162, 92
+	noisenote 15, 228, 60
+	noisenote 10, 199, 76
+	noisenote 10, 199, 60
+	noisenote 12, 183, 76
+	noisenote 15, 162, 92
 	endchannel

--- a/audio/sfx/cry24_3.asm
+++ b/audio/sfx/cry24_3.asm
@@ -1,33 +1,33 @@
 SFX_Cry24_3_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 247, 128, 6
-	unknownsfx0x20 10, 230, 132, 6
-	unknownsfx0x20 15, 215, 144, 6
-	unknownsfx0x20 8, 213, 144, 6
-	unknownsfx0x20 6, 196, 136, 6
-	unknownsfx0x20 5, 211, 112, 6
-	unknownsfx0x20 4, 211, 96, 6
-	unknownsfx0x20 8, 193, 64, 6
+	squarenote 15, 247, 128, 6
+	squarenote 10, 230, 132, 6
+	squarenote 15, 215, 144, 6
+	squarenote 8, 213, 144, 6
+	squarenote 6, 196, 136, 6
+	squarenote 5, 211, 112, 6
+	squarenote 4, 211, 96, 6
+	squarenote 8, 193, 64, 6
 	endchannel
 
 
 SFX_Cry24_3_Ch5:
 	dutycycle 5
-	unknownsfx0x20 15, 183, 65, 6
-	unknownsfx0x20 10, 150, 66, 6
-	unknownsfx0x20 15, 167, 81, 6
-	unknownsfx0x20 8, 165, 81, 6
-	unknownsfx0x20 6, 148, 71, 6
-	unknownsfx0x20 5, 163, 49, 6
-	unknownsfx0x20 4, 147, 34, 6
-	unknownsfx0x20 8, 113, 1, 6
+	squarenote 15, 183, 65, 6
+	squarenote 10, 150, 66, 6
+	squarenote 15, 167, 81, 6
+	squarenote 8, 165, 81, 6
+	squarenote 6, 148, 71, 6
+	squarenote 5, 163, 49, 6
+	squarenote 4, 147, 34, 6
+	squarenote 8, 113, 1, 6
 	endchannel
 
 
 SFX_Cry24_3_Ch7:
-	unknownnoise0x20 15, 228, 60
-	unknownnoise0x20 10, 199, 76
-	unknownnoise0x20 10, 199, 60
-	unknownnoise0x20 12, 183, 76
-	unknownnoise0x20 15, 162, 92
+	noisenote 15, 228, 60
+	noisenote 10, 199, 76
+	noisenote 10, 199, 60
+	noisenote 12, 183, 76
+	noisenote 15, 162, 92
 	endchannel

--- a/audio/sfx/cry25_1.asm
+++ b/audio/sfx/cry25_1.asm
@@ -1,26 +1,26 @@
 SFX_Cry25_1_Ch4:
 	dutycycle 165
-	unknownsfx0x20 6, 244, 64, 7
-	unknownsfx0x20 15, 227, 48, 7
-	unknownsfx0x20 4, 244, 64, 7
-	unknownsfx0x20 5, 179, 72, 7
-	unknownsfx0x20 8, 209, 80, 7
+	squarenote 6, 244, 64, 7
+	squarenote 15, 227, 48, 7
+	squarenote 4, 244, 64, 7
+	squarenote 5, 179, 72, 7
+	squarenote 8, 209, 80, 7
 	endchannel
 
 
 SFX_Cry25_1_Ch5:
 	dutycycle 119
-	unknownsfx0x20 6, 195, 18, 7
-	unknownsfx0x20 15, 179, 4, 7
-	unknownsfx0x20 3, 195, 18, 7
-	unknownsfx0x20 4, 195, 33, 7
-	unknownsfx0x20 8, 177, 50, 7
+	squarenote 6, 195, 18, 7
+	squarenote 15, 179, 4, 7
+	squarenote 3, 195, 18, 7
+	squarenote 4, 195, 33, 7
+	squarenote 8, 177, 50, 7
 	endchannel
 
 
 SFX_Cry25_1_Ch7:
-	unknownnoise0x20 8, 214, 44
-	unknownnoise0x20 12, 198, 60
-	unknownnoise0x20 10, 182, 44
-	unknownnoise0x20 8, 145, 28
+	noisenote 8, 214, 44
+	noisenote 12, 198, 60
+	noisenote 10, 182, 44
+	noisenote 8, 145, 28
 	endchannel

--- a/audio/sfx/cry25_2.asm
+++ b/audio/sfx/cry25_2.asm
@@ -1,26 +1,26 @@
 SFX_Cry25_2_Ch4:
 	dutycycle 165
-	unknownsfx0x20 6, 244, 64, 7
-	unknownsfx0x20 15, 227, 48, 7
-	unknownsfx0x20 4, 244, 64, 7
-	unknownsfx0x20 5, 179, 72, 7
-	unknownsfx0x20 8, 209, 80, 7
+	squarenote 6, 244, 64, 7
+	squarenote 15, 227, 48, 7
+	squarenote 4, 244, 64, 7
+	squarenote 5, 179, 72, 7
+	squarenote 8, 209, 80, 7
 	endchannel
 
 
 SFX_Cry25_2_Ch5:
 	dutycycle 119
-	unknownsfx0x20 6, 195, 18, 7
-	unknownsfx0x20 15, 179, 4, 7
-	unknownsfx0x20 3, 195, 18, 7
-	unknownsfx0x20 4, 195, 33, 7
-	unknownsfx0x20 8, 177, 50, 7
+	squarenote 6, 195, 18, 7
+	squarenote 15, 179, 4, 7
+	squarenote 3, 195, 18, 7
+	squarenote 4, 195, 33, 7
+	squarenote 8, 177, 50, 7
 	endchannel
 
 
 SFX_Cry25_2_Ch7:
-	unknownnoise0x20 8, 214, 44
-	unknownnoise0x20 12, 198, 60
-	unknownnoise0x20 10, 182, 44
-	unknownnoise0x20 8, 145, 28
+	noisenote 8, 214, 44
+	noisenote 12, 198, 60
+	noisenote 10, 182, 44
+	noisenote 8, 145, 28
 	endchannel

--- a/audio/sfx/cry25_3.asm
+++ b/audio/sfx/cry25_3.asm
@@ -1,26 +1,26 @@
 SFX_Cry25_3_Ch4:
 	dutycycle 165
-	unknownsfx0x20 6, 244, 64, 7
-	unknownsfx0x20 15, 227, 48, 7
-	unknownsfx0x20 4, 244, 64, 7
-	unknownsfx0x20 5, 179, 72, 7
-	unknownsfx0x20 8, 209, 80, 7
+	squarenote 6, 244, 64, 7
+	squarenote 15, 227, 48, 7
+	squarenote 4, 244, 64, 7
+	squarenote 5, 179, 72, 7
+	squarenote 8, 209, 80, 7
 	endchannel
 
 
 SFX_Cry25_3_Ch5:
 	dutycycle 119
-	unknownsfx0x20 6, 195, 18, 7
-	unknownsfx0x20 15, 179, 4, 7
-	unknownsfx0x20 3, 195, 18, 7
-	unknownsfx0x20 4, 195, 33, 7
-	unknownsfx0x20 8, 177, 50, 7
+	squarenote 6, 195, 18, 7
+	squarenote 15, 179, 4, 7
+	squarenote 3, 195, 18, 7
+	squarenote 4, 195, 33, 7
+	squarenote 8, 177, 50, 7
 	endchannel
 
 
 SFX_Cry25_3_Ch7:
-	unknownnoise0x20 8, 214, 44
-	unknownnoise0x20 12, 198, 60
-	unknownnoise0x20 10, 182, 44
-	unknownnoise0x20 8, 145, 28
+	noisenote 8, 214, 44
+	noisenote 12, 198, 60
+	noisenote 10, 182, 44
+	noisenote 8, 145, 28
 	endchannel

--- a/audio/sfx/cut_1.asm
+++ b/audio/sfx/cut_1.asm
@@ -1,7 +1,7 @@
 SFX_Cut_1_Ch7:
-	unknownnoise0x20 2, 247, 36
-	unknownnoise0x20 2, 247, 52
-	unknownnoise0x20 4, 247, 68
-	unknownnoise0x20 8, 244, 85
-	unknownnoise0x20 8, 241, 68
+	noisenote 2, 247, 36
+	noisenote 2, 247, 52
+	noisenote 4, 247, 68
+	noisenote 8, 244, 85
+	noisenote 8, 241, 68
 	endchannel

--- a/audio/sfx/cut_3.asm
+++ b/audio/sfx/cut_3.asm
@@ -1,7 +1,7 @@
 SFX_Cut_3_Ch7:
-	unknownnoise0x20 2, 247, 36
-	unknownnoise0x20 2, 247, 52
-	unknownnoise0x20 4, 247, 68
-	unknownnoise0x20 8, 244, 85
-	unknownnoise0x20 8, 241, 68
+	noisenote 2, 247, 36
+	noisenote 2, 247, 52
+	noisenote 4, 247, 68
+	noisenote 8, 244, 85
+	noisenote 8, 241, 68
 	endchannel

--- a/audio/sfx/cymbal1_1.asm
+++ b/audio/sfx/cymbal1_1.asm
@@ -1,3 +1,3 @@
 SFX_Cymbal1_1_Ch7:
-	unknownnoise0x20 0, 161, 16
+	noisenote 0, 161, 16
 	endchannel

--- a/audio/sfx/cymbal1_2.asm
+++ b/audio/sfx/cymbal1_2.asm
@@ -1,3 +1,3 @@
 SFX_Cymbal1_2_Ch7:
-	unknownnoise0x20 0, 161, 16
+	noisenote 0, 161, 16
 	endchannel

--- a/audio/sfx/cymbal1_3.asm
+++ b/audio/sfx/cymbal1_3.asm
@@ -1,3 +1,3 @@
 SFX_Cymbal1_3_Ch7:
-	unknownnoise0x20 0, 161, 16
+	noisenote 0, 161, 16
 	endchannel

--- a/audio/sfx/cymbal2_1.asm
+++ b/audio/sfx/cymbal2_1.asm
@@ -1,3 +1,3 @@
 SFX_Cymbal2_1_Ch7:
-	unknownnoise0x20 0, 162, 17
+	noisenote 0, 162, 17
 	endchannel

--- a/audio/sfx/cymbal2_2.asm
+++ b/audio/sfx/cymbal2_2.asm
@@ -1,3 +1,3 @@
 SFX_Cymbal2_2_Ch7:
-	unknownnoise0x20 0, 162, 17
+	noisenote 0, 162, 17
 	endchannel

--- a/audio/sfx/cymbal2_3.asm
+++ b/audio/sfx/cymbal2_3.asm
@@ -1,3 +1,3 @@
 SFX_Cymbal2_3_Ch7:
-	unknownnoise0x20 0, 162, 17
+	noisenote 0, 162, 17
 	endchannel

--- a/audio/sfx/cymbal3_1.asm
+++ b/audio/sfx/cymbal3_1.asm
@@ -1,3 +1,3 @@
 SFX_Cymbal3_1_Ch7:
-	unknownnoise0x20 0, 162, 80
+	noisenote 0, 162, 80
 	endchannel

--- a/audio/sfx/cymbal3_2.asm
+++ b/audio/sfx/cymbal3_2.asm
@@ -1,3 +1,3 @@
 SFX_Cymbal3_2_Ch7:
-	unknownnoise0x20 0, 162, 80
+	noisenote 0, 162, 80
 	endchannel

--- a/audio/sfx/cymbal3_3.asm
+++ b/audio/sfx/cymbal3_3.asm
@@ -1,3 +1,3 @@
 SFX_Cymbal3_3_Ch7:
-	unknownnoise0x20 0, 162, 80
+	noisenote 0, 162, 80
 	endchannel

--- a/audio/sfx/damage.asm
+++ b/audio/sfx/damage.asm
@@ -1,5 +1,5 @@
 SFX_Damage_Ch7:
-	unknownnoise0x20 2, 244, 68
-	unknownnoise0x20 2, 244, 20
-	unknownnoise0x20 15, 241, 50
+	noisenote 2, 244, 68
+	noisenote 2, 244, 20
+	noisenote 15, 241, 50
 	endchannel

--- a/audio/sfx/denied_1.asm
+++ b/audio/sfx/denied_1.asm
@@ -1,18 +1,18 @@
 SFX_Denied_1_Ch4:
 	duty 3
-	unknownsfx0x10 90
-	unknownsfx0x20 4, 240, 0, 5
-	unknownsfx0x10 8
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 1, 0, 0, 0
+	pitchenvelope 90
+	squarenote 4, 240, 0, 5
+	pitchenvelope 8
+	squarenote 4, 0, 0, 0
+	squarenote 15, 240, 0, 5
+	squarenote 1, 0, 0, 0
 	endchannel
 
 
 SFX_Denied_1_Ch5:
 	duty 3
-	unknownsfx0x20 4, 240, 1, 4
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 15, 240, 1, 4
-	unknownsfx0x20 1, 0, 0, 0
+	squarenote 4, 240, 1, 4
+	squarenote 4, 0, 0, 0
+	squarenote 15, 240, 1, 4
+	squarenote 1, 0, 0, 0
 	endchannel

--- a/audio/sfx/denied_3.asm
+++ b/audio/sfx/denied_3.asm
@@ -1,18 +1,18 @@
 SFX_Denied_3_Ch4:
 	duty 3
-	unknownsfx0x10 90
-	unknownsfx0x20 4, 240, 0, 5
-	unknownsfx0x10 8
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 1, 0, 0, 0
+	pitchenvelope 90
+	squarenote 4, 240, 0, 5
+	pitchenvelope 8
+	squarenote 4, 0, 0, 0
+	squarenote 15, 240, 0, 5
+	squarenote 1, 0, 0, 0
 	endchannel
 
 
 SFX_Denied_3_Ch5:
 	duty 3
-	unknownsfx0x20 4, 240, 1, 4
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 15, 240, 1, 4
-	unknownsfx0x20 1, 0, 0, 0
+	squarenote 4, 240, 1, 4
+	squarenote 4, 0, 0, 0
+	squarenote 15, 240, 1, 4
+	squarenote 1, 0, 0, 0
 	endchannel

--- a/audio/sfx/dex_page_added.asm
+++ b/audio/sfx/dex_page_added.asm
@@ -1,15 +1,15 @@
 SFX_Dex_Page_Added_Ch4:
 	duty 2
-	unknownsfx0x10 68
-	unknownsfx0x20 15, 240, 240, 4
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 242, 80, 6
-	unknownsfx0x10 8
+	pitchenvelope 68
+	squarenote 15, 240, 240, 4
+	pitchenvelope 23
+	squarenote 15, 242, 80, 6
+	pitchenvelope 8
 	endchannel
 
 
 SFX_Dex_Page_Added_Ch5:
 	duty 2
-	unknownsfx0x20 15, 146, 0, 6
-	unknownsfx0x20 15, 146, 130, 7
+	squarenote 15, 146, 0, 6
+	squarenote 15, 146, 130, 7
 	endchannel

--- a/audio/sfx/doubleslap.asm
+++ b/audio/sfx/doubleslap.asm
@@ -1,4 +1,4 @@
 SFX_Doubleslap_Ch7:
-	unknownnoise0x20 8, 241, 50
-	unknownnoise0x20 8, 241, 51
+	noisenote 8, 241, 50
+	noisenote 8, 241, 51
 	endchannel

--- a/audio/sfx/enter_pc_1.asm
+++ b/audio/sfx/enter_pc_1.asm
@@ -1,7 +1,7 @@
 SFX_Enter_PC_1_Ch4:
 	duty 2
-	unknownsfx0x20 6, 240, 0, 7
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 6, 240, 0, 7
-	unknownsfx0x20 1, 0, 0, 0
+	squarenote 6, 240, 0, 7
+	squarenote 4, 0, 0, 0
+	squarenote 6, 240, 0, 7
+	squarenote 1, 0, 0, 0
 	endchannel

--- a/audio/sfx/enter_pc_3.asm
+++ b/audio/sfx/enter_pc_3.asm
@@ -1,7 +1,7 @@
 SFX_Enter_PC_3_Ch4:
 	duty 2
-	unknownsfx0x20 4, 240, 0, 7
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 4, 240, 0, 7
-	unknownsfx0x20 1, 0, 0, 0
+	squarenote 4, 240, 0, 7
+	squarenote 4, 0, 0, 0
+	squarenote 4, 240, 0, 7
+	squarenote 1, 0, 0, 0
 	endchannel

--- a/audio/sfx/faint_fall.asm
+++ b/audio/sfx/faint_fall.asm
@@ -1,6 +1,6 @@
 SFX_Faint_Fall_Ch4:
 	duty 1
-	unknownsfx0x10 175
-	unknownsfx0x20 15, 242, 128, 7
-	unknownsfx0x10 8
+	pitchenvelope 175
+	squarenote 15, 242, 128, 7
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/faint_thud.asm
+++ b/audio/sfx/faint_thud.asm
@@ -1,11 +1,11 @@
 SFX_Faint_Thud_Ch4:
-	unknownsfx0x20 15, 209, 0, 2
-	unknownsfx0x10 8
+	squarenote 15, 209, 0, 2
+	pitchenvelope 8
 	endchannel
 
 
 SFX_Faint_Thud_Ch7:
-	unknownnoise0x20 4, 245, 51
-	unknownnoise0x20 8, 244, 34
-	unknownnoise0x20 15, 242, 33
+	noisenote 4, 245, 51
+	noisenote 8, 244, 34
+	noisenote 15, 242, 33
 	endchannel

--- a/audio/sfx/fly_1.asm
+++ b/audio/sfx/fly_1.asm
@@ -1,18 +1,18 @@
 SFX_Fly_1_Ch7:
-	unknownnoise0x20 2, 241, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 161, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 209, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 129, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 177, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 97, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 145, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 65, 18
-	unknownnoise0x20 2, 0, 0
+	noisenote 2, 241, 18
+	noisenote 2, 0, 0
+	noisenote 2, 161, 18
+	noisenote 2, 0, 0
+	noisenote 2, 209, 18
+	noisenote 2, 0, 0
+	noisenote 2, 129, 18
+	noisenote 2, 0, 0
+	noisenote 2, 177, 18
+	noisenote 2, 0, 0
+	noisenote 2, 97, 18
+	noisenote 2, 0, 0
+	noisenote 2, 145, 18
+	noisenote 2, 0, 0
+	noisenote 2, 65, 18
+	noisenote 2, 0, 0
 	endchannel

--- a/audio/sfx/fly_3.asm
+++ b/audio/sfx/fly_3.asm
@@ -1,18 +1,18 @@
 SFX_Fly_3_Ch7:
-	unknownnoise0x20 2, 241, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 161, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 209, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 129, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 177, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 97, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 145, 18
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 65, 18
-	unknownnoise0x20 2, 0, 0
+	noisenote 2, 241, 18
+	noisenote 2, 0, 0
+	noisenote 2, 161, 18
+	noisenote 2, 0, 0
+	noisenote 2, 209, 18
+	noisenote 2, 0, 0
+	noisenote 2, 129, 18
+	noisenote 2, 0, 0
+	noisenote 2, 177, 18
+	noisenote 2, 0, 0
+	noisenote 2, 97, 18
+	noisenote 2, 0, 0
+	noisenote 2, 145, 18
+	noisenote 2, 0, 0
+	noisenote 2, 65, 18
+	noisenote 2, 0, 0
 	endchannel

--- a/audio/sfx/go_inside_1.asm
+++ b/audio/sfx/go_inside_1.asm
@@ -1,4 +1,4 @@
 SFX_Go_Inside_1_Ch7:
-	unknownnoise0x20 9, 241, 68
-	unknownnoise0x20 8, 209, 67
+	noisenote 9, 241, 68
+	noisenote 8, 209, 67
 	endchannel

--- a/audio/sfx/go_inside_3.asm
+++ b/audio/sfx/go_inside_3.asm
@@ -1,4 +1,4 @@
 SFX_Go_Inside_3_Ch7:
-	unknownnoise0x20 9, 241, 68
-	unknownnoise0x20 8, 209, 67
+	noisenote 9, 241, 68
+	noisenote 8, 209, 67
 	endchannel

--- a/audio/sfx/go_outside_1.asm
+++ b/audio/sfx/go_outside_1.asm
@@ -1,7 +1,7 @@
 SFX_Go_Outside_1_Ch7:
-	unknownnoise0x20 2, 241, 84
-	unknownnoise0x20 12, 113, 35
-	unknownnoise0x20 2, 177, 84
-	unknownnoise0x20 12, 97, 35
-	unknownnoise0x20 6, 65, 84
+	noisenote 2, 241, 84
+	noisenote 12, 113, 35
+	noisenote 2, 177, 84
+	noisenote 12, 97, 35
+	noisenote 6, 65, 84
 	endchannel

--- a/audio/sfx/go_outside_3.asm
+++ b/audio/sfx/go_outside_3.asm
@@ -1,7 +1,7 @@
 SFX_Go_Outside_3_Ch7:
-	unknownnoise0x20 2, 241, 84
-	unknownnoise0x20 12, 113, 35
-	unknownnoise0x20 2, 177, 84
-	unknownnoise0x20 12, 97, 35
-	unknownnoise0x20 6, 65, 84
+	noisenote 2, 241, 84
+	noisenote 12, 113, 35
+	noisenote 2, 177, 84
+	noisenote 12, 97, 35
+	noisenote 6, 65, 84
 	endchannel

--- a/audio/sfx/heal_ailment_1.asm
+++ b/audio/sfx/heal_ailment_1.asm
@@ -1,9 +1,9 @@
 SFX_Heal_Ailment_1_Ch4:
 	duty 2
-	unknownsfx0x10 20
-	unknownsfx0x20 4, 242, 0, 6
-	unknownsfx0x20 4, 242, 0, 6
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 242, 0, 6
-	unknownsfx0x10 8
+	pitchenvelope 20
+	squarenote 4, 242, 0, 6
+	squarenote 4, 242, 0, 6
+	pitchenvelope 23
+	squarenote 15, 242, 0, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/heal_ailment_2.asm
+++ b/audio/sfx/heal_ailment_2.asm
@@ -1,9 +1,9 @@
 SFX_Heal_Ailment_2_Ch4:
 	duty 2
-	unknownsfx0x10 20
-	unknownsfx0x20 4, 242, 0, 6
-	unknownsfx0x20 4, 242, 0, 6
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 242, 0, 6
-	unknownsfx0x10 8
+	pitchenvelope 20
+	squarenote 4, 242, 0, 6
+	squarenote 4, 242, 0, 6
+	pitchenvelope 23
+	squarenote 15, 242, 0, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/heal_ailment_3.asm
+++ b/audio/sfx/heal_ailment_3.asm
@@ -1,9 +1,9 @@
 SFX_Heal_Ailment_3_Ch4:
 	duty 2
-	unknownsfx0x10 20
-	unknownsfx0x20 4, 242, 0, 6
-	unknownsfx0x20 4, 242, 0, 6
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 242, 0, 6
-	unknownsfx0x10 8
+	pitchenvelope 20
+	squarenote 4, 242, 0, 6
+	squarenote 4, 242, 0, 6
+	pitchenvelope 23
+	squarenote 15, 242, 0, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/heal_hp_1.asm
+++ b/audio/sfx/heal_hp_1.asm
@@ -1,7 +1,7 @@
 SFX_Heal_HP_1_Ch4:
 	duty 2
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 240, 240, 4
-	unknownsfx0x20 15, 242, 80, 6
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 240, 240, 4
+	squarenote 15, 242, 80, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/heal_hp_2.asm
+++ b/audio/sfx/heal_hp_2.asm
@@ -1,7 +1,7 @@
 SFX_Heal_HP_2_Ch4:
 	duty 2
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 240, 240, 4
-	unknownsfx0x20 15, 242, 80, 6
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 240, 240, 4
+	squarenote 15, 242, 80, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/heal_hp_3.asm
+++ b/audio/sfx/heal_hp_3.asm
@@ -1,7 +1,7 @@
 SFX_Heal_HP_3_Ch4:
 	duty 2
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 240, 240, 4
-	unknownsfx0x20 15, 242, 80, 6
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 240, 240, 4
+	squarenote 15, 242, 80, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/healing_machine_1.asm
+++ b/audio/sfx/healing_machine_1.asm
@@ -1,9 +1,9 @@
 SFX_Healing_Machine_1_Ch4:
 	duty 2
-	unknownsfx0x10 44
-	unknownsfx0x20 4, 242, 0, 5
-	unknownsfx0x10 34
-	unknownsfx0x20 2, 241, 0, 5
-	unknownsfx0x10 8
-	unknownsfx0x20 1, 0, 0, 0
+	pitchenvelope 44
+	squarenote 4, 242, 0, 5
+	pitchenvelope 34
+	squarenote 2, 241, 0, 5
+	pitchenvelope 8
+	squarenote 1, 0, 0, 0
 	endchannel

--- a/audio/sfx/healing_machine_3.asm
+++ b/audio/sfx/healing_machine_3.asm
@@ -1,9 +1,9 @@
 SFX_Healing_Machine_3_Ch4:
 	duty 2
-	unknownsfx0x10 44
-	unknownsfx0x20 4, 242, 0, 5
-	unknownsfx0x10 34
-	unknownsfx0x20 2, 241, 0, 5
-	unknownsfx0x10 8
-	unknownsfx0x20 1, 0, 0, 0
+	pitchenvelope 44
+	squarenote 4, 242, 0, 5
+	pitchenvelope 34
+	squarenote 2, 241, 0, 5
+	pitchenvelope 8
+	squarenote 1, 0, 0, 0
 	endchannel

--- a/audio/sfx/horn_drill.asm
+++ b/audio/sfx/horn_drill.asm
@@ -1,6 +1,6 @@
 SFX_Horn_Drill_Ch7:
-	unknownnoise0x20 3, 146, 49
-	unknownnoise0x20 3, 178, 50
-	unknownnoise0x20 3, 194, 51
-	unknownnoise0x20 8, 241, 84
+	noisenote 3, 146, 49
+	noisenote 3, 178, 50
+	noisenote 3, 194, 51
+	noisenote 8, 241, 84
 	endchannel

--- a/audio/sfx/intro_crash.asm
+++ b/audio/sfx/intro_crash.asm
@@ -1,4 +1,4 @@
 SFX_Intro_Crash_Ch7:
-	unknownnoise0x20 2, 210, 50
-	unknownnoise0x20 15, 242, 67
+	noisenote 2, 210, 50
+	noisenote 15, 242, 67
 	endchannel

--- a/audio/sfx/intro_hip.asm
+++ b/audio/sfx/intro_hip.asm
@@ -1,6 +1,6 @@
 SFX_Intro_Hip_Ch4:
 	duty 2
-	unknownsfx0x10 38
-	unknownsfx0x20 12, 194, 64, 7
-	unknownsfx0x10 8
+	pitchenvelope 38
+	squarenote 12, 194, 64, 7
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/intro_hop.asm
+++ b/audio/sfx/intro_hop.asm
@@ -1,6 +1,6 @@
 SFX_Intro_Hop_Ch4:
 	duty 2
-	unknownsfx0x10 38
-	unknownsfx0x20 12, 194, 128, 6
-	unknownsfx0x10 8
+	pitchenvelope 38
+	squarenote 12, 194, 128, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/intro_lunge.asm
+++ b/audio/sfx/intro_lunge.asm
@@ -1,10 +1,10 @@
 SFX_Intro_Lunge_Ch7:
-	unknownnoise0x20 6, 32, 16
-	unknownnoise0x20 6, 47, 64
-	unknownnoise0x20 6, 79, 65
-	unknownnoise0x20 6, 143, 65
-	unknownnoise0x20 6, 207, 66
-	unknownnoise0x20 8, 215, 66
-	unknownnoise0x20 15, 231, 67
-	unknownnoise0x20 15, 242, 67
+	noisenote 6, 32, 16
+	noisenote 6, 47, 64
+	noisenote 6, 79, 65
+	noisenote 6, 143, 65
+	noisenote 6, 207, 66
+	noisenote 8, 215, 66
+	noisenote 15, 231, 67
+	noisenote 15, 242, 67
 	endchannel

--- a/audio/sfx/intro_raise.asm
+++ b/audio/sfx/intro_raise.asm
@@ -1,5 +1,5 @@
 SFX_Intro_Raise_Ch7:
-	unknownnoise0x20 2, 111, 33
-	unknownnoise0x20 2, 175, 49
-	unknownnoise0x20 15, 242, 65
+	noisenote 2, 111, 33
+	noisenote 2, 175, 49
+	noisenote 15, 242, 65
 	endchannel

--- a/audio/sfx/intro_whoosh.asm
+++ b/audio/sfx/intro_whoosh.asm
@@ -1,7 +1,7 @@
 SFX_Intro_Whoosh_Ch7:
-	unknownnoise0x20 4, 44, 32
-	unknownnoise0x20 3, 160, 32
-	unknownnoise0x20 3, 176, 33
-	unknownnoise0x20 3, 192, 34
-	unknownnoise0x20 15, 210, 36
+	noisenote 4, 44, 32
+	noisenote 3, 160, 32
+	noisenote 3, 176, 33
+	noisenote 3, 192, 34
+	noisenote 15, 210, 36
 	endchannel

--- a/audio/sfx/ledge_1.asm
+++ b/audio/sfx/ledge_1.asm
@@ -1,6 +1,6 @@
 SFX_Ledge_1_Ch4:
 	duty 2
-	unknownsfx0x10 149
-	unknownsfx0x20 15, 242, 0, 4
-	unknownsfx0x10 8
+	pitchenvelope 149
+	squarenote 15, 242, 0, 4
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/ledge_3.asm
+++ b/audio/sfx/ledge_3.asm
@@ -1,6 +1,6 @@
 SFX_Ledge_3_Ch4:
 	duty 2
-	unknownsfx0x10 149
-	unknownsfx0x20 15, 242, 0, 4
-	unknownsfx0x10 8
+	pitchenvelope 149
+	squarenote 15, 242, 0, 4
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/muted_snare1_1.asm
+++ b/audio/sfx/muted_snare1_1.asm
@@ -1,4 +1,4 @@
 SFX_Muted_Snare1_1_Ch7:
-	unknownnoise0x20 0, 161, 24
-	unknownnoise0x20 0, 49, 51
+	noisenote 0, 161, 24
+	noisenote 0, 49, 51
 	endchannel

--- a/audio/sfx/muted_snare1_2.asm
+++ b/audio/sfx/muted_snare1_2.asm
@@ -1,4 +1,4 @@
 SFX_Muted_Snare1_2_Ch7:
-	unknownnoise0x20 0, 161, 24
-	unknownnoise0x20 0, 49, 51
+	noisenote 0, 161, 24
+	noisenote 0, 49, 51
 	endchannel

--- a/audio/sfx/muted_snare1_3.asm
+++ b/audio/sfx/muted_snare1_3.asm
@@ -1,4 +1,4 @@
 SFX_Muted_Snare1_3_Ch7:
-	unknownnoise0x20 0, 161, 24
-	unknownnoise0x20 0, 49, 51
+	noisenote 0, 161, 24
+	noisenote 0, 49, 51
 	endchannel

--- a/audio/sfx/muted_snare2_1.asm
+++ b/audio/sfx/muted_snare2_1.asm
@@ -1,3 +1,3 @@
 SFX_Muted_Snare2_1_Ch7:
-	unknownnoise0x20 0, 145, 34
+	noisenote 0, 145, 34
 	endchannel

--- a/audio/sfx/muted_snare2_2.asm
+++ b/audio/sfx/muted_snare2_2.asm
@@ -1,3 +1,3 @@
 SFX_Muted_Snare2_2_Ch7:
-	unknownnoise0x20 0, 145, 34
+	noisenote 0, 145, 34
 	endchannel

--- a/audio/sfx/muted_snare2_3.asm
+++ b/audio/sfx/muted_snare2_3.asm
@@ -1,3 +1,3 @@
 SFX_Muted_Snare2_3_Ch7:
-	unknownnoise0x20 0, 145, 34
+	noisenote 0, 145, 34
 	endchannel

--- a/audio/sfx/muted_snare3_1.asm
+++ b/audio/sfx/muted_snare3_1.asm
@@ -1,3 +1,3 @@
 SFX_Muted_Snare3_1_Ch7:
-	unknownnoise0x20 0, 113, 34
+	noisenote 0, 113, 34
 	endchannel

--- a/audio/sfx/muted_snare3_2.asm
+++ b/audio/sfx/muted_snare3_2.asm
@@ -1,3 +1,3 @@
 SFX_Muted_Snare3_2_Ch7:
-	unknownnoise0x20 0, 113, 34
+	noisenote 0, 113, 34
 	endchannel

--- a/audio/sfx/muted_snare3_3.asm
+++ b/audio/sfx/muted_snare3_3.asm
@@ -1,3 +1,3 @@
 SFX_Muted_Snare3_3_Ch7:
-	unknownnoise0x20 0, 113, 34
+	noisenote 0, 113, 34
 	endchannel

--- a/audio/sfx/muted_snare4_1.asm
+++ b/audio/sfx/muted_snare4_1.asm
@@ -1,3 +1,3 @@
 SFX_Muted_Snare4_1_Ch7:
-	unknownnoise0x20 0, 97, 34
+	noisenote 0, 97, 34
 	endchannel

--- a/audio/sfx/muted_snare4_2.asm
+++ b/audio/sfx/muted_snare4_2.asm
@@ -1,3 +1,3 @@
 SFX_Muted_Snare4_2_Ch7:
-	unknownnoise0x20 0, 97, 34
+	noisenote 0, 97, 34
 	endchannel

--- a/audio/sfx/muted_snare4_3.asm
+++ b/audio/sfx/muted_snare4_3.asm
@@ -1,3 +1,3 @@
 SFX_Muted_Snare4_3_Ch7:
-	unknownnoise0x20 0, 97, 34
+	noisenote 0, 97, 34
 	endchannel

--- a/audio/sfx/not_very_effective.asm
+++ b/audio/sfx/not_very_effective.asm
@@ -1,6 +1,6 @@
 SFX_Not_Very_Effective_Ch7:
-	unknownnoise0x20 4, 143, 85
-	unknownnoise0x20 2, 244, 68
-	unknownnoise0x20 8, 244, 34
-	unknownnoise0x20 15, 242, 33
+	noisenote 4, 143, 85
+	noisenote 2, 244, 68
+	noisenote 8, 244, 34
+	noisenote 15, 242, 33
 	endchannel

--- a/audio/sfx/peck.asm
+++ b/audio/sfx/peck.asm
@@ -1,3 +1,3 @@
 SFX_Peck_Ch7:
-	unknownnoise0x20 2, 161, 18
+	noisenote 2, 161, 18
 	endchannel

--- a/audio/sfx/poisoned_1.asm
+++ b/audio/sfx/poisoned_1.asm
@@ -1,8 +1,8 @@
 SFX_Poisoned_1_Ch4:
 	duty 0
-	unknownsfx0x10 20
-	unknownsfx0x20 4, 242, 0, 6
+	pitchenvelope 20
+	squarenote 4, 242, 0, 6
 	loopchannel 4, SFX_Poisoned_1_Ch4
-	unknownsfx0x20 15, 243, 0, 6
-	unknownsfx0x10 8
+	squarenote 15, 243, 0, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/poisoned_3.asm
+++ b/audio/sfx/poisoned_3.asm
@@ -1,8 +1,8 @@
 SFX_Poisoned_3_Ch4:
 	duty 0
-	unknownsfx0x10 20
-	unknownsfx0x20 4, 242, 0, 6
+	pitchenvelope 20
+	squarenote 4, 242, 0, 6
 	loopchannel 4, SFX_Poisoned_3_Ch4
-	unknownsfx0x20 15, 243, 0, 6
-	unknownsfx0x10 8
+	squarenote 15, 243, 0, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/pound.asm
+++ b/audio/sfx/pound.asm
@@ -1,3 +1,3 @@
 SFX_Pound_Ch7:
-	unknownnoise0x20 2, 161, 34
+	noisenote 2, 161, 34
 	endchannel

--- a/audio/sfx/press_ab_1.asm
+++ b/audio/sfx/press_ab_1.asm
@@ -1,7 +1,7 @@
 SFX_Press_AB_1_Ch4:
 	duty 2
-	unknownsfx0x20 0, 145, 192, 7
-	unknownsfx0x20 0, 129, 208, 7
-	unknownsfx0x20 0, 145, 192, 7
-	unknownsfx0x20 12, 161, 208, 7
+	squarenote 0, 145, 192, 7
+	squarenote 0, 129, 208, 7
+	squarenote 0, 145, 192, 7
+	squarenote 12, 161, 208, 7
 	endchannel

--- a/audio/sfx/press_ab_2.asm
+++ b/audio/sfx/press_ab_2.asm
@@ -1,7 +1,7 @@
 SFX_Press_AB_2_Ch4:
 	duty 2
-	unknownsfx0x20 0, 145, 192, 7
-	unknownsfx0x20 0, 129, 208, 7
-	unknownsfx0x20 0, 145, 192, 7
-	unknownsfx0x20 12, 161, 208, 7
+	squarenote 0, 145, 192, 7
+	squarenote 0, 129, 208, 7
+	squarenote 0, 145, 192, 7
+	squarenote 12, 161, 208, 7
 	endchannel

--- a/audio/sfx/press_ab_3.asm
+++ b/audio/sfx/press_ab_3.asm
@@ -1,7 +1,7 @@
 SFX_Press_AB_3_Ch4:
 	duty 2
-	unknownsfx0x20 0, 145, 192, 7
-	unknownsfx0x20 0, 129, 208, 7
-	unknownsfx0x20 0, 145, 192, 7
-	unknownsfx0x20 12, 161, 208, 7
+	squarenote 0, 145, 192, 7
+	squarenote 0, 129, 208, 7
+	squarenote 0, 145, 192, 7
+	squarenote 12, 161, 208, 7
 	endchannel

--- a/audio/sfx/psybeam.asm
+++ b/audio/sfx/psybeam.asm
@@ -1,25 +1,25 @@
 SFX_Psybeam_Ch4:
 	dutycycle 161
-	unknownsfx0x20 10, 241, 64, 6
-	unknownsfx0x20 10, 243, 128, 6
-	unknownsfx0x20 10, 242, 32, 6
+	squarenote 10, 241, 64, 6
+	squarenote 10, 243, 128, 6
+	squarenote 10, 242, 32, 6
 	loopchannel 4, SFX_Psybeam_Ch4
-	unknownsfx0x20 10, 241, 64, 6
+	squarenote 10, 241, 64, 6
 	endchannel
 
 
 SFX_Psybeam_Ch5:
 	dutycycle 179
-	unknownsfx0x20 10, 243, 113, 5
-	unknownsfx0x20 7, 227, 49, 5
-	unknownsfx0x20 10, 241, 81, 5
+	squarenote 10, 243, 113, 5
+	squarenote 7, 227, 49, 5
+	squarenote 10, 241, 81, 5
 	loopchannel 4, SFX_Psybeam_Ch5
-	unknownsfx0x20 10, 241, 113, 5
+	squarenote 10, 241, 113, 5
 	endchannel
 
 
 SFX_Psybeam_Ch7:
-	unknownnoise0x20 2, 209, 74
-	unknownnoise0x20 2, 210, 42
+	noisenote 2, 209, 74
+	noisenote 2, 210, 42
 	loopchannel 21, SFX_Psybeam_Ch7
 	endchannel

--- a/audio/sfx/psychic_m.asm
+++ b/audio/sfx/psychic_m.asm
@@ -1,32 +1,32 @@
 SFX_Psychic_M_Ch4:
 	duty 2
-	unknownsfx0x10 247
-	unknownsfx0x20 8, 196, 189, 7
-	unknownsfx0x20 8, 196, 190, 7
-	unknownsfx0x20 8, 196, 191, 7
-	unknownsfx0x20 8, 196, 192, 7
-	unknownsfx0x20 15, 196, 193, 7
-	unknownsfx0x20 15, 242, 192, 7
-	unknownsfx0x10 8
+	pitchenvelope 247
+	squarenote 8, 196, 189, 7
+	squarenote 8, 196, 190, 7
+	squarenote 8, 196, 191, 7
+	squarenote 8, 196, 192, 7
+	squarenote 15, 196, 193, 7
+	squarenote 15, 242, 192, 7
+	pitchenvelope 8
 	endchannel
 
 
 SFX_Psychic_M_Ch5:
 	duty 2
-	unknownsfx0x20 8, 196, 112, 7
-	unknownsfx0x20 8, 196, 97, 7
-	unknownsfx0x20 8, 196, 98, 7
-	unknownsfx0x20 8, 196, 99, 7
-	unknownsfx0x20 15, 196, 100, 7
-	unknownsfx0x20 15, 242, 100, 7
+	squarenote 8, 196, 112, 7
+	squarenote 8, 196, 97, 7
+	squarenote 8, 196, 98, 7
+	squarenote 8, 196, 99, 7
+	squarenote 15, 196, 100, 7
+	squarenote 15, 242, 100, 7
 	endchannel
 
 
 SFX_Psychic_M_Ch7:
-	unknownnoise0x20 15, 63, 20
-	unknownnoise0x20 15, 207, 19
-	unknownnoise0x20 15, 207, 18
-	unknownnoise0x20 15, 207, 17
-	unknownnoise0x20 15, 207, 16
-	unknownnoise0x20 15, 194, 16
+	noisenote 15, 63, 20
+	noisenote 15, 207, 19
+	noisenote 15, 207, 18
+	noisenote 15, 207, 17
+	noisenote 15, 207, 16
+	noisenote 15, 194, 16
 	endchannel

--- a/audio/sfx/purchase_1.asm
+++ b/audio/sfx/purchase_1.asm
@@ -1,13 +1,13 @@
 SFX_Purchase_1_Ch4:
 	duty 2
-	unknownsfx0x20 4, 225, 0, 7
-	unknownsfx0x20 8, 242, 224, 7
+	squarenote 4, 225, 0, 7
+	squarenote 8, 242, 224, 7
 	endchannel
 
 
 SFX_Purchase_1_Ch5:
 	duty 2
-	unknownsfx0x20 1, 8, 0, 0
-	unknownsfx0x20 4, 145, 193, 6
-	unknownsfx0x20 8, 162, 161, 7
+	squarenote 1, 8, 0, 0
+	squarenote 4, 145, 193, 6
+	squarenote 8, 162, 161, 7
 	endchannel

--- a/audio/sfx/purchase_3.asm
+++ b/audio/sfx/purchase_3.asm
@@ -1,13 +1,13 @@
 SFX_Purchase_3_Ch4:
 	duty 2
-	unknownsfx0x20 4, 225, 0, 7
-	unknownsfx0x20 8, 242, 224, 7
+	squarenote 4, 225, 0, 7
+	squarenote 8, 242, 224, 7
 	endchannel
 
 
 SFX_Purchase_3_Ch5:
 	duty 2
-	unknownsfx0x20 1, 8, 0, 0
-	unknownsfx0x20 4, 145, 193, 6
-	unknownsfx0x20 8, 162, 161, 7
+	squarenote 1, 8, 0, 0
+	squarenote 4, 145, 193, 6
+	squarenote 8, 162, 161, 7
 	endchannel

--- a/audio/sfx/push_boulder_1.asm
+++ b/audio/sfx/push_boulder_1.asm
@@ -1,10 +1,10 @@
 SFX_Push_Boulder_1_Ch7:
-	unknownnoise0x20 4, 162, 35
-	unknownnoise0x20 8, 241, 52
-	unknownnoise0x20 15, 0, 0
-	unknownnoise0x20 2, 247, 36
-	unknownnoise0x20 2, 247, 52
-	unknownnoise0x20 4, 247, 68
-	unknownnoise0x20 8, 244, 85
-	unknownnoise0x20 8, 241, 68
+	noisenote 4, 162, 35
+	noisenote 8, 241, 52
+	noisenote 15, 0, 0
+	noisenote 2, 247, 36
+	noisenote 2, 247, 52
+	noisenote 4, 247, 68
+	noisenote 8, 244, 85
+	noisenote 8, 241, 68
 	endchannel

--- a/audio/sfx/push_boulder_3.asm
+++ b/audio/sfx/push_boulder_3.asm
@@ -1,10 +1,10 @@
 SFX_Push_Boulder_3_Ch7:
-	unknownnoise0x20 4, 162, 35
-	unknownnoise0x20 8, 241, 52
-	unknownnoise0x20 15, 0, 0
-	unknownnoise0x20 2, 247, 36
-	unknownnoise0x20 2, 247, 52
-	unknownnoise0x20 4, 247, 68
-	unknownnoise0x20 8, 244, 85
-	unknownnoise0x20 8, 241, 68
+	noisenote 4, 162, 35
+	noisenote 8, 241, 52
+	noisenote 15, 0, 0
+	noisenote 2, 247, 36
+	noisenote 2, 247, 52
+	noisenote 4, 247, 68
+	noisenote 8, 244, 85
+	noisenote 8, 241, 68
 	endchannel

--- a/audio/sfx/run.asm
+++ b/audio/sfx/run.asm
@@ -1,13 +1,13 @@
 SFX_Run_Ch7:
-	unknownnoise0x20 2, 97, 35
-	unknownnoise0x20 2, 161, 51
-	unknownnoise0x20 2, 193, 51
-	unknownnoise0x20 2, 81, 17
-	unknownnoise0x20 2, 241, 51
-	unknownnoise0x20 2, 65, 17
-	unknownnoise0x20 2, 193, 51
-	unknownnoise0x20 2, 49, 17
-	unknownnoise0x20 2, 129, 51
-	unknownnoise0x20 2, 49, 17
-	unknownnoise0x20 8, 65, 51
+	noisenote 2, 97, 35
+	noisenote 2, 161, 51
+	noisenote 2, 193, 51
+	noisenote 2, 81, 17
+	noisenote 2, 241, 51
+	noisenote 2, 65, 17
+	noisenote 2, 193, 51
+	noisenote 2, 49, 17
+	noisenote 2, 129, 51
+	noisenote 2, 49, 17
+	noisenote 8, 65, 51
 	endchannel

--- a/audio/sfx/safari_zone_pa.asm
+++ b/audio/sfx/safari_zone_pa.asm
@@ -1,9 +1,9 @@
 SFX_Safari_Zone_PA_Ch4:
 	duty 2
-	unknownsfx0x20 15, 243, 48, 7
-	unknownsfx0x20 8, 101, 48, 7
-	unknownsfx0x20 15, 244, 0, 7
-	unknownsfx0x20 15, 116, 0, 7
-	unknownsfx0x20 15, 68, 0, 7
-	unknownsfx0x20 15, 36, 0, 7
+	squarenote 15, 243, 48, 7
+	squarenote 8, 101, 48, 7
+	squarenote 15, 244, 0, 7
+	squarenote 15, 116, 0, 7
+	squarenote 15, 68, 0, 7
+	squarenote 15, 36, 0, 7
 	endchannel

--- a/audio/sfx/save_1.asm
+++ b/audio/sfx/save_1.asm
@@ -1,23 +1,23 @@
 SFX_Save_1_Ch4:
 	duty 2
-	unknownsfx0x20 4, 244, 0, 7
-	unknownsfx0x20 2, 228, 0, 6
-	unknownsfx0x20 2, 228, 128, 6
-	unknownsfx0x20 2, 228, 192, 6
-	unknownsfx0x20 2, 228, 0, 7
-	unknownsfx0x20 2, 228, 160, 7
-	unknownsfx0x20 15, 242, 224, 7
+	squarenote 4, 244, 0, 7
+	squarenote 2, 228, 0, 6
+	squarenote 2, 228, 128, 6
+	squarenote 2, 228, 192, 6
+	squarenote 2, 228, 0, 7
+	squarenote 2, 228, 160, 7
+	squarenote 15, 242, 224, 7
 	endchannel
 
 
 SFX_Save_1_Ch5:
 	duty 2
-	unknownsfx0x20 4, 8, 0, 0
-	unknownsfx0x20 2, 212, 1, 7
-	unknownsfx0x20 2, 196, 1, 6
-	unknownsfx0x20 2, 196, 129, 6
-	unknownsfx0x20 2, 196, 193, 6
-	unknownsfx0x20 2, 196, 1, 7
-	unknownsfx0x20 2, 196, 161, 7
-	unknownsfx0x20 15, 210, 225, 7
+	squarenote 4, 8, 0, 0
+	squarenote 2, 212, 1, 7
+	squarenote 2, 196, 1, 6
+	squarenote 2, 196, 129, 6
+	squarenote 2, 196, 193, 6
+	squarenote 2, 196, 1, 7
+	squarenote 2, 196, 161, 7
+	squarenote 15, 210, 225, 7
 	endchannel

--- a/audio/sfx/save_3.asm
+++ b/audio/sfx/save_3.asm
@@ -1,17 +1,17 @@
 SFX_Save_3_Ch4:
 	duty 2
 IF DEF(_RED)
-	unknownsfx0x20 4, 244, 0, 7
-	unknownsfx0x20 3, 228, 128, 6
-	unknownsfx0x20 3, 228, 192, 6
-	unknownsfx0x20 3, 228, 0, 7
-	unknownsfx0x20 2, 228, 160, 7
+	squarenote 4, 244, 0, 7
+	squarenote 3, 228, 128, 6
+	squarenote 3, 228, 192, 6
+	squarenote 3, 228, 0, 7
+	squarenote 2, 228, 160, 7
 ELSE
-	unknownsfx0x20 3, 228, 0, 6
-	unknownsfx0x20 3, 228, 128, 6
-	unknownsfx0x20 3, 228, 192, 6
-	unknownsfx0x20 3, 228, 0, 7
-	unknownsfx0x20 15, 242, 224, 7
+	squarenote 3, 228, 0, 6
+	squarenote 3, 228, 128, 6
+	squarenote 3, 228, 192, 6
+	squarenote 3, 228, 0, 7
+	squarenote 15, 242, 224, 7
 ENDC
 	endchannel
 
@@ -19,18 +19,18 @@ ENDC
 SFX_Save_3_Ch5:
 	duty 2
 IF DEF(_RED)
-	unknownsfx0x20 4, 8, 0, 0
-	unknownsfx0x20 3, 212, 1, 7
-	unknownsfx0x20 3, 196, 129, 6
-	unknownsfx0x20 3, 196, 193, 6
-	unknownsfx0x20 3, 196, 1, 7
-	unknownsfx0x20 2, 196, 161, 7
+	squarenote 4, 8, 0, 0
+	squarenote 3, 212, 1, 7
+	squarenote 3, 196, 129, 6
+	squarenote 3, 196, 193, 6
+	squarenote 3, 196, 1, 7
+	squarenote 2, 196, 161, 7
 ELSE
-	unknownsfx0x20 3, 8, 0, 0
-	unknownsfx0x20 3, 196, 1, 6
-	unknownsfx0x20 3, 196, 129, 6
-	unknownsfx0x20 3, 196, 193, 6
-	unknownsfx0x20 3, 196, 1, 7
-	unknownsfx0x20 15, 210, 225, 7
+	squarenote 3, 8, 0, 0
+	squarenote 3, 196, 1, 6
+	squarenote 3, 196, 129, 6
+	squarenote 3, 196, 193, 6
+	squarenote 3, 196, 1, 7
+	squarenote 15, 210, 225, 7
 ENDC
 	endchannel

--- a/audio/sfx/shooting_star.asm
+++ b/audio/sfx/shooting_star.asm
@@ -1,14 +1,14 @@
 SFX_Shooting_Star_Ch4:
 	dutycycle 228
-	unknownsfx0x10 47
-	unknownsfx0x20 4, 64, 224, 7
-	unknownsfx0x20 4, 96, 224, 7
-	unknownsfx0x20 4, 128, 224, 7
-	unknownsfx0x20 8, 160, 224, 7
-	unknownsfx0x20 8, 160, 224, 7
-	unknownsfx0x20 8, 128, 224, 7
-	unknownsfx0x20 8, 96, 224, 7
-	unknownsfx0x20 8, 48, 224, 7
-	unknownsfx0x20 15, 18, 224, 7
-	unknownsfx0x10 8
+	pitchenvelope 47
+	squarenote 4, 64, 224, 7
+	squarenote 4, 96, 224, 7
+	squarenote 4, 128, 224, 7
+	squarenote 8, 160, 224, 7
+	squarenote 8, 160, 224, 7
+	squarenote 8, 128, 224, 7
+	squarenote 8, 96, 224, 7
+	squarenote 8, 48, 224, 7
+	squarenote 15, 18, 224, 7
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/shrink_1.asm
+++ b/audio/sfx/shrink_1.asm
@@ -1,10 +1,10 @@
 SFX_Shrink_1_Ch4:
 	duty 1
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 215, 0, 6
-	unknownsfx0x20 15, 183, 128, 5
-	unknownsfx0x20 15, 135, 0, 5
-	unknownsfx0x20 15, 71, 128, 4
-	unknownsfx0x20 15, 23, 0, 4
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 215, 0, 6
+	squarenote 15, 183, 128, 5
+	squarenote 15, 135, 0, 5
+	squarenote 15, 71, 128, 4
+	squarenote 15, 23, 0, 4
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/shrink_3.asm
+++ b/audio/sfx/shrink_3.asm
@@ -1,10 +1,10 @@
 SFX_Shrink_3_Ch4:
 	duty 1
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 215, 0, 6
-	unknownsfx0x20 15, 183, 128, 5
-	unknownsfx0x20 15, 135, 0, 5
-	unknownsfx0x20 15, 71, 128, 4
-	unknownsfx0x20 15, 23, 0, 4
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 215, 0, 6
+	squarenote 15, 183, 128, 5
+	squarenote 15, 135, 0, 5
+	squarenote 15, 71, 128, 4
+	squarenote 15, 23, 0, 4
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/silph_scope.asm
+++ b/audio/sfx/silph_scope.asm
@@ -1,9 +1,9 @@
 SFX_Silph_Scope_Ch4:
 	duty 0
-	unknownsfx0x20 0, 210, 0, 7
-	unknownsfx0x20 0, 210, 64, 7
-	unknownsfx0x20 0, 210, 128, 7
-	unknownsfx0x20 0, 210, 192, 7
-	unknownsfx0x20 10, 225, 224, 7
-	unknownsfx0x20 1, 0, 0, 0
+	squarenote 0, 210, 0, 7
+	squarenote 0, 210, 64, 7
+	squarenote 0, 210, 128, 7
+	squarenote 0, 210, 192, 7
+	squarenote 10, 225, 224, 7
+	squarenote 1, 0, 0, 0
 	endchannel

--- a/audio/sfx/slots_new_spin.asm
+++ b/audio/sfx/slots_new_spin.asm
@@ -1,14 +1,14 @@
 SFX_Slots_New_Spin_Ch4:
 	duty 3
-	unknownsfx0x20 5, 225, 0, 7
-	unknownsfx0x20 2, 225, 128, 7
-	unknownsfx0x20 15, 241, 192, 7
+	squarenote 5, 225, 0, 7
+	squarenote 2, 225, 128, 7
+	squarenote 15, 241, 192, 7
 	endchannel
 
 
 SFX_Slots_New_Spin_Ch5:
 	duty 2
-	unknownsfx0x20 4, 193, 193, 6
-	unknownsfx0x20 2, 193, 65, 7
-	unknownsfx0x20 15, 209, 129, 7
+	squarenote 4, 193, 193, 6
+	squarenote 2, 193, 65, 7
+	squarenote 15, 209, 129, 7
 	endchannel

--- a/audio/sfx/slots_reward.asm
+++ b/audio/sfx/slots_reward.asm
@@ -1,5 +1,5 @@
 SFX_Slots_Reward_Ch4:
 	duty 2
-	unknownsfx0x20 2, 241, 0, 7
-	unknownsfx0x20 8, 129, 224, 7
+	squarenote 2, 241, 0, 7
+	squarenote 8, 129, 224, 7
 	endchannel

--- a/audio/sfx/slots_stop_wheel.asm
+++ b/audio/sfx/slots_stop_wheel.asm
@@ -1,6 +1,6 @@
 SFX_Slots_Stop_Wheel_Ch4:
 	duty 2
-	unknownsfx0x20 1, 242, 160, 6
-	unknownsfx0x20 1, 242, 224, 6
-	unknownsfx0x20 8, 241, 0, 7
+	squarenote 1, 242, 160, 6
+	squarenote 1, 242, 224, 6
+	squarenote 8, 241, 0, 7
 	endchannel

--- a/audio/sfx/snare1_1.asm
+++ b/audio/sfx/snare1_1.asm
@@ -1,3 +1,3 @@
 SFX_Snare1_1_Ch7:
-	unknownnoise0x20 0, 193, 51
+	noisenote 0, 193, 51
 	endchannel

--- a/audio/sfx/snare1_2.asm
+++ b/audio/sfx/snare1_2.asm
@@ -1,3 +1,3 @@
 SFX_Snare1_2_Ch7:
-	unknownnoise0x20 0, 193, 51
+	noisenote 0, 193, 51
 	endchannel

--- a/audio/sfx/snare1_3.asm
+++ b/audio/sfx/snare1_3.asm
@@ -1,3 +1,3 @@
 SFX_Snare1_3_Ch7:
-	unknownnoise0x20 0, 193, 51
+	noisenote 0, 193, 51
 	endchannel

--- a/audio/sfx/snare2_1.asm
+++ b/audio/sfx/snare2_1.asm
@@ -1,3 +1,3 @@
 SFX_Snare2_1_Ch7:
-	unknownnoise0x20 0, 177, 51
+	noisenote 0, 177, 51
 	endchannel

--- a/audio/sfx/snare2_2.asm
+++ b/audio/sfx/snare2_2.asm
@@ -1,3 +1,3 @@
 SFX_Snare2_2_Ch7:
-	unknownnoise0x20 0, 177, 51
+	noisenote 0, 177, 51
 	endchannel

--- a/audio/sfx/snare2_3.asm
+++ b/audio/sfx/snare2_3.asm
@@ -1,3 +1,3 @@
 SFX_Snare2_3_Ch7:
-	unknownnoise0x20 0, 177, 51
+	noisenote 0, 177, 51
 	endchannel

--- a/audio/sfx/snare3_1.asm
+++ b/audio/sfx/snare3_1.asm
@@ -1,3 +1,3 @@
 SFX_Snare3_1_Ch7:
-	unknownnoise0x20 0, 161, 51
+	noisenote 0, 161, 51
 	endchannel

--- a/audio/sfx/snare3_2.asm
+++ b/audio/sfx/snare3_2.asm
@@ -1,3 +1,3 @@
 SFX_Snare3_2_Ch7:
-	unknownnoise0x20 0, 161, 51
+	noisenote 0, 161, 51
 	endchannel

--- a/audio/sfx/snare3_3.asm
+++ b/audio/sfx/snare3_3.asm
@@ -1,3 +1,3 @@
 SFX_Snare3_3_Ch7:
-	unknownnoise0x20 0, 161, 51
+	noisenote 0, 161, 51
 	endchannel

--- a/audio/sfx/snare4_1.asm
+++ b/audio/sfx/snare4_1.asm
@@ -1,3 +1,3 @@
 SFX_Snare4_1_Ch7:
-	unknownnoise0x20 0, 129, 51
+	noisenote 0, 129, 51
 	endchannel

--- a/audio/sfx/snare4_2.asm
+++ b/audio/sfx/snare4_2.asm
@@ -1,3 +1,3 @@
 SFX_Snare4_2_Ch7:
-	unknownnoise0x20 0, 129, 51
+	noisenote 0, 129, 51
 	endchannel

--- a/audio/sfx/snare4_3.asm
+++ b/audio/sfx/snare4_3.asm
@@ -1,3 +1,3 @@
 SFX_Snare4_3_Ch7:
-	unknownnoise0x20 0, 129, 51
+	noisenote 0, 129, 51
 	endchannel

--- a/audio/sfx/snare5_1.asm
+++ b/audio/sfx/snare5_1.asm
@@ -1,8 +1,8 @@
 SFX_Snare5_1_Ch7:
-	unknownnoise0x20 7, 132, 55
-	unknownnoise0x20 6, 132, 54
-	unknownnoise0x20 5, 131, 53
-	unknownnoise0x20 4, 131, 52
-	unknownnoise0x20 3, 130, 51
-	unknownnoise0x20 2, 129, 50
+	noisenote 7, 132, 55
+	noisenote 6, 132, 54
+	noisenote 5, 131, 53
+	noisenote 4, 131, 52
+	noisenote 3, 130, 51
+	noisenote 2, 129, 50
 	endchannel

--- a/audio/sfx/snare5_2.asm
+++ b/audio/sfx/snare5_2.asm
@@ -1,8 +1,8 @@
 SFX_Snare5_2_Ch7:
-	unknownnoise0x20 7, 132, 55
-	unknownnoise0x20 6, 132, 54
-	unknownnoise0x20 5, 131, 53
-	unknownnoise0x20 4, 131, 52
-	unknownnoise0x20 3, 130, 51
-	unknownnoise0x20 2, 129, 50
+	noisenote 7, 132, 55
+	noisenote 6, 132, 54
+	noisenote 5, 131, 53
+	noisenote 4, 131, 52
+	noisenote 3, 130, 51
+	noisenote 2, 129, 50
 	endchannel

--- a/audio/sfx/snare5_3.asm
+++ b/audio/sfx/snare5_3.asm
@@ -1,8 +1,8 @@
 SFX_Snare5_3_Ch7:
-	unknownnoise0x20 7, 132, 55
-	unknownnoise0x20 6, 132, 54
-	unknownnoise0x20 5, 131, 53
-	unknownnoise0x20 4, 131, 52
-	unknownnoise0x20 3, 130, 51
-	unknownnoise0x20 2, 129, 50
+	noisenote 7, 132, 55
+	noisenote 6, 132, 54
+	noisenote 5, 131, 53
+	noisenote 4, 131, 52
+	noisenote 3, 130, 51
+	noisenote 2, 129, 50
 	endchannel

--- a/audio/sfx/snare6_1.asm
+++ b/audio/sfx/snare6_1.asm
@@ -1,3 +1,3 @@
 SFX_Snare6_1_Ch7:
-	unknownnoise0x20 0, 129, 16
+	noisenote 0, 129, 16
 	endchannel

--- a/audio/sfx/snare6_2.asm
+++ b/audio/sfx/snare6_2.asm
@@ -1,3 +1,3 @@
 SFX_Snare6_2_Ch7:
-	unknownnoise0x20 0, 129, 16
+	noisenote 0, 129, 16
 	endchannel

--- a/audio/sfx/snare6_3.asm
+++ b/audio/sfx/snare6_3.asm
@@ -1,3 +1,3 @@
 SFX_Snare6_3_Ch7:
-	unknownnoise0x20 0, 129, 16
+	noisenote 0, 129, 16
 	endchannel

--- a/audio/sfx/snare7_1.asm
+++ b/audio/sfx/snare7_1.asm
@@ -1,3 +1,3 @@
 SFX_Snare7_1_Ch7:
-	unknownnoise0x20 0, 130, 35
+	noisenote 0, 130, 35
 	endchannel

--- a/audio/sfx/snare7_2.asm
+++ b/audio/sfx/snare7_2.asm
@@ -1,3 +1,3 @@
 SFX_Snare7_2_Ch7:
-	unknownnoise0x20 0, 130, 35
+	noisenote 0, 130, 35
 	endchannel

--- a/audio/sfx/snare7_3.asm
+++ b/audio/sfx/snare7_3.asm
@@ -1,3 +1,3 @@
 SFX_Snare7_3_Ch7:
-	unknownnoise0x20 0, 130, 35
+	noisenote 0, 130, 35
 	endchannel

--- a/audio/sfx/snare8_1.asm
+++ b/audio/sfx/snare8_1.asm
@@ -1,3 +1,3 @@
 SFX_Snare8_1_Ch7:
-	unknownnoise0x20 0, 130, 37
+	noisenote 0, 130, 37
 	endchannel

--- a/audio/sfx/snare8_2.asm
+++ b/audio/sfx/snare8_2.asm
@@ -1,3 +1,3 @@
 SFX_Snare8_2_Ch7:
-	unknownnoise0x20 0, 130, 37
+	noisenote 0, 130, 37
 	endchannel

--- a/audio/sfx/snare8_3.asm
+++ b/audio/sfx/snare8_3.asm
@@ -1,3 +1,3 @@
 SFX_Snare8_3_Ch7:
-	unknownnoise0x20 0, 130, 37
+	noisenote 0, 130, 37
 	endchannel

--- a/audio/sfx/snare9_1.asm
+++ b/audio/sfx/snare9_1.asm
@@ -1,3 +1,3 @@
 SFX_Snare9_1_Ch7:
-	unknownnoise0x20 0, 130, 38
+	noisenote 0, 130, 38
 	endchannel

--- a/audio/sfx/snare9_2.asm
+++ b/audio/sfx/snare9_2.asm
@@ -1,3 +1,3 @@
 SFX_Snare9_2_Ch7:
-	unknownnoise0x20 0, 130, 38
+	noisenote 0, 130, 38
 	endchannel

--- a/audio/sfx/snare9_3.asm
+++ b/audio/sfx/snare9_3.asm
@@ -1,3 +1,3 @@
 SFX_Snare9_3_Ch7:
-	unknownnoise0x20 0, 130, 38
+	noisenote 0, 130, 38
 	endchannel

--- a/audio/sfx/ss_anne_horn_1.asm
+++ b/audio/sfx/ss_anne_horn_1.asm
@@ -1,22 +1,22 @@
 SFX_SS_Anne_Horn_1_Ch4:
 	duty 2
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 15, 242, 0, 5
+	squarenote 15, 240, 0, 5
+	squarenote 4, 0, 0, 0
+	squarenote 15, 240, 0, 5
+	squarenote 15, 240, 0, 5
+	squarenote 15, 240, 0, 5
+	squarenote 15, 240, 0, 5
+	squarenote 15, 242, 0, 5
 	endchannel
 
 
 SFX_SS_Anne_Horn_1_Ch5:
 	duty 3
-	unknownsfx0x20 15, 240, 130, 4
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 15, 240, 130, 4
-	unknownsfx0x20 15, 240, 130, 4
-	unknownsfx0x20 15, 240, 130, 4
-	unknownsfx0x20 15, 240, 130, 4
-	unknownsfx0x20 15, 242, 130, 4
+	squarenote 15, 240, 130, 4
+	squarenote 4, 0, 0, 0
+	squarenote 15, 240, 130, 4
+	squarenote 15, 240, 130, 4
+	squarenote 15, 240, 130, 4
+	squarenote 15, 240, 130, 4
+	squarenote 15, 242, 130, 4
 	endchannel

--- a/audio/sfx/ss_anne_horn_3.asm
+++ b/audio/sfx/ss_anne_horn_3.asm
@@ -1,22 +1,22 @@
 SFX_SS_Anne_Horn_3_Ch4:
 	duty 2
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 15, 240, 0, 5
-	unknownsfx0x20 15, 242, 0, 5
+	squarenote 15, 240, 0, 5
+	squarenote 4, 0, 0, 0
+	squarenote 15, 240, 0, 5
+	squarenote 15, 240, 0, 5
+	squarenote 15, 240, 0, 5
+	squarenote 15, 240, 0, 5
+	squarenote 15, 242, 0, 5
 	endchannel
 
 
 SFX_SS_Anne_Horn_3_Ch5:
 	duty 3
-	unknownsfx0x20 15, 240, 130, 4
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 15, 240, 130, 4
-	unknownsfx0x20 15, 240, 130, 4
-	unknownsfx0x20 15, 240, 130, 4
-	unknownsfx0x20 15, 240, 130, 4
-	unknownsfx0x20 15, 242, 130, 4
+	squarenote 15, 240, 130, 4
+	squarenote 4, 0, 0, 0
+	squarenote 15, 240, 130, 4
+	squarenote 15, 240, 130, 4
+	squarenote 15, 240, 130, 4
+	squarenote 15, 240, 130, 4
+	squarenote 15, 242, 130, 4
 	endchannel

--- a/audio/sfx/start_menu_1.asm
+++ b/audio/sfx/start_menu_1.asm
@@ -1,4 +1,4 @@
 SFX_Start_Menu_1_Ch7:
-	unknownnoise0x20 1, 226, 51
-	unknownnoise0x20 8, 225, 34
+	noisenote 1, 226, 51
+	noisenote 8, 225, 34
 	endchannel

--- a/audio/sfx/start_menu_2.asm
+++ b/audio/sfx/start_menu_2.asm
@@ -1,4 +1,4 @@
 SFX_Start_Menu_2_Ch7:
-	unknownnoise0x20 1, 226, 51
-	unknownnoise0x20 8, 225, 34
+	noisenote 1, 226, 51
+	noisenote 8, 225, 34
 	endchannel

--- a/audio/sfx/start_menu_3.asm
+++ b/audio/sfx/start_menu_3.asm
@@ -1,4 +1,4 @@
 SFX_Start_Menu_3_Ch7:
-	unknownnoise0x20 1, 226, 51
-	unknownnoise0x20 8, 225, 34
+	noisenote 1, 226, 51
+	noisenote 8, 225, 34
 	endchannel

--- a/audio/sfx/super_effective.asm
+++ b/audio/sfx/super_effective.asm
@@ -1,4 +1,4 @@
 SFX_Super_Effective_Ch7:
-	unknownnoise0x20 4, 241, 52
-	unknownnoise0x20 15, 242, 100
+	noisenote 4, 241, 52
+	noisenote 15, 242, 100
 	endchannel

--- a/audio/sfx/swap_1.asm
+++ b/audio/sfx/swap_1.asm
@@ -1,11 +1,11 @@
 SFX_Swap_1_Ch4:
 	duty 2
-	unknownsfx0x20 8, 225, 64, 7
+	squarenote 8, 225, 64, 7
 	endchannel
 
 
 SFX_Swap_1_Ch5:
 	duty 2
-	unknownsfx0x20 2, 8, 0, 0
-	unknownsfx0x20 8, 177, 65, 7
+	squarenote 2, 8, 0, 0
+	squarenote 8, 177, 65, 7
 	endchannel

--- a/audio/sfx/swap_3.asm
+++ b/audio/sfx/swap_3.asm
@@ -1,11 +1,11 @@
 SFX_Swap_3_Ch4:
 	duty 2
-	unknownsfx0x20 8, 225, 64, 7
+	squarenote 8, 225, 64, 7
 	endchannel
 
 
 SFX_Swap_3_Ch5:
 	duty 2
-	unknownsfx0x20 2, 8, 0, 0
-	unknownsfx0x20 8, 177, 65, 7
+	squarenote 2, 8, 0, 0
+	squarenote 8, 177, 65, 7
 	endchannel

--- a/audio/sfx/switch_1.asm
+++ b/audio/sfx/switch_1.asm
@@ -1,8 +1,8 @@
 SFX_Switch_1_Ch4:
 	duty 2
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 2, 241, 128, 6
-	unknownsfx0x20 1, 0, 0, 0
-	unknownsfx0x20 4, 241, 128, 7
-	unknownsfx0x20 4, 0, 0, 0
+	squarenote 4, 0, 0, 0
+	squarenote 2, 241, 128, 6
+	squarenote 1, 0, 0, 0
+	squarenote 4, 241, 128, 7
+	squarenote 4, 0, 0, 0
 	endchannel

--- a/audio/sfx/switch_3.asm
+++ b/audio/sfx/switch_3.asm
@@ -1,8 +1,8 @@
 SFX_Switch_3_Ch4:
 	duty 2
-	unknownsfx0x20 4, 0, 0, 0
-	unknownsfx0x20 2, 241, 128, 6
-	unknownsfx0x20 1, 0, 0, 0
-	unknownsfx0x20 4, 241, 128, 7
-	unknownsfx0x20 4, 0, 0, 0
+	squarenote 4, 0, 0, 0
+	squarenote 2, 241, 128, 6
+	squarenote 1, 0, 0, 0
+	squarenote 4, 241, 128, 7
+	squarenote 4, 0, 0, 0
 	endchannel

--- a/audio/sfx/teleport_enter1_1.asm
+++ b/audio/sfx/teleport_enter1_1.asm
@@ -1,10 +1,10 @@
 SFX_Teleport_Enter1_1_Ch4:
 	duty 1
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 215, 0, 7
-	unknownsfx0x20 15, 183, 128, 6
-	unknownsfx0x20 15, 135, 0, 6
-	unknownsfx0x20 15, 71, 128, 5
-	unknownsfx0x20 15, 23, 0, 5
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 215, 0, 7
+	squarenote 15, 183, 128, 6
+	squarenote 15, 135, 0, 6
+	squarenote 15, 71, 128, 5
+	squarenote 15, 23, 0, 5
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/teleport_enter1_3.asm
+++ b/audio/sfx/teleport_enter1_3.asm
@@ -1,10 +1,10 @@
 SFX_Teleport_Enter1_3_Ch4:
 	duty 1
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 215, 0, 7
-	unknownsfx0x20 15, 183, 128, 6
-	unknownsfx0x20 15, 135, 0, 6
-	unknownsfx0x20 15, 71, 128, 5
-	unknownsfx0x20 15, 23, 0, 5
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 215, 0, 7
+	squarenote 15, 183, 128, 6
+	squarenote 15, 135, 0, 6
+	squarenote 15, 71, 128, 5
+	squarenote 15, 23, 0, 5
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/teleport_enter2_1.asm
+++ b/audio/sfx/teleport_enter2_1.asm
@@ -1,6 +1,6 @@
 SFX_Teleport_Enter2_1_Ch7:
-	unknownnoise0x20 2, 241, 50
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 241, 34
-	unknownnoise0x20 1, 0, 0
+	noisenote 2, 241, 50
+	noisenote 2, 0, 0
+	noisenote 2, 241, 34
+	noisenote 1, 0, 0
 	endchannel

--- a/audio/sfx/teleport_enter2_3.asm
+++ b/audio/sfx/teleport_enter2_3.asm
@@ -1,6 +1,6 @@
 SFX_Teleport_Enter2_3_Ch7:
-	unknownnoise0x20 2, 241, 50
-	unknownnoise0x20 2, 0, 0
-	unknownnoise0x20 2, 241, 34
-	unknownnoise0x20 1, 0, 0
+	noisenote 2, 241, 50
+	noisenote 2, 0, 0
+	noisenote 2, 241, 34
+	noisenote 1, 0, 0
 	endchannel

--- a/audio/sfx/teleport_exit1_1.asm
+++ b/audio/sfx/teleport_exit1_1.asm
@@ -1,10 +1,10 @@
 SFX_Teleport_Exit1_1_Ch4:
 	duty 1
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 215, 0, 5
-	unknownsfx0x20 15, 183, 128, 5
-	unknownsfx0x20 15, 135, 0, 6
-	unknownsfx0x20 15, 71, 128, 6
-	unknownsfx0x20 15, 23, 0, 7
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 215, 0, 5
+	squarenote 15, 183, 128, 5
+	squarenote 15, 135, 0, 6
+	squarenote 15, 71, 128, 6
+	squarenote 15, 23, 0, 7
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/teleport_exit1_3.asm
+++ b/audio/sfx/teleport_exit1_3.asm
@@ -1,10 +1,10 @@
 SFX_Teleport_Exit1_3_Ch4:
 	duty 1
-	unknownsfx0x10 23
-	unknownsfx0x20 15, 215, 0, 5
-	unknownsfx0x20 15, 183, 128, 5
-	unknownsfx0x20 15, 135, 0, 6
-	unknownsfx0x20 15, 71, 128, 6
-	unknownsfx0x20 15, 23, 0, 7
-	unknownsfx0x10 8
+	pitchenvelope 23
+	squarenote 15, 215, 0, 5
+	squarenote 15, 183, 128, 5
+	squarenote 15, 135, 0, 6
+	squarenote 15, 71, 128, 6
+	squarenote 15, 23, 0, 7
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/teleport_exit2_1.asm
+++ b/audio/sfx/teleport_exit2_1.asm
@@ -1,6 +1,6 @@
 SFX_Teleport_Exit2_1_Ch4:
 	duty 1
-	unknownsfx0x10 22
-	unknownsfx0x20 15, 210, 0, 5
-	unknownsfx0x10 8
+	pitchenvelope 22
+	squarenote 15, 210, 0, 5
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/teleport_exit2_3.asm
+++ b/audio/sfx/teleport_exit2_3.asm
@@ -1,6 +1,6 @@
 SFX_Teleport_Exit2_3_Ch4:
 	duty 1
-	unknownsfx0x10 22
-	unknownsfx0x20 15, 210, 0, 5
-	unknownsfx0x10 8
+	pitchenvelope 22
+	squarenote 15, 210, 0, 5
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/tink_1.asm
+++ b/audio/sfx/tink_1.asm
@@ -1,8 +1,8 @@
 SFX_Tink_1_Ch4:
 	duty 2
-	unknownsfx0x10 58
-	unknownsfx0x20 4, 242, 0, 2
-	unknownsfx0x10 34
-	unknownsfx0x20 8, 226, 0, 2
-	unknownsfx0x10 8
+	pitchenvelope 58
+	squarenote 4, 242, 0, 2
+	pitchenvelope 34
+	squarenote 8, 226, 0, 2
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/tink_2.asm
+++ b/audio/sfx/tink_2.asm
@@ -1,8 +1,8 @@
 SFX_Tink_2_Ch4:
 	duty 2
-	unknownsfx0x10 58
-	unknownsfx0x20 4, 242, 0, 2
-	unknownsfx0x10 34
-	unknownsfx0x20 8, 226, 0, 2
-	unknownsfx0x10 8
+	pitchenvelope 58
+	squarenote 4, 242, 0, 2
+	pitchenvelope 34
+	squarenote 8, 226, 0, 2
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/tink_3.asm
+++ b/audio/sfx/tink_3.asm
@@ -1,8 +1,8 @@
 SFX_Tink_3_Ch4:
 	duty 2
-	unknownsfx0x10 58
-	unknownsfx0x20 4, 242, 0, 2
-	unknownsfx0x10 34
-	unknownsfx0x20 8, 226, 0, 2
-	unknownsfx0x10 8
+	pitchenvelope 58
+	squarenote 4, 242, 0, 2
+	pitchenvelope 34
+	squarenote 8, 226, 0, 2
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/trade_machine_1.asm
+++ b/audio/sfx/trade_machine_1.asm
@@ -1,7 +1,7 @@
 SFX_Trade_Machine_1_Ch4:
 	duty 2
-	unknownsfx0x10 21
-	unknownsfx0x20 15, 240, 240, 4
-	unknownsfx0x20 15, 242, 80, 6
-	unknownsfx0x10 8
+	pitchenvelope 21
+	squarenote 15, 240, 240, 4
+	squarenote 15, 242, 80, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/trade_machine_3.asm
+++ b/audio/sfx/trade_machine_3.asm
@@ -1,7 +1,7 @@
 SFX_Trade_Machine_3_Ch4:
 	duty 2
-	unknownsfx0x10 21
-	unknownsfx0x20 15, 240, 240, 4
-	unknownsfx0x20 15, 242, 80, 6
-	unknownsfx0x10 8
+	pitchenvelope 21
+	squarenote 15, 240, 240, 4
+	squarenote 15, 242, 80, 6
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/triangle1_1.asm
+++ b/audio/sfx/triangle1_1.asm
@@ -1,3 +1,3 @@
 SFX_Triangle1_1_Ch7:
-	unknownnoise0x20 0, 81, 42
+	noisenote 0, 81, 42
 	endchannel

--- a/audio/sfx/triangle1_2.asm
+++ b/audio/sfx/triangle1_2.asm
@@ -1,3 +1,3 @@
 SFX_Triangle1_2_Ch7:
-	unknownnoise0x20 0, 81, 42
+	noisenote 0, 81, 42
 	endchannel

--- a/audio/sfx/triangle1_3.asm
+++ b/audio/sfx/triangle1_3.asm
@@ -1,3 +1,3 @@
 SFX_Triangle1_3_Ch7:
-	unknownnoise0x20 0, 81, 42
+	noisenote 0, 81, 42
 	endchannel

--- a/audio/sfx/triangle2_1.asm
+++ b/audio/sfx/triangle2_1.asm
@@ -1,4 +1,4 @@
 SFX_Triangle2_1_Ch7:
-	unknownnoise0x20 1, 65, 43
-	unknownnoise0x20 0, 97, 42
+	noisenote 1, 65, 43
+	noisenote 0, 97, 42
 	endchannel

--- a/audio/sfx/triangle2_2.asm
+++ b/audio/sfx/triangle2_2.asm
@@ -1,4 +1,4 @@
 SFX_Triangle2_2_Ch7:
-	unknownnoise0x20 1, 65, 43
-	unknownnoise0x20 0, 97, 42
+	noisenote 1, 65, 43
+	noisenote 0, 97, 42
 	endchannel

--- a/audio/sfx/triangle2_3.asm
+++ b/audio/sfx/triangle2_3.asm
@@ -1,4 +1,4 @@
 SFX_Triangle2_3_Ch7:
-	unknownnoise0x20 1, 65, 43
-	unknownnoise0x20 0, 97, 42
+	noisenote 1, 65, 43
+	noisenote 0, 97, 42
 	endchannel

--- a/audio/sfx/triangle3_1.asm
+++ b/audio/sfx/triangle3_1.asm
@@ -1,4 +1,4 @@
 SFX_Triangle3_1_Ch7:
-	unknownnoise0x20 2, 145, 40
-	unknownnoise0x20 0, 113, 24
+	noisenote 2, 145, 40
+	noisenote 0, 113, 24
 	endchannel

--- a/audio/sfx/triangle3_2.asm
+++ b/audio/sfx/triangle3_2.asm
@@ -1,4 +1,4 @@
 SFX_Triangle3_2_Ch7:
-	unknownnoise0x20 2, 145, 40
-	unknownnoise0x20 0, 113, 24
+	noisenote 2, 145, 40
+	noisenote 0, 113, 24
 	endchannel

--- a/audio/sfx/triangle3_3.asm
+++ b/audio/sfx/triangle3_3.asm
@@ -1,4 +1,4 @@
 SFX_Triangle3_3_Ch7:
-	unknownnoise0x20 2, 145, 40
-	unknownnoise0x20 0, 113, 24
+	noisenote 2, 145, 40
+	noisenote 0, 113, 24
 	endchannel

--- a/audio/sfx/turn_off_pc_1.asm
+++ b/audio/sfx/turn_off_pc_1.asm
@@ -1,7 +1,7 @@
 SFX_Turn_Off_PC_1_Ch4:
 	duty 2
-	unknownsfx0x20 4, 240, 0, 6
-	unknownsfx0x20 4, 240, 0, 4
-	unknownsfx0x20 4, 240, 0, 2
-	unknownsfx0x20 1, 0, 0, 0
+	squarenote 4, 240, 0, 6
+	squarenote 4, 240, 0, 4
+	squarenote 4, 240, 0, 2
+	squarenote 1, 0, 0, 0
 	endchannel

--- a/audio/sfx/turn_off_pc_3.asm
+++ b/audio/sfx/turn_off_pc_3.asm
@@ -1,7 +1,7 @@
 SFX_Turn_Off_PC_3_Ch4:
 	duty 2
-	unknownsfx0x20 4, 240, 0, 6
-	unknownsfx0x20 4, 240, 0, 4
-	unknownsfx0x20 4, 240, 0, 2
-	unknownsfx0x20 1, 0, 0, 0
+	squarenote 4, 240, 0, 6
+	squarenote 4, 240, 0, 4
+	squarenote 4, 240, 0, 2
+	squarenote 1, 0, 0, 0
 	endchannel

--- a/audio/sfx/turn_on_pc_1.asm
+++ b/audio/sfx/turn_on_pc_1.asm
@@ -1,13 +1,13 @@
 SFX_Turn_On_PC_1_Ch4:
 	duty 2
-	unknownsfx0x20 15, 242, 192, 7
-	unknownsfx0x20 15, 0, 0, 0
-	unknownsfx0x20 3, 161, 128, 7
-	unknownsfx0x20 3, 161, 0, 7
-	unknownsfx0x20 3, 161, 64, 7
-	unknownsfx0x20 3, 161, 0, 7
-	unknownsfx0x20 3, 161, 128, 7
-	unknownsfx0x20 3, 161, 0, 7
-	unknownsfx0x20 3, 161, 192, 7
-	unknownsfx0x20 8, 161, 0, 7
+	squarenote 15, 242, 192, 7
+	squarenote 15, 0, 0, 0
+	squarenote 3, 161, 128, 7
+	squarenote 3, 161, 0, 7
+	squarenote 3, 161, 64, 7
+	squarenote 3, 161, 0, 7
+	squarenote 3, 161, 128, 7
+	squarenote 3, 161, 0, 7
+	squarenote 3, 161, 192, 7
+	squarenote 8, 161, 0, 7
 	endchannel

--- a/audio/sfx/turn_on_pc_3.asm
+++ b/audio/sfx/turn_on_pc_3.asm
@@ -1,14 +1,14 @@
 SFX_Turn_On_PC_3_Ch4:
 	duty 2
-	unknownsfx0x20 15, 242, 192, 7
-	unknownsfx0x20 15, 0, 0, 0
-	unknownsfx0x20 15, 0, 0, 0
-	unknownsfx0x20 3, 129, 128, 7
-	unknownsfx0x20 3, 129, 0, 7
-	unknownsfx0x20 3, 129, 64, 7
-	unknownsfx0x20 3, 129, 0, 7
-	unknownsfx0x20 3, 129, 128, 7
-	unknownsfx0x20 3, 129, 0, 7
-	unknownsfx0x20 3, 129, 192, 7
-	unknownsfx0x20 3, 129, 0, 7
+	squarenote 15, 242, 192, 7
+	squarenote 15, 0, 0, 0
+	squarenote 15, 0, 0, 0
+	squarenote 3, 129, 128, 7
+	squarenote 3, 129, 0, 7
+	squarenote 3, 129, 64, 7
+	squarenote 3, 129, 0, 7
+	squarenote 3, 129, 128, 7
+	squarenote 3, 129, 0, 7
+	squarenote 3, 129, 192, 7
+	squarenote 3, 129, 0, 7
 	endchannel

--- a/audio/sfx/unused_1.asm
+++ b/audio/sfx/unused_1.asm
@@ -1,31 +1,31 @@
 SFX_02_unused_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 224, 128, 7
-	unknownsfx0x20 15, 240, 132, 7
-	unknownsfx0x20 15, 195, 224, 5
-	unknownsfx0x20 15, 196, 0, 6
-	unknownsfx0x20 10, 108, 128, 7
-	unknownsfx0x20 8, 113, 132, 7
+	squarenote 15, 224, 128, 7
+	squarenote 15, 240, 132, 7
+	squarenote 15, 195, 224, 5
+	squarenote 15, 196, 0, 6
+	squarenote 10, 108, 128, 7
+	squarenote 8, 113, 132, 7
 	endchannel
 
 
 SFX_02_unused_Ch5:
 	dutycycle 5
-	unknownsfx0x20 15, 160, 65, 7
-	unknownsfx0x20 15, 176, 67, 7
-	unknownsfx0x20 15, 147, 177, 5
-	unknownsfx0x20 15, 148, 193, 5
-	unknownsfx0x20 10, 76, 65, 7
-	unknownsfx0x20 8, 49, 70, 7
+	squarenote 15, 160, 65, 7
+	squarenote 15, 176, 67, 7
+	squarenote 15, 147, 177, 5
+	squarenote 15, 148, 193, 5
+	squarenote 10, 76, 65, 7
+	squarenote 8, 49, 70, 7
 	endchannel
 
 
 SFX_02_unused_Ch7:
-	unknownnoise0x20 2, 242, 76
-	unknownnoise0x20 6, 224, 58
-	unknownnoise0x20 15, 208, 58
-	unknownnoise0x20 8, 208, 44
-	unknownnoise0x20 6, 230, 76
-	unknownnoise0x20 12, 125, 76
-	unknownnoise0x20 15, 211, 76
+	noisenote 2, 242, 76
+	noisenote 6, 224, 58
+	noisenote 15, 208, 58
+	noisenote 8, 208, 44
+	noisenote 6, 230, 76
+	noisenote 12, 125, 76
+	noisenote 15, 211, 76
 	endchannel

--- a/audio/sfx/unused_2.asm
+++ b/audio/sfx/unused_2.asm
@@ -1,31 +1,31 @@
 SFX_08_unused_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 224, 128, 7
-	unknownsfx0x20 15, 240, 132, 7
-	unknownsfx0x20 15, 195, 224, 5
-	unknownsfx0x20 15, 196, 0, 6
-	unknownsfx0x20 10, 108, 128, 7
-	unknownsfx0x20 8, 113, 132, 7
+	squarenote 15, 224, 128, 7
+	squarenote 15, 240, 132, 7
+	squarenote 15, 195, 224, 5
+	squarenote 15, 196, 0, 6
+	squarenote 10, 108, 128, 7
+	squarenote 8, 113, 132, 7
 	endchannel
 
 
 SFX_08_unused_Ch5:
 	dutycycle 5
-	unknownsfx0x20 15, 160, 65, 7
-	unknownsfx0x20 15, 176, 67, 7
-	unknownsfx0x20 15, 147, 177, 5
-	unknownsfx0x20 15, 148, 193, 5
-	unknownsfx0x20 10, 76, 65, 7
-	unknownsfx0x20 8, 49, 70, 7
+	squarenote 15, 160, 65, 7
+	squarenote 15, 176, 67, 7
+	squarenote 15, 147, 177, 5
+	squarenote 15, 148, 193, 5
+	squarenote 10, 76, 65, 7
+	squarenote 8, 49, 70, 7
 	endchannel
 
 
 SFX_08_unused_Ch7:
-	unknownnoise0x20 2, 242, 76
-	unknownnoise0x20 6, 224, 58
-	unknownnoise0x20 15, 208, 58
-	unknownnoise0x20 8, 208, 44
-	unknownnoise0x20 6, 230, 76
-	unknownnoise0x20 12, 125, 76
-	unknownnoise0x20 15, 211, 76
+	noisenote 2, 242, 76
+	noisenote 6, 224, 58
+	noisenote 15, 208, 58
+	noisenote 8, 208, 44
+	noisenote 6, 230, 76
+	noisenote 12, 125, 76
+	noisenote 15, 211, 76
 	endchannel

--- a/audio/sfx/unused_3.asm
+++ b/audio/sfx/unused_3.asm
@@ -1,31 +1,31 @@
 SFX_1f_unused_Ch4:
 	dutycycle 240
-	unknownsfx0x20 15, 224, 128, 7
-	unknownsfx0x20 15, 240, 132, 7
-	unknownsfx0x20 15, 195, 224, 5
-	unknownsfx0x20 15, 196, 0, 6
-	unknownsfx0x20 10, 108, 128, 7
-	unknownsfx0x20 8, 113, 132, 7
+	squarenote 15, 224, 128, 7
+	squarenote 15, 240, 132, 7
+	squarenote 15, 195, 224, 5
+	squarenote 15, 196, 0, 6
+	squarenote 10, 108, 128, 7
+	squarenote 8, 113, 132, 7
 	endchannel
 
 
 SFX_1f_unused_Ch5:
 	dutycycle 5
-	unknownsfx0x20 15, 160, 65, 7
-	unknownsfx0x20 15, 176, 67, 7
-	unknownsfx0x20 15, 147, 177, 5
-	unknownsfx0x20 15, 148, 193, 5
-	unknownsfx0x20 10, 76, 65, 7
-	unknownsfx0x20 8, 49, 70, 7
+	squarenote 15, 160, 65, 7
+	squarenote 15, 176, 67, 7
+	squarenote 15, 147, 177, 5
+	squarenote 15, 148, 193, 5
+	squarenote 10, 76, 65, 7
+	squarenote 8, 49, 70, 7
 	endchannel
 
 
 SFX_1f_unused_Ch7:
-	unknownnoise0x20 2, 242, 76
-	unknownnoise0x20 6, 224, 58
-	unknownnoise0x20 15, 208, 58
-	unknownnoise0x20 8, 208, 44
-	unknownnoise0x20 6, 230, 76
-	unknownnoise0x20 12, 125, 76
-	unknownnoise0x20 15, 211, 76
+	noisenote 2, 242, 76
+	noisenote 6, 224, 58
+	noisenote 15, 208, 58
+	noisenote 8, 208, 44
+	noisenote 6, 230, 76
+	noisenote 12, 125, 76
+	noisenote 15, 211, 76
 	endchannel

--- a/audio/sfx/vine_whip.asm
+++ b/audio/sfx/vine_whip.asm
@@ -1,10 +1,10 @@
 SFX_Vine_Whip_Ch7:
-	unknownnoise0x20 1, 194, 51
-	unknownnoise0x20 2, 242, 33
-	unknownnoise0x20 1, 226, 51
-	unknownnoise0x20 1, 194, 50
-	unknownnoise0x20 1, 146, 18
-	unknownnoise0x20 1, 178, 49
-	unknownnoise0x20 12, 145, 16
-	unknownnoise0x20 8, 242, 65
+	noisenote 1, 194, 51
+	noisenote 2, 242, 33
+	noisenote 1, 226, 51
+	noisenote 1, 194, 50
+	noisenote 1, 146, 18
+	noisenote 1, 178, 49
+	noisenote 12, 145, 16
+	noisenote 8, 242, 65
 	endchannel

--- a/audio/sfx/withdraw_deposit_1.asm
+++ b/audio/sfx/withdraw_deposit_1.asm
@@ -1,12 +1,12 @@
 SFX_Withdraw_Deposit_1_Ch4:
 	duty 1
-	unknownsfx0x10 58
-	unknownsfx0x20 4, 242, 0, 5
-	unknownsfx0x10 34
-	unknownsfx0x20 4, 226, 0, 5
-	unknownsfx0x10 58
-	unknownsfx0x20 4, 242, 0, 7
-	unknownsfx0x10 34
-	unknownsfx0x20 15, 226, 0, 7
-	unknownsfx0x10 8
+	pitchenvelope 58
+	squarenote 4, 242, 0, 5
+	pitchenvelope 34
+	squarenote 4, 226, 0, 5
+	pitchenvelope 58
+	squarenote 4, 242, 0, 7
+	pitchenvelope 34
+	squarenote 15, 226, 0, 7
+	pitchenvelope 8
 	endchannel

--- a/audio/sfx/withdraw_deposit_3.asm
+++ b/audio/sfx/withdraw_deposit_3.asm
@@ -1,12 +1,12 @@
 SFX_Withdraw_Deposit_3_Ch4:
 	duty 1
-	unknownsfx0x10 58
-	unknownsfx0x20 4, 242, 0, 5
-	unknownsfx0x10 34
-	unknownsfx0x20 4, 226, 0, 5
-	unknownsfx0x10 58
-	unknownsfx0x20 4, 242, 0, 7
-	unknownsfx0x10 34
-	unknownsfx0x20 15, 226, 0, 7
-	unknownsfx0x10 8
+	pitchenvelope 58
+	squarenote 4, 242, 0, 5
+	pitchenvelope 34
+	squarenote 4, 226, 0, 5
+	pitchenvelope 58
+	squarenote 4, 242, 0, 7
+	pitchenvelope 34
+	squarenote 15, 226, 0, 7
+	pitchenvelope 8
 	endchannel

--- a/macros/audio_macros.asm
+++ b/macros/audio_macros.asm
@@ -30,19 +30,19 @@ audio: MACRO
 	ENDC
 ENDM
 
-eSquarePitchEnvelope: MACRO
+eSquarePitchEnvelope: MACRO ; this was originally unknownsfx0x10
 	db $10
 	db \1
 ENDM
 
-SquareSound: MACRO
+SquareSound: MACRO ; this was originally unknownsfx0x20
 	db $20 | \1
 	db \2
 	db \3
 	db \4
 ENDM
 
-NoiseSound: MACRO
+NoiseSound: MACRO ; this was originally unknownnoise0x20
 	db $20 | \1
 	db \2
 	db \3

--- a/macros/audio_macros.asm
+++ b/macros/audio_macros.asm
@@ -30,19 +30,19 @@ audio: MACRO
 	ENDC
 ENDM
 
-eSquarePitchEnvelope: MACRO ; this was originally unknownsfx0x10
+pitchenvelope: MACRO ; this was originally unknownsfx0x10
 	db $10
 	db \1
 ENDM
 
-SquareSound: MACRO ; this was originally unknownsfx0x20
+squarenote: MACRO ; this was originally unknownsfx0x20
 	db $20 | \1
 	db \2
 	db \3
 	db \4
 ENDM
 
-NoiseSound: MACRO ; this was originally unknownnoise0x20
+noisenote: MACRO ; this was originally unknownnoise0x20
 	db $20 | \1
 	db \2
 	db \3

--- a/macros/audio_macros.asm
+++ b/macros/audio_macros.asm
@@ -30,19 +30,19 @@ audio: MACRO
 	ENDC
 ENDM
 
-unknownsfx0x10: MACRO
+eSquarePitchEnvelope: MACRO
 	db $10
 	db \1
 ENDM
 
-unknownsfx0x20: MACRO
+SquareSound: MACRO
 	db $20 | \1
 	db \2
 	db \3
 	db \4
 ENDM
 
-unknownnoise0x20: MACRO
+NoiseSound: MACRO
 	db $20 | \1
 	db \2
 	db \3


### PR DESCRIPTION
Through personal experimentation, I discovered what unknownsfx0x20, unknownsfx0x10 and unknownnoise0x20 do. Namely, two of them are for generating a sound/note and one is an effect that modifies how they sound, so in my fork I've renamed them accordingly (squarenote, pitchenvelope and noisenote, respectively).