### PR TITLE
Replaced instances of Mon### with the Pokemon's name

### DIFF
--- a/data/evos_moves.asm
+++ b/data/evos_moves.asm
@@ -1,197 +1,196 @@
 EvosMovesPointerTable:
-	dw Mon112_EvosMoves
-	dw Mon115_EvosMoves
-	dw Mon032_EvosMoves
-	dw Mon035_EvosMoves
-	dw Mon021_EvosMoves
-	dw Mon100_EvosMoves
-	dw Mon034_EvosMoves
-	dw Mon080_EvosMoves
-	dw Mon002_EvosMoves
-	dw Mon103_EvosMoves
-	dw Mon108_EvosMoves
-	dw Mon102_EvosMoves
-	dw Mon088_EvosMoves
-	dw Mon094_EvosMoves
-	dw Mon029_EvosMoves
-	dw Mon031_EvosMoves
-	dw Mon104_EvosMoves
-	dw Mon111_EvosMoves
-	dw Mon131_EvosMoves
-	dw Mon059_EvosMoves
-	dw Mon151_EvosMoves
-	dw Mon130_EvosMoves
-	dw Mon090_EvosMoves
-	dw Mon072_EvosMoves
-	dw Mon092_EvosMoves
-	dw Mon123_EvosMoves
-	dw Mon120_EvosMoves
-	dw Mon009_EvosMoves
-	dw Mon127_EvosMoves
-	dw Mon114_EvosMoves
-	dw Mon152_EvosMoves ;MissingNo
-	dw Mon153_EvosMoves ;MissingNo
-	dw Mon058_EvosMoves
-	dw Mon095_EvosMoves
-	dw Mon022_EvosMoves
-	dw Mon016_EvosMoves
-	dw Mon079_EvosMoves
-	dw Mon064_EvosMoves
-	dw Mon075_EvosMoves
-	dw Mon113_EvosMoves
-	dw Mon067_EvosMoves
-	dw Mon122_EvosMoves
-	dw Mon106_EvosMoves
-	dw Mon107_EvosMoves
-	dw Mon024_EvosMoves
-	dw Mon047_EvosMoves
-	dw Mon054_EvosMoves
-	dw Mon096_EvosMoves
-	dw Mon076_EvosMoves
-	dw Mon154_EvosMoves ;MissingNo
-	dw Mon126_EvosMoves
-	dw Mon155_EvosMoves ;MissingNo
-	dw Mon125_EvosMoves
-	dw Mon082_EvosMoves
-	dw Mon109_EvosMoves
-	dw Mon156_EvosMoves ;MissingNo
-	dw Mon056_EvosMoves
-	dw Mon086_EvosMoves
-	dw Mon050_EvosMoves
-	dw Mon128_EvosMoves
-	dw Mon157_EvosMoves ;MissingNo
-	dw Mon158_EvosMoves ;MissingNo
-	dw Mon159_EvosMoves ;MissingNo
-	dw Mon083_EvosMoves
-	dw Mon048_EvosMoves
-	dw Mon149_EvosMoves
-	dw Mon160_EvosMoves ;MissingNo
-	dw Mon161_EvosMoves ;MissingNo
-	dw Mon162_EvosMoves ;MissingNo
-	dw Mon084_EvosMoves
-	dw Mon060_EvosMoves
-	dw Mon124_EvosMoves
-	dw Mon146_EvosMoves
-	dw Mon144_EvosMoves
-	dw Mon145_EvosMoves
-	dw Mon132_EvosMoves
-	dw Mon052_EvosMoves
-	dw Mon098_EvosMoves
-	dw Mon163_EvosMoves ;MissingNo
-	dw Mon164_EvosMoves ;MissingNo
-	dw Mon165_EvosMoves ;MissingNo
-	dw Mon037_EvosMoves
-	dw Mon038_EvosMoves
-	dw Mon025_EvosMoves
-	dw Mon026_EvosMoves
-	dw Mon166_EvosMoves ;MissingNo
-	dw Mon167_EvosMoves ;MissingNo
-	dw Mon147_EvosMoves
-	dw Mon148_EvosMoves
-	dw Mon140_EvosMoves
-	dw Mon141_EvosMoves
-	dw Mon116_EvosMoves
-	dw Mon117_EvosMoves
-	dw Mon168_EvosMoves ;MissingNo
-	dw Mon169_EvosMoves ;MissingNo
-	dw Mon027_EvosMoves
-	dw Mon028_EvosMoves
-	dw Mon138_EvosMoves
-	dw Mon139_EvosMoves
-	dw Mon039_EvosMoves
-	dw Mon040_EvosMoves
-	dw Mon133_EvosMoves
-	dw Mon136_EvosMoves
-	dw Mon135_EvosMoves
-	dw Mon134_EvosMoves
-	dw Mon066_EvosMoves
-	dw Mon041_EvosMoves
-	dw Mon023_EvosMoves
-	dw Mon046_EvosMoves
-	dw Mon061_EvosMoves
-	dw Mon062_EvosMoves
-	dw Mon013_EvosMoves
-	dw Mon014_EvosMoves
-	dw Mon015_EvosMoves
-	dw Mon170_EvosMoves ;MissingNo
-	dw Mon085_EvosMoves
-	dw Mon057_EvosMoves
-	dw Mon051_EvosMoves
-	dw Mon049_EvosMoves
-	dw Mon087_EvosMoves
-	dw Mon171_EvosMoves ;MissingNo
-	dw Mon172_EvosMoves ;MissingNo
-	dw Mon010_EvosMoves
-	dw Mon011_EvosMoves
-	dw Mon012_EvosMoves
-	dw Mon068_EvosMoves
-	dw Mon173_EvosMoves ;MissingNo
-	dw Mon055_EvosMoves
-	dw Mon097_EvosMoves
-	dw Mon042_EvosMoves
-	dw Mon150_EvosMoves
-	dw Mon143_EvosMoves
-	dw Mon129_EvosMoves
-	dw Mon174_EvosMoves ;MissingNo
-	dw Mon175_EvosMoves ;MissingNo
-	dw Mon089_EvosMoves
-	dw Mon176_EvosMoves ;MissingNo
-	dw Mon099_EvosMoves
-	dw Mon091_EvosMoves
-	dw Mon177_EvosMoves ;MissingNo
-	dw Mon101_EvosMoves
-	dw Mon036_EvosMoves
-	dw Mon110_EvosMoves
-	dw Mon053_EvosMoves
-	dw Mon105_EvosMoves
-	dw Mon178_EvosMoves ;MissingNo
-	dw Mon093_EvosMoves
-	dw Mon063_EvosMoves
-	dw Mon065_EvosMoves
-	dw Mon017_EvosMoves
-	dw Mon018_EvosMoves
-	dw Mon121_EvosMoves
-	dw Mon001_EvosMoves
-	dw Mon003_EvosMoves
-	dw Mon073_EvosMoves
-	dw Mon179_EvosMoves ;MissingNo
-	dw Mon118_EvosMoves
-	dw Mon119_EvosMoves
-	dw Mon180_EvosMoves ;MissingNo
-	dw Mon181_EvosMoves ;MissingNo
-	dw Mon182_EvosMoves ;MissingNo
-	dw Mon183_EvosMoves ;MissingNo
-	dw Mon077_EvosMoves
-	dw Mon078_EvosMoves
-	dw Mon019_EvosMoves
-	dw Mon020_EvosMoves
-	dw Mon033_EvosMoves
-	dw Mon030_EvosMoves
-	dw Mon074_EvosMoves
-	dw Mon137_EvosMoves
-	dw Mon142_EvosMoves
-	dw Mon184_EvosMoves ;MissingNo
-	dw Mon081_EvosMoves
-	dw Mon185_EvosMoves ;MissingNo
-	dw Mon186_EvosMoves ;MissingNo
-	dw Mon004_EvosMoves
-	dw Mon007_EvosMoves
-	dw Mon005_EvosMoves
-	dw Mon008_EvosMoves
-	dw Mon006_EvosMoves
-	dw Mon187_EvosMoves ;MissingNo
-	dw Mon188_EvosMoves ;MissingNo
-	dw Mon189_EvosMoves ;MissingNo
-	dw Mon190_EvosMoves ;MissingNo
-	dw Mon043_EvosMoves
-	dw Mon044_EvosMoves
-	dw Mon045_EvosMoves
-	dw Mon069_EvosMoves
-	dw Mon070_EvosMoves
-	dw Mon071_EvosMoves
+	dw RHYDON_EvosMoves
+	dw KANGASKHAN_EvosMoves
+	dw NIDORAN_M_EvosMoves
+	dw CLEFAIRY_EvosMoves
+	dw SPEAROW_EvosMoves
+	dw VOLTORB_EvosMoves
+	dw NIDOKING_EvosMoves
+	dw SLOWBRO_EvosMoves
+	dw IVYSAUR_EvosMoves
+	dw EXEGGUTOR_EvosMoves
+	dw LICKITUNG_EvosMoves
+	dw EXEGGCUTE_EvosMoves
+	dw GRIMER_EvosMoves
+	dw GENGAR_EvosMoves
+	dw NIDORAN_F_EvosMoves
+	dw NIDOQUEEN_EvosMoves
+	dw CUBONE_EvosMoves
+	dw RHYHORN_EvosMoves
+	dw LAPRAS_EvosMoves
+	dw ARCANINE_EvosMoves
+	dw MEW_EvosMoves
+	dw GYARADOS_EvosMoves
+	dw SHELLDER_EvosMoves
+	dw TENTACOOL_EvosMoves
+	dw GASTLY_EvosMoves
+	dw SCYTHER_EvosMoves
+	dw STARYU_EvosMoves
+	dw BLASTOISE_EvosMoves
+	dw PINSIR_EvosMoves
+	dw TANGELA_EvosMoves
+	dw MISSINGNO_1F_EvosMoves
+	dw MISSINGNO_20_EvosMoves
+	dw GROWLITHE_EvosMoves
+	dw ONIX_EvosMoves
+	dw FEAROW_EvosMoves
+	dw PIDGEY_EvosMoves
+	dw SLOWPOKE_EvosMoves
+	dw KADABRA_EvosMoves
+	dw GRAVELER_EvosMoves
+	dw CHANSEY_EvosMoves
+	dw MACHOKE_EvosMoves
+	dw MR_MIME_EvosMoves
+	dw HITMONLEE_EvosMoves
+	dw HITMONCHAN_EvosMoves
+	dw ARBOK_EvosMoves
+	dw PARASECT_EvosMoves
+	dw PSYDUCK_EvosMoves
+	dw DROWZEE_EvosMoves
+	dw GOLEM_EvosMoves
+	dw MISSINGNO_32_EvosMoves
+	dw MAGMAR_EvosMoves
+	dw MISSINGNO_34_EvosMoves
+	dw ELECTABUZZ_EvosMoves
+	dw MAGNETON_EvosMoves
+	dw KOFFING_EvosMoves
+	dw MISSINGNO_38_EvosMoves
+	dw MANKEY_EvosMoves
+	dw SEEL_EvosMoves
+	dw DIGLETT_EvosMoves
+	dw TAUROS_EvosMoves
+	dw MISSINGNO_3D_EvosMoves
+	dw MISSINGNO_3E_EvosMoves
+	dw MISSINGNO_3F_EvosMoves
+	dw FARFETCHD_EvosMoves
+	dw VENONAT_EvosMoves
+	dw DRAGONITE_EvosMoves
+	dw MISSINGNO_43_EvosMoves
+	dw MISSINGNO_44_EvosMoves
+	dw MISSINGNO_45_EvosMoves
+	dw DODUO_EvosMoves
+	dw POLIWAG_EvosMoves
+	dw JYNX_EvosMoves
+	dw MOLTRES_EvosMoves
+	dw ARTICUNO_EvosMoves
+	dw ZAPDOS_EvosMoves
+	dw DITTO_EvosMoves
+	dw MEOWTH_EvosMoves
+	dw KRABBY_EvosMoves
+	dw MISSINGNO_4F_EvosMoves
+	dw MISSINGNO_50_EvosMoves
+	dw MISSINGNO_51_EvosMoves
+	dw VULPIX_EvosMoves
+	dw NINETALES_EvosMoves
+	dw PIKACHU_EvosMoves
+	dw RAICHU_EvosMoves
+	dw MISSINGNO_56_EvosMoves
+	dw MISSINGNO_57_EvosMoves
+	dw DRATINI_EvosMoves
+	dw DRAGONAIR_EvosMoves
+	dw KABUTO_EvosMoves
+	dw KABUTOPS_EvosMoves
+	dw HORSEA_EvosMoves
+	dw SEADRA_EvosMoves
+	dw MISSINGNO_5E_EvosMoves
+	dw MISSINGNO_5F_EvosMoves
+	dw SANDSHREW_EvosMoves
+	dw SANDSLASH_EvosMoves
+	dw OMANYTE_EvosMoves
+	dw OMASTAR_EvosMoves
+	dw JIGGLYPUFF_EvosMoves
+	dw WIGGLYTUFF_EvosMoves
+	dw EEVEE_EvosMoves
+	dw FLAREON_EvosMoves
+	dw JOLTEON_EvosMoves
+	dw VAPOREON_EvosMoves
+	dw MACHOP_EvosMoves
+	dw ZUBAT_EvosMoves
+	dw EKANS_EvosMoves
+	dw PARAS_EvosMoves
+	dw POLIWHIRL_EvosMoves
+	dw POLIWRATH_EvosMoves
+	dw WEEDLE_EvosMoves
+	dw KAKUNA_EvosMoves
+	dw BEEDRILL_EvosMoves
+	dw MISSINGNO_73_EvosMoves
+	dw DODRIO_EvosMoves
+	dw PRIMEAPE_EvosMoves
+	dw DUGTRIO_EvosMoves
+	dw VENOMOTH_EvosMoves
+	dw DEWGONG_EvosMoves
+	dw MISSINGNO_79_EvosMoves
+	dw MISSINGNO_7A_EvosMoves
+	dw CATERPIE_EvosMoves
+	dw METAPOD_EvosMoves
+	dw BUTTERFREE_EvosMoves
+	dw MACHAMP_EvosMoves
+	dw MISSINGNO_7F_EvosMoves
+	dw GOLDUCK_EvosMoves
+	dw HYPNO_EvosMoves
+	dw GOLBAT_EvosMoves
+	dw MEWTWO_EvosMoves
+	dw SNORLAX_EvosMoves
+	dw MAGIKARP_EvosMoves
+	dw MISSINGNO_86_EvosMoves
+	dw MISSINGNO_87_EvosMoves
+	dw MUK_EvosMoves
+	dw MISSINGNO_8A_EvosMoves
+	dw KINGLER_EvosMoves
+	dw CLOYSTER_EvosMoves
+	dw MISSINGNO_8C_EvosMoves
+	dw ELECTRODE_EvosMoves
+	dw CLEFABLE_EvosMoves
+	dw WEEZING_EvosMoves
+	dw PERSIAN_EvosMoves
+	dw MAROWAK_EvosMoves
+	dw MISSINGNO_92_EvosMoves
+	dw HAUNTER_EvosMoves
+	dw ABRA_EvosMoves
+	dw ALAKAZAM_EvosMoves
+	dw PIDGEOTTO_EvosMoves
+	dw PIDGEOT_EvosMoves
+	dw STARMIE_EvosMoves
+	dw BULBASAUR_EvosMoves
+	dw VENUSAUR_EvosMoves
+	dw TENTACRUEL_EvosMoves
+	dw MISSINGNO_9C_EvosMoves
+	dw GOLDEEN_EvosMoves
+	dw SEAKING_EvosMoves
+	dw MISSINGNO_9F_EvosMoves
+	dw MISSINGNO_A0_EvosMoves
+	dw MISSINGNO_A1_EvosMoves
+	dw MISSINGNO_A2_EvosMoves
+	dw PONYTA_EvosMoves
+	dw RAPIDASH_EvosMoves
+	dw RATTATA_EvosMoves
+	dw RATICATE_EvosMoves
+	dw NIDORINO_EvosMoves
+	dw NIDORINA_EvosMoves
+	dw GEODUDE_EvosMoves
+	dw PORYGON_EvosMoves
+	dw AERODACTYL_EvosMoves
+	dw MISSINGNO_AC_EvosMoves
+	dw MAGNEMITE_EvosMoves
+	dw MISSINGNO_AE_EvosMoves
+	dw MISSINGNO_AF_EvosMoves
+	dw CHARMANDER_EvosMoves
+	dw SQUIRTLE_EvosMoves
+	dw CHARMELEON_EvosMoves
+	dw WARTORTLE_EvosMoves
+	dw CHARIZARD_EvosMoves
+	dw MISSINGNO_B5_EvosMoves
+	dw FOSSIL_KABUTOPS_EvosMoves
+	dw FOSSIL_AERODACTYL_EvosMoves
+	dw MON_GHOST_EvosMoves
+	dw ODDISH_EvosMoves
+	dw GLOOM_EvosMoves
+	dw VILEPLUME_EvosMoves
+	dw BELLSPROUT_EvosMoves
+	dw WEEPINBELL_EvosMoves
+	dw VICTREEBEL_EvosMoves
 
-Mon112_EvosMoves:
-;RHYDON
+RHYDON_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -203,8 +202,7 @@ Mon112_EvosMoves:
 	db 64,TAKE_DOWN
 	db 0
 
-Mon115_EvosMoves:
-;KANGASKHAN
+KANGASKHAN_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -215,8 +213,7 @@ Mon115_EvosMoves:
 	db 46,DIZZY_PUNCH
 	db 0
 
-Mon032_EvosMoves:
-;NIDORAN_M
+NIDORAN_M_EvosMoves
 ;Evolutions
 	db EV_LEVEL,16,NIDORINO
 	db 0
@@ -229,8 +226,7 @@ Mon032_EvosMoves:
 	db 43,DOUBLE_KICK
 	db 0
 
-Mon035_EvosMoves:
-;CLEFAIRY
+CLEFAIRY_EvosMoves
 ;Evolutions
 	db EV_ITEM,MOON_STONE,1,CLEFABLE
 	db 0
@@ -243,8 +239,7 @@ Mon035_EvosMoves:
 	db 48,LIGHT_SCREEN
 	db 0
 
-Mon021_EvosMoves:
-;SPEAROW
+SPEAROW_EvosMoves
 ;Evolutions
 	db EV_LEVEL,20,FEAROW
 	db 0
@@ -256,8 +251,7 @@ Mon021_EvosMoves:
 	db 36,AGILITY
 	db 0
 
-Mon100_EvosMoves:
-;VOLTORB
+VOLTORB_EvosMoves
 ;Evolutions
 	db EV_LEVEL,30,ELECTRODE
 	db 0
@@ -269,8 +263,7 @@ Mon100_EvosMoves:
 	db 43,EXPLOSION
 	db 0
 
-Mon034_EvosMoves:
-;NIDOKING
+NIDOKING_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -279,8 +272,7 @@ Mon034_EvosMoves:
 	db 23,THRASH
 	db 0
 
-Mon080_EvosMoves:
-;SLOWBRO
+SLOWBRO_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -293,8 +285,7 @@ Mon080_EvosMoves:
 	db 55,PSYCHIC_M
 	db 0
 
-Mon002_EvosMoves:
-;IVYSAUR
+IVYSAUR_EvosMoves
 ;Evolutions
 	db EV_LEVEL,32,VENUSAUR
 	db 0
@@ -308,16 +299,14 @@ Mon002_EvosMoves:
 	db 54,SOLARBEAM
 	db 0
 
-Mon103_EvosMoves:
-;EXEGGUTOR
+EXEGGUTOR_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 28,STOMP
 	db 0
 
-Mon108_EvosMoves:
-;LICKITUNG
+LICKITUNG_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -328,8 +317,7 @@ Mon108_EvosMoves:
 	db 39,SCREECH
 	db 0
 
-Mon102_EvosMoves:
-;EXEGGCUTE
+EXEGGCUTE_EvosMoves
 ;Evolutions
 	db EV_ITEM,LEAF_STONE,1,EXEGGUTOR
 	db 0
@@ -342,8 +330,7 @@ Mon102_EvosMoves:
 	db 48,SLEEP_POWDER
 	db 0
 
-Mon088_EvosMoves:
-;GRIMER
+GRIMER_EvosMoves
 ;Evolutions
 	db EV_LEVEL,38,MUK
 	db 0
@@ -356,8 +343,7 @@ Mon088_EvosMoves:
 	db 55,ACID_ARMOR
 	db 0
 
-Mon094_EvosMoves:
-;GENGAR
+GENGAR_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -365,8 +351,7 @@ Mon094_EvosMoves:
 	db 38,DREAM_EATER
 	db 0
 
-Mon029_EvosMoves:
-;NIDORAN_F
+NIDORAN_F_EvosMoves
 ;Evolutions
 	db EV_LEVEL,16,NIDORINA
 	db 0
@@ -379,8 +364,7 @@ Mon029_EvosMoves:
 	db 43,DOUBLE_KICK
 	db 0
 
-Mon031_EvosMoves:
-;NIDOQUEEN
+NIDOQUEEN_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -389,8 +373,7 @@ Mon031_EvosMoves:
 	db 23,BODY_SLAM
 	db 0
 
-Mon104_EvosMoves:
-;CUBONE
+CUBONE_EvosMoves
 ;Evolutions
 	db EV_LEVEL,28,MAROWAK
 	db 0
@@ -402,8 +385,7 @@ Mon104_EvosMoves:
 	db 46,RAGE
 	db 0
 
-Mon111_EvosMoves:
-;RHYHORN
+RHYHORN_EvosMoves
 ;Evolutions
 	db EV_LEVEL,42,RHYDON
 	db 0
@@ -416,8 +398,7 @@ Mon111_EvosMoves:
 	db 55,TAKE_DOWN
 	db 0
 
-Mon131_EvosMoves:
-;LAPRAS
+LAPRAS_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -429,15 +410,13 @@ Mon131_EvosMoves:
 	db 46,HYDRO_PUMP
 	db 0
 
-Mon059_EvosMoves:
-;ARCANINE
+ARCANINE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon151_EvosMoves:
-;MEW
+MEW_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -447,8 +426,7 @@ Mon151_EvosMoves:
 	db 40,PSYCHIC_M
 	db 0
 
-Mon130_EvosMoves:
-;GYARADOS
+GYARADOS_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -459,8 +437,7 @@ Mon130_EvosMoves:
 	db 52,HYPER_BEAM
 	db 0
 
-Mon090_EvosMoves:
-;SHELLDER
+SHELLDER_EvosMoves
 ;Evolutions
 	db EV_ITEM,WATER_STONE,1,CLOYSTER
 	db 0
@@ -472,8 +449,7 @@ Mon090_EvosMoves:
 	db 50,ICE_BEAM
 	db 0
 
-Mon072_EvosMoves:
-;TENTACOOL
+TENTACOOL_EvosMoves
 ;Evolutions
 	db EV_LEVEL,30,TENTACRUEL
 	db 0
@@ -488,8 +464,7 @@ Mon072_EvosMoves:
 	db 48,HYDRO_PUMP
 	db 0
 
-Mon092_EvosMoves:
-;GASTLY
+GASTLY_EvosMoves
 ;Evolutions
 	db EV_LEVEL,25,HAUNTER
 	db 0
@@ -498,8 +473,7 @@ Mon092_EvosMoves:
 	db 35,DREAM_EATER
 	db 0
 
-Mon123_EvosMoves:
-;SCYTHER
+SCYTHER_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -511,8 +485,7 @@ Mon123_EvosMoves:
 	db 42,AGILITY
 	db 0
 
-Mon120_EvosMoves:
-;STARYU
+STARYU_EvosMoves
 ;Evolutions
 	db EV_ITEM,WATER_STONE,1,STARMIE
 	db 0
@@ -526,8 +499,7 @@ Mon120_EvosMoves:
 	db 47,HYDRO_PUMP
 	db 0
 
-Mon009_EvosMoves:
-;BLASTOISE
+BLASTOISE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -539,8 +511,7 @@ Mon009_EvosMoves:
 	db 52,HYDRO_PUMP
 	db 0
 
-Mon127_EvosMoves:
-;PINSIR
+PINSIR_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -552,8 +523,7 @@ Mon127_EvosMoves:
 	db 54,SWORDS_DANCE
 	db 0
 
-Mon114_EvosMoves:
-;TANGELA
+TANGELA_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -565,22 +535,19 @@ Mon114_EvosMoves:
 	db 49,GROWTH
 	db 0
 
-Mon152_EvosMoves:
-;MISSINGNO
+MISSINGNO_1F_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon153_EvosMoves:
-;MISSINGNO
+MISSINGNO_20_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon058_EvosMoves:
-;GROWLITHE
+GROWLITHE_EvosMoves
 ;Evolutions
 	db EV_ITEM,FIRE_STONE,1,ARCANINE
 	db 0
@@ -592,8 +559,7 @@ Mon058_EvosMoves:
 	db 50,FLAMETHROWER
 	db 0
 
-Mon095_EvosMoves:
-;ONIX
+ONIX_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -604,8 +570,7 @@ Mon095_EvosMoves:
 	db 43,HARDEN
 	db 0
 
-Mon022_EvosMoves:
-;FEAROW
+FEAROW_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -616,8 +581,7 @@ Mon022_EvosMoves:
 	db 43,AGILITY
 	db 0
 
-Mon016_EvosMoves:
-;PIDGEY
+PIDGEY_EvosMoves
 ;Evolutions
 	db EV_LEVEL,18,PIDGEOTTO
 	db 0
@@ -630,8 +594,7 @@ Mon016_EvosMoves:
 	db 44,MIRROR_MOVE
 	db 0
 
-Mon079_EvosMoves:
-;SLOWPOKE
+SLOWPOKE_EvosMoves
 ;Evolutions
 	db EV_LEVEL,37,SLOWBRO
 	db 0
@@ -644,8 +607,7 @@ Mon079_EvosMoves:
 	db 48,PSYCHIC_M
 	db 0
 
-Mon064_EvosMoves:
-;KADABRA
+KADABRA_EvosMoves
 ;Evolutions
 	db EV_TRADE,1,ALAKAZAM
 	db 0
@@ -658,8 +620,7 @@ Mon064_EvosMoves:
 	db 42,REFLECT
 	db 0
 
-Mon075_EvosMoves:
-;GRAVELER
+GRAVELER_EvosMoves
 ;Evolutions
 	db EV_TRADE,1,GOLEM
 	db 0
@@ -672,8 +633,7 @@ Mon075_EvosMoves:
 	db 43,EXPLOSION
 	db 0
 
-Mon113_EvosMoves:
-;CHANSEY
+CHANSEY_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -685,8 +645,7 @@ Mon113_EvosMoves:
 	db 54,DOUBLE_EDGE
 	db 0
 
-Mon067_EvosMoves:
-;MACHOKE
+MACHOKE_EvosMoves
 ;Evolutions
 	db EV_TRADE,1,MACHAMP
 	db 0
@@ -698,8 +657,7 @@ Mon067_EvosMoves:
 	db 52,SUBMISSION
 	db 0
 
-Mon122_EvosMoves:
-;MR_MIME
+MR_MIME_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -710,8 +668,7 @@ Mon122_EvosMoves:
 	db 47,SUBSTITUTE
 	db 0
 
-Mon106_EvosMoves:
-;HITMONLEE
+HITMONLEE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -722,8 +679,7 @@ Mon106_EvosMoves:
 	db 53,MEGA_KICK
 	db 0
 
-Mon107_EvosMoves:
-;HITMONCHAN
+HITMONCHAN_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -734,8 +690,7 @@ Mon107_EvosMoves:
 	db 53,COUNTER
 	db 0
 
-Mon024_EvosMoves:
-;ARBOK
+ARBOK_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -746,8 +701,7 @@ Mon024_EvosMoves:
 	db 47,ACID
 	db 0
 
-Mon047_EvosMoves:
-;PARASECT
+PARASECT_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -758,8 +712,7 @@ Mon047_EvosMoves:
 	db 48,GROWTH
 	db 0
 
-Mon054_EvosMoves:
-;PSYDUCK
+PSYDUCK_EvosMoves
 ;Evolutions
 	db EV_LEVEL,33,GOLDUCK
 	db 0
@@ -771,8 +724,7 @@ Mon054_EvosMoves:
 	db 52,HYDRO_PUMP
 	db 0
 
-Mon096_EvosMoves:
-;DROWZEE
+DROWZEE_EvosMoves
 ;Evolutions
 	db EV_LEVEL,26,HYPNO
 	db 0
@@ -785,8 +737,7 @@ Mon096_EvosMoves:
 	db 37,MEDITATE
 	db 0
 
-Mon076_EvosMoves:
-;GOLEM
+GOLEM_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -798,15 +749,13 @@ Mon076_EvosMoves:
 	db 43,EXPLOSION
 	db 0
 
-Mon154_EvosMoves:
-;MISSINGNO
+MISSINGNO_32_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon126_EvosMoves:
-;MAGMAR
+MAGMAR_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -818,15 +767,13 @@ Mon126_EvosMoves:
 	db 55,FLAMETHROWER
 	db 0
 
-Mon155_EvosMoves:
-;MISSINGNO
+MISSINGNO_34_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon125_EvosMoves:
-;ELECTABUZZ
+ELECTABUZZ_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -837,8 +784,7 @@ Mon125_EvosMoves:
 	db 54,THUNDER
 	db 0
 
-Mon082_EvosMoves:
-;MAGNETON
+MAGNETON_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -850,8 +796,7 @@ Mon082_EvosMoves:
 	db 54,SCREECH
 	db 0
 
-Mon109_EvosMoves:
-;KOFFING
+KOFFING_EvosMoves
 ;Evolutions
 	db EV_LEVEL,35,WEEZING
 	db 0
@@ -863,15 +808,13 @@ Mon109_EvosMoves:
 	db 48,EXPLOSION
 	db 0
 
-Mon156_EvosMoves:
-;MISSINGNO
+MISSINGNO_38_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon056_EvosMoves:
-;MANKEY
+MANKEY_EvosMoves
 ;Evolutions
 	db EV_LEVEL,28,PRIMEAPE
 	db 0
@@ -883,8 +826,7 @@ Mon056_EvosMoves:
 	db 39,THRASH
 	db 0
 
-Mon086_EvosMoves:
-;SEEL
+SEEL_EvosMoves
 ;Evolutions
 	db EV_LEVEL,34,DEWGONG
 	db 0
@@ -896,8 +838,7 @@ Mon086_EvosMoves:
 	db 50,ICE_BEAM
 	db 0
 
-Mon050_EvosMoves:
-;DIGLETT
+DIGLETT_EvosMoves
 ;Evolutions
 	db EV_LEVEL,26,DUGTRIO
 	db 0
@@ -909,8 +850,7 @@ Mon050_EvosMoves:
 	db 40,EARTHQUAKE
 	db 0
 
-Mon128_EvosMoves:
-;TAUROS
+TAUROS_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -921,29 +861,25 @@ Mon128_EvosMoves:
 	db 51,TAKE_DOWN
 	db 0
 
-Mon157_EvosMoves:
-;MISSINGNO
+MISSINGNO_3D_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon158_EvosMoves:
-;MISSINGNO
+MISSINGNO_3E_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon159_EvosMoves:
-;MISSINGNO
+MISSINGNO_3F_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon083_EvosMoves:
-;FARFETCHD
+FARFETCHD_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -954,8 +890,7 @@ Mon083_EvosMoves:
 	db 39,SLASH
 	db 0
 
-Mon048_EvosMoves:
-;VENONAT
+VENONAT_EvosMoves
 ;Evolutions
 	db EV_LEVEL,31,VENOMOTH
 	db 0
@@ -968,8 +903,7 @@ Mon048_EvosMoves:
 	db 43,PSYCHIC_M
 	db 0
 
-Mon149_EvosMoves:
-;DRAGONITE
+DRAGONITE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -980,29 +914,25 @@ Mon149_EvosMoves:
 	db 60,HYPER_BEAM
 	db 0
 
-Mon160_EvosMoves:
-;MISSINGNO
+MISSINGNO_43_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon161_EvosMoves:
-;MISSINGNO
+MISSINGNO_44_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon162_EvosMoves:
-;MISSINGNO
+MISSINGNO_45_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon084_EvosMoves:
-;DODUO
+DODUO_EvosMoves
 ;Evolutions
 	db EV_LEVEL,31,DODRIO
 	db 0
@@ -1015,8 +945,7 @@ Mon084_EvosMoves:
 	db 44,AGILITY
 	db 0
 
-Mon060_EvosMoves:
-;POLIWAG
+POLIWAG_EvosMoves
 ;Evolutions
 	db EV_LEVEL,25,POLIWHIRL
 	db 0
@@ -1029,8 +958,7 @@ Mon060_EvosMoves:
 	db 45,HYDRO_PUMP
 	db 0
 
-Mon124_EvosMoves:
-;JYNX
+JYNX_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1042,8 +970,7 @@ Mon124_EvosMoves:
 	db 58,BLIZZARD
 	db 0
 
-Mon146_EvosMoves:
-;MOLTRES
+MOLTRES_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1052,8 +979,7 @@ Mon146_EvosMoves:
 	db 60,SKY_ATTACK
 	db 0
 
-Mon144_EvosMoves:
-;ARTICUNO
+ARTICUNO_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1062,8 +988,7 @@ Mon144_EvosMoves:
 	db 60,MIST
 	db 0
 
-Mon145_EvosMoves:
-;ZAPDOS
+ZAPDOS_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1072,15 +997,13 @@ Mon145_EvosMoves:
 	db 60,LIGHT_SCREEN
 	db 0
 
-Mon132_EvosMoves:
-;DITTO
+DITTO_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon052_EvosMoves:
-;MEOWTH
+MEOWTH_EvosMoves
 ;Evolutions
 	db EV_LEVEL,28,PERSIAN
 	db 0
@@ -1092,8 +1015,7 @@ Mon052_EvosMoves:
 	db 44,SLASH
 	db 0
 
-Mon098_EvosMoves:
-;KRABBY
+KRABBY_EvosMoves
 ;Evolutions
 	db EV_LEVEL,28,KINGLER
 	db 0
@@ -1105,29 +1027,25 @@ Mon098_EvosMoves:
 	db 40,HARDEN
 	db 0
 
-Mon163_EvosMoves:
-;MISSINGNO
+MISSINGNO_4F_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon164_EvosMoves:
-;MISSINGNO
+MISSINGNO_50_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon165_EvosMoves:
-;MISSINGNO
+MISSINGNO_51_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon037_EvosMoves:
-;VULPIX
+VULPIX_EvosMoves
 ;Evolutions
 	db EV_ITEM,FIRE_STONE,1,NINETALES
 	db 0
@@ -1139,15 +1057,13 @@ Mon037_EvosMoves:
 	db 42,FIRE_SPIN
 	db 0
 
-Mon038_EvosMoves:
-;NINETALES
+NINETALES_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon025_EvosMoves:
-;PIKACHU
+PIKACHU_EvosMoves
 ;Evolutions
 	db EV_ITEM,THUNDER_STONE,1,RAICHU
 	db 0
@@ -1159,29 +1075,25 @@ Mon025_EvosMoves:
 	db 43,THUNDER
 	db 0
 
-Mon026_EvosMoves:
-;RAICHU
+RAICHU_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon166_EvosMoves:
-;MISSINGNO
+MISSINGNO_56_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon167_EvosMoves:
-;MISSINGNO
+MISSINGNO_57_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon147_EvosMoves:
-;DRATINI
+DRATINI_EvosMoves
 ;Evolutions
 	db EV_LEVEL,30,DRAGONAIR
 	db 0
@@ -1193,8 +1105,7 @@ Mon147_EvosMoves:
 	db 50,HYPER_BEAM
 	db 0
 
-Mon148_EvosMoves:
-;DRAGONAIR
+DRAGONAIR_EvosMoves
 ;Evolutions
 	db EV_LEVEL,55,DRAGONITE
 	db 0
@@ -1206,8 +1117,7 @@ Mon148_EvosMoves:
 	db 55,HYPER_BEAM
 	db 0
 
-Mon140_EvosMoves:
-;KABUTO
+KABUTO_EvosMoves
 ;Evolutions
 	db EV_LEVEL,40,KABUTOPS
 	db 0
@@ -1218,8 +1128,7 @@ Mon140_EvosMoves:
 	db 49,HYDRO_PUMP
 	db 0
 
-Mon141_EvosMoves:
-;KABUTOPS
+KABUTOPS_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1229,8 +1138,7 @@ Mon141_EvosMoves:
 	db 53,HYDRO_PUMP
 	db 0
 
-Mon116_EvosMoves:
-;HORSEA
+HORSEA_EvosMoves
 ;Evolutions
 	db EV_LEVEL,32,SEADRA
 	db 0
@@ -1242,8 +1150,7 @@ Mon116_EvosMoves:
 	db 45,HYDRO_PUMP
 	db 0
 
-Mon117_EvosMoves:
-;SEADRA
+SEADRA_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1254,22 +1161,19 @@ Mon117_EvosMoves:
 	db 52,HYDRO_PUMP
 	db 0
 
-Mon168_EvosMoves:
-;MISSINGNO
+MISSINGNO_5E_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon169_EvosMoves:
-;MISSINGNO
+MISSINGNO_5F_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon027_EvosMoves:
-;SANDSHREW
+SANDSHREW_EvosMoves
 ;Evolutions
 	db EV_LEVEL,22,SANDSLASH
 	db 0
@@ -1281,8 +1185,7 @@ Mon027_EvosMoves:
 	db 38,FURY_SWIPES
 	db 0
 
-Mon028_EvosMoves:
-;SANDSLASH
+SANDSLASH_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1293,8 +1196,7 @@ Mon028_EvosMoves:
 	db 47,FURY_SWIPES
 	db 0
 
-Mon138_EvosMoves:
-;OMANYTE
+OMANYTE_EvosMoves
 ;Evolutions
 	db EV_LEVEL,40,OMASTAR
 	db 0
@@ -1305,8 +1207,7 @@ Mon138_EvosMoves:
 	db 53,HYDRO_PUMP
 	db 0
 
-Mon139_EvosMoves:
-;OMASTAR
+OMASTAR_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1316,8 +1217,7 @@ Mon139_EvosMoves:
 	db 49,HYDRO_PUMP
 	db 0
 
-Mon039_EvosMoves:
-;JIGGLYPUFF
+JIGGLYPUFF_EvosMoves
 ;Evolutions
 	db EV_ITEM,MOON_STONE,1,WIGGLYTUFF
 	db 0
@@ -1331,30 +1231,26 @@ Mon039_EvosMoves:
 	db 39,DOUBLE_EDGE
 	db 0
 
-Mon040_EvosMoves:
-;WIGGLYTUFF
+WIGGLYTUFF_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon133_EvosMoves:
-;EEVEE
+EEVEE_EvosMoves
 ;Evolutions
 	db EV_ITEM,FIRE_STONE,1,FLAREON
 	db EV_ITEM,THUNDER_STONE,1,JOLTEON
 	db EV_ITEM,WATER_STONE,1,VAPOREON
 	db 0
-Mon133_EvosEnd:
-;Learnset
+EEVEE_EvosEnd
 	db 27,QUICK_ATTACK
 	db 31,TAIL_WHIP
 	db 37,BITE
 	db 45,TAKE_DOWN
 	db 0
 
-Mon136_EvosMoves:
-;FLAREON
+FLAREON_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1368,8 +1264,7 @@ Mon136_EvosMoves:
 	db 54,FLAMETHROWER
 	db 0
 
-Mon135_EvosMoves:
-;JOLTEON
+JOLTEON_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1383,8 +1278,7 @@ Mon135_EvosMoves:
 	db 54,THUNDER
 	db 0
 
-Mon134_EvosMoves:
-;VAPOREON
+VAPOREON_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1398,8 +1292,7 @@ Mon134_EvosMoves:
 	db 54,HYDRO_PUMP
 	db 0
 
-Mon066_EvosMoves:
-;MACHOP
+MACHOP_EvosMoves
 ;Evolutions
 	db EV_LEVEL,28,MACHOKE
 	db 0
@@ -1411,8 +1304,7 @@ Mon066_EvosMoves:
 	db 46,SUBMISSION
 	db 0
 
-Mon041_EvosMoves:
-;ZUBAT
+ZUBAT_EvosMoves
 ;Evolutions
 	db EV_LEVEL,22,GOLBAT
 	db 0
@@ -1424,8 +1316,7 @@ Mon041_EvosMoves:
 	db 36,HAZE
 	db 0
 
-Mon023_EvosMoves:
-;EKANS
+EKANS_EvosMoves
 ;Evolutions
 	db EV_LEVEL,22,ARBOK
 	db 0
@@ -1437,8 +1328,7 @@ Mon023_EvosMoves:
 	db 38,ACID
 	db 0
 
-Mon046_EvosMoves:
-;PARAS
+PARAS_EvosMoves
 ;Evolutions
 	db EV_LEVEL,24,PARASECT
 	db 0
@@ -1450,8 +1340,7 @@ Mon046_EvosMoves:
 	db 41,GROWTH
 	db 0
 
-Mon061_EvosMoves:
-;POLIWHIRL
+POLIWHIRL_EvosMoves
 ;Evolutions
 	db EV_ITEM,WATER_STONE,1,POLIWRATH
 	db 0
@@ -1464,8 +1353,7 @@ Mon061_EvosMoves:
 	db 49,HYDRO_PUMP
 	db 0
 
-Mon062_EvosMoves:
-;POLIWRATH
+POLIWRATH_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1473,24 +1361,21 @@ Mon062_EvosMoves:
 	db 19,WATER_GUN
 	db 0
 
-Mon013_EvosMoves:
-;WEEDLE
+WEEDLE_EvosMoves
 ;Evolutions
 	db EV_LEVEL,7,KAKUNA
 	db 0
 ;Learnset
 	db 0
 
-Mon014_EvosMoves:
-;KAKUNA
+KAKUNA_EvosMoves
 ;Evolutions
 	db EV_LEVEL,10,BEEDRILL
 	db 0
 ;Learnset
 	db 0
 
-Mon015_EvosMoves:
-;BEEDRILL
+BEEDRILL_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1502,15 +1387,13 @@ Mon015_EvosMoves:
 	db 35,AGILITY
 	db 0
 
-Mon170_EvosMoves:
-;MISSINGNO
+MISSINGNO_73_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon085_EvosMoves:
-;DODRIO
+DODRIO_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1522,8 +1405,7 @@ Mon085_EvosMoves:
 	db 51,AGILITY
 	db 0
 
-Mon057_EvosMoves:
-;PRIMEAPE
+PRIMEAPE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1534,8 +1416,7 @@ Mon057_EvosMoves:
 	db 46,THRASH
 	db 0
 
-Mon051_EvosMoves:
-;DUGTRIO
+DUGTRIO_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1546,8 +1427,7 @@ Mon051_EvosMoves:
 	db 47,EARTHQUAKE
 	db 0
 
-Mon049_EvosMoves:
-;VENOMOTH
+VENOMOTH_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1559,8 +1439,7 @@ Mon049_EvosMoves:
 	db 50,PSYCHIC_M
 	db 0
 
-Mon087_EvosMoves:
-;DEWGONG
+DEWGONG_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1571,38 +1450,33 @@ Mon087_EvosMoves:
 	db 56,ICE_BEAM
 	db 0
 
-Mon171_EvosMoves:
-;MISSINGNO
+MISSINGNO_79_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon172_EvosMoves:
-;MISSINGNO
+MISSINGNO_7A_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon010_EvosMoves:
-;CATERPIE
+CATERPIE_EvosMoves
 ;Evolutions
 	db EV_LEVEL,7,METAPOD
 	db 0
 ;Learnset
 	db 0
 
-Mon011_EvosMoves:
-;METAPOD
+METAPOD_EvosMoves
 ;Evolutions
 	db EV_LEVEL,10,BUTTERFREE
 	db 0
 ;Learnset
 	db 0
 
-Mon012_EvosMoves:
-;BUTTERFREE
+BUTTERFREE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1615,8 +1489,7 @@ Mon012_EvosMoves:
 	db 32,PSYBEAM
 	db 0
 
-Mon068_EvosMoves:
-;MACHAMP
+MACHAMP_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1627,15 +1500,13 @@ Mon068_EvosMoves:
 	db 52,SUBMISSION
 	db 0
 
-Mon173_EvosMoves:
-;MISSINGNO
+MISSINGNO_7F_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon055_EvosMoves:
-;GOLDUCK
+GOLDUCK_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1646,8 +1517,7 @@ Mon055_EvosMoves:
 	db 59,HYDRO_PUMP
 	db 0
 
-Mon097_EvosMoves:
-;HYPNO
+HYPNO_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1659,8 +1529,7 @@ Mon097_EvosMoves:
 	db 43,MEDITATE
 	db 0
 
-Mon042_EvosMoves:
-;GOLBAT
+GOLBAT_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1671,8 +1540,7 @@ Mon042_EvosMoves:
 	db 43,HAZE
 	db 0
 
-Mon150_EvosMoves:
-;MEWTWO
+MEWTWO_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1683,8 +1551,7 @@ Mon150_EvosMoves:
 	db 81,AMNESIA
 	db 0
 
-Mon143_EvosMoves:
-;SNORLAX
+SNORLAX_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1694,8 +1561,7 @@ Mon143_EvosMoves:
 	db 56,HYPER_BEAM
 	db 0
 
-Mon129_EvosMoves:
-;MAGIKARP
+MAGIKARP_EvosMoves
 ;Evolutions
 	db EV_LEVEL,20,GYARADOS
 	db 0
@@ -1703,22 +1569,19 @@ Mon129_EvosMoves:
 	db 15,TACKLE
 	db 0
 
-Mon174_EvosMoves:
-;MISSINGNO
+MISSINGNO_86_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon175_EvosMoves:
-;MISSINGNO
+MISSINGNO_87_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon089_EvosMoves:
-;MUK
+MUK_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1730,15 +1593,13 @@ Mon089_EvosMoves:
 	db 60,ACID_ARMOR
 	db 0
 
-Mon176_EvosMoves:
-;MISSINGNO
+MISSINGNO_8A_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon099_EvosMoves:
-;KINGLER
+KINGLER_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1749,23 +1610,20 @@ Mon099_EvosMoves:
 	db 49,HARDEN
 	db 0
 
-Mon091_EvosMoves:
-;CLOYSTER
+CLOYSTER_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 50,SPIKE_CANNON
 	db 0
 
-Mon177_EvosMoves:
-;MISSINGNO
+MISSINGNO_8C_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon101_EvosMoves:
-;ELECTRODE
+ELECTRODE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1776,15 +1634,13 @@ Mon101_EvosMoves:
 	db 50,EXPLOSION
 	db 0
 
-Mon036_EvosMoves:
-;CLEFABLE
+CLEFABLE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon110_EvosMoves:
-;WEEZING
+WEEZING_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1795,8 +1651,7 @@ Mon110_EvosMoves:
 	db 53,EXPLOSION
 	db 0
 
-Mon053_EvosMoves:
-;PERSIAN
+PERSIAN_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1807,8 +1662,7 @@ Mon053_EvosMoves:
 	db 51,SLASH
 	db 0
 
-Mon105_EvosMoves:
-;MAROWAK
+MAROWAK_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1819,15 +1673,13 @@ Mon105_EvosMoves:
 	db 55,RAGE
 	db 0
 
-Mon178_EvosMoves:
-;MISSINGNO
+MISSINGNO_92_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon093_EvosMoves:
-;HAUNTER
+HAUNTER_EvosMoves
 ;Evolutions
 	db EV_TRADE,1,GENGAR
 	db 0
@@ -1836,16 +1688,14 @@ Mon093_EvosMoves:
 	db 38,DREAM_EATER
 	db 0
 
-Mon063_EvosMoves:
-;ABRA
+ABRA_EvosMoves
 ;Evolutions
 	db EV_LEVEL,16,KADABRA
 	db 0
 ;Learnset
 	db 0
 
-Mon065_EvosMoves:
-;ALAKAZAM
+ALAKAZAM_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1857,8 +1707,7 @@ Mon065_EvosMoves:
 	db 42,REFLECT
 	db 0
 
-Mon017_EvosMoves:
-;PIDGEOTTO
+PIDGEOTTO_EvosMoves
 ;Evolutions
 	db EV_LEVEL,36,PIDGEOT
 	db 0
@@ -1871,8 +1720,7 @@ Mon017_EvosMoves:
 	db 49,MIRROR_MOVE
 	db 0
 
-Mon018_EvosMoves:
-;PIDGEOT
+PIDGEOT_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1884,15 +1732,13 @@ Mon018_EvosMoves:
 	db 54,MIRROR_MOVE
 	db 0
 
-Mon121_EvosMoves:
-;STARMIE
+STARMIE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon001_EvosMoves:
-;BULBASAUR
+BULBASAUR_EvosMoves
 ;Evolutions
 	db EV_LEVEL,16,IVYSAUR
 	db 0
@@ -1906,8 +1752,7 @@ Mon001_EvosMoves:
 	db 48,SOLARBEAM
 	db 0
 
-Mon003_EvosMoves:
-;VENUSAUR
+VENUSAUR_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1920,8 +1765,7 @@ Mon003_EvosMoves:
 	db 65,SOLARBEAM
 	db 0
 
-Mon073_EvosMoves:
-;TENTACRUEL
+TENTACRUEL_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1935,15 +1779,13 @@ Mon073_EvosMoves:
 	db 50,HYDRO_PUMP
 	db 0
 
-Mon179_EvosMoves:
-;MISSINGNO
+MISSINGNO_9C_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon118_EvosMoves:
-;GOLDEEN
+GOLDEEN_EvosMoves
 ;Evolutions
 	db EV_LEVEL,33,SEAKING
 	db 0
@@ -1956,8 +1798,7 @@ Mon118_EvosMoves:
 	db 54,AGILITY
 	db 0
 
-Mon119_EvosMoves:
-;SEAKING
+SEAKING_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -1969,36 +1810,31 @@ Mon119_EvosMoves:
 	db 54,AGILITY
 	db 0
 
-Mon180_EvosMoves:
-;MISSINGNO
+MISSINGNO_9F_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon181_EvosMoves:
-;MISSINGNO
+MISSINGNO_A0_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon182_EvosMoves:
-;MISSINGNO
+MISSINGNO_A1_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon183_EvosMoves:
-;MISSINGNO
+MISSINGNO_A2_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon077_EvosMoves:
-;PONYTA
+PONYTA_EvosMoves
 ;Evolutions
 	db EV_LEVEL,40,RAPIDASH
 	db 0
@@ -2011,8 +1847,7 @@ Mon077_EvosMoves:
 	db 48,AGILITY
 	db 0
 
-Mon078_EvosMoves:
-;RAPIDASH
+RAPIDASH_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -2024,8 +1859,7 @@ Mon078_EvosMoves:
 	db 55,AGILITY
 	db 0
 
-Mon019_EvosMoves:
-;RATTATA
+RATTATA_EvosMoves
 ;Evolutions
 	db EV_LEVEL,20,RATICATE
 	db 0
@@ -2036,8 +1870,7 @@ Mon019_EvosMoves:
 	db 34,SUPER_FANG
 	db 0
 
-Mon020_EvosMoves:
-;RATICATE
+RATICATE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -2047,8 +1880,7 @@ Mon020_EvosMoves:
 	db 41,SUPER_FANG
 	db 0
 
-Mon033_EvosMoves:
-;NIDORINO
+NIDORINO_EvosMoves
 ;Evolutions
 	db EV_ITEM,MOON_STONE,1,NIDOKING
 	db 0
@@ -2061,8 +1893,7 @@ Mon033_EvosMoves:
 	db 50,DOUBLE_KICK
 	db 0
 
-Mon030_EvosMoves:
-;NIDORINA
+NIDORINA_EvosMoves
 ;Evolutions
 	db EV_ITEM,MOON_STONE,1,NIDOQUEEN
 	db 0
@@ -2075,8 +1906,7 @@ Mon030_EvosMoves:
 	db 50,DOUBLE_KICK
 	db 0
 
-Mon074_EvosMoves:
-;GEODUDE
+GEODUDE_EvosMoves
 ;Evolutions
 	db EV_LEVEL,25,GRAVELER
 	db 0
@@ -2089,8 +1919,7 @@ Mon074_EvosMoves:
 	db 36,EXPLOSION
 	db 0
 
-Mon137_EvosMoves:
-;PORYGON
+PORYGON_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -2100,8 +1929,7 @@ Mon137_EvosMoves:
 	db 42,TRI_ATTACK
 	db 0
 
-Mon142_EvosMoves:
-;AERODACTYL
+AERODACTYL_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -2111,15 +1939,13 @@ Mon142_EvosMoves:
 	db 54,HYPER_BEAM
 	db 0
 
-Mon184_EvosMoves:
-;MISSINGNO
+MISSINGNO_AC_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon081_EvosMoves:
-;MAGNEMITE
+MAGNEMITE_EvosMoves
 ;Evolutions
 	db EV_LEVEL,30,MAGNETON
 	db 0
@@ -2132,22 +1958,19 @@ Mon081_EvosMoves:
 	db 47,SCREECH
 	db 0
 
-Mon185_EvosMoves:
-;MISSINGNO
+MISSINGNO_AE_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon186_EvosMoves:
-;MISSINGNO
+MISSINGNO_AF_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon004_EvosMoves:
-;CHARMANDER
+CHARMANDER_EvosMoves
 ;Evolutions
 	db EV_LEVEL,16,CHARMELEON
 	db 0
@@ -2160,8 +1983,7 @@ Mon004_EvosMoves:
 	db 46,FIRE_SPIN
 	db 0
 
-Mon007_EvosMoves:
-;SQUIRTLE
+SQUIRTLE_EvosMoves
 ;Evolutions
 	db EV_LEVEL,16,WARTORTLE
 	db 0
@@ -2174,8 +1996,7 @@ Mon007_EvosMoves:
 	db 42,HYDRO_PUMP
 	db 0
 
-Mon005_EvosMoves:
-;CHARMELEON
+CHARMELEON_EvosMoves
 ;Evolutions
 	db EV_LEVEL,36,CHARIZARD
 	db 0
@@ -2188,8 +2009,7 @@ Mon005_EvosMoves:
 	db 56,FIRE_SPIN
 	db 0
 
-Mon008_EvosMoves:
-;WARTORTLE
+WARTORTLE_EvosMoves
 ;Evolutions
 	db EV_LEVEL,36,BLASTOISE
 	db 0
@@ -2202,8 +2022,7 @@ Mon008_EvosMoves:
 	db 47,HYDRO_PUMP
 	db 0
 
-Mon006_EvosMoves:
-;CHARIZARD
+CHARIZARD_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -2215,36 +2034,31 @@ Mon006_EvosMoves:
 	db 55,FIRE_SPIN
 	db 0
 
-Mon187_EvosMoves:
-;MISSINGNO
+MISSINGNO_B5_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon188_EvosMoves:
-;MISSINGNO
+FOSSIL_KABUTOPS_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon189_EvosMoves:
-;MISSINGNO
+FOSSIL_AERODACTYL_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon190_EvosMoves:
-;MISSINGNO
+MON_GHOST_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-Mon043_EvosMoves:
-;ODDISH
+ODDISH_EvosMoves
 ;Evolutions
 	db EV_LEVEL,21,GLOOM
 	db 0
@@ -2257,8 +2071,7 @@ Mon043_EvosMoves:
 	db 46,SOLARBEAM
 	db 0
 
-Mon044_EvosMoves:
-;GLOOM
+GLOOM_EvosMoves
 ;Evolutions
 	db EV_ITEM,LEAF_STONE,1,VILEPLUME
 	db 0
@@ -2271,8 +2084,7 @@ Mon044_EvosMoves:
 	db 52,SOLARBEAM
 	db 0
 
-Mon045_EvosMoves:
-;VILEPLUME
+VILEPLUME_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset
@@ -2281,8 +2093,7 @@ Mon045_EvosMoves:
 	db 19,SLEEP_POWDER
 	db 0
 
-Mon069_EvosMoves:
-;BELLSPROUT
+BELLSPROUT_EvosMoves
 ;Evolutions
 	db EV_LEVEL,21,WEEPINBELL
 	db 0
@@ -2296,8 +2107,7 @@ Mon069_EvosMoves:
 	db 42,SLAM
 	db 0
 
-Mon070_EvosMoves:
-;WEEPINBELL
+WEEPINBELL_EvosMoves
 ;Evolutions
 	db EV_ITEM,LEAF_STONE,1,VICTREEBEL
 	db 0
@@ -2311,8 +2121,7 @@ Mon070_EvosMoves:
 	db 49,SLAM
 	db 0
 
-Mon071_EvosMoves:
-;VICTREEBEL
+VICTREEBEL_EvosMoves
 ;Evolutions
 	db 0
 ;Learnset

--- a/data/evos_moves.asm
+++ b/data/evos_moves.asm
@@ -1,196 +1,196 @@
 EvosMovesPointerTable:
-	dw RHYDON_EvosMoves
-	dw KANGASKHAN_EvosMoves
-	dw NIDORAN_M_EvosMoves
-	dw CLEFAIRY_EvosMoves
-	dw SPEAROW_EvosMoves
-	dw VOLTORB_EvosMoves
-	dw NIDOKING_EvosMoves
-	dw SLOWBRO_EvosMoves
-	dw IVYSAUR_EvosMoves
-	dw EXEGGUTOR_EvosMoves
-	dw LICKITUNG_EvosMoves
-	dw EXEGGCUTE_EvosMoves
-	dw GRIMER_EvosMoves
-	dw GENGAR_EvosMoves
-	dw NIDORAN_F_EvosMoves
-	dw NIDOQUEEN_EvosMoves
-	dw CUBONE_EvosMoves
-	dw RHYHORN_EvosMoves
-	dw LAPRAS_EvosMoves
-	dw ARCANINE_EvosMoves
-	dw MEW_EvosMoves
-	dw GYARADOS_EvosMoves
-	dw SHELLDER_EvosMoves
-	dw TENTACOOL_EvosMoves
-	dw GASTLY_EvosMoves
-	dw SCYTHER_EvosMoves
-	dw STARYU_EvosMoves
-	dw BLASTOISE_EvosMoves
-	dw PINSIR_EvosMoves
-	dw TANGELA_EvosMoves
-	dw MISSINGNO_1F_EvosMoves
-	dw MISSINGNO_20_EvosMoves
-	dw GROWLITHE_EvosMoves
-	dw ONIX_EvosMoves
-	dw FEAROW_EvosMoves
-	dw PIDGEY_EvosMoves
-	dw SLOWPOKE_EvosMoves
-	dw KADABRA_EvosMoves
-	dw GRAVELER_EvosMoves
-	dw CHANSEY_EvosMoves
-	dw MACHOKE_EvosMoves
-	dw MR_MIME_EvosMoves
-	dw HITMONLEE_EvosMoves
-	dw HITMONCHAN_EvosMoves
-	dw ARBOK_EvosMoves
-	dw PARASECT_EvosMoves
-	dw PSYDUCK_EvosMoves
-	dw DROWZEE_EvosMoves
-	dw GOLEM_EvosMoves
-	dw MISSINGNO_32_EvosMoves
-	dw MAGMAR_EvosMoves
-	dw MISSINGNO_34_EvosMoves
-	dw ELECTABUZZ_EvosMoves
-	dw MAGNETON_EvosMoves
-	dw KOFFING_EvosMoves
-	dw MISSINGNO_38_EvosMoves
-	dw MANKEY_EvosMoves
-	dw SEEL_EvosMoves
-	dw DIGLETT_EvosMoves
-	dw TAUROS_EvosMoves
-	dw MISSINGNO_3D_EvosMoves
-	dw MISSINGNO_3E_EvosMoves
-	dw MISSINGNO_3F_EvosMoves
-	dw FARFETCHD_EvosMoves
-	dw VENONAT_EvosMoves
-	dw DRAGONITE_EvosMoves
-	dw MISSINGNO_43_EvosMoves
-	dw MISSINGNO_44_EvosMoves
-	dw MISSINGNO_45_EvosMoves
-	dw DODUO_EvosMoves
-	dw POLIWAG_EvosMoves
-	dw JYNX_EvosMoves
-	dw MOLTRES_EvosMoves
-	dw ARTICUNO_EvosMoves
-	dw ZAPDOS_EvosMoves
-	dw DITTO_EvosMoves
-	dw MEOWTH_EvosMoves
-	dw KRABBY_EvosMoves
-	dw MISSINGNO_4F_EvosMoves
-	dw MISSINGNO_50_EvosMoves
-	dw MISSINGNO_51_EvosMoves
-	dw VULPIX_EvosMoves
-	dw NINETALES_EvosMoves
-	dw PIKACHU_EvosMoves
-	dw RAICHU_EvosMoves
-	dw MISSINGNO_56_EvosMoves
-	dw MISSINGNO_57_EvosMoves
-	dw DRATINI_EvosMoves
-	dw DRAGONAIR_EvosMoves
-	dw KABUTO_EvosMoves
-	dw KABUTOPS_EvosMoves
-	dw HORSEA_EvosMoves
-	dw SEADRA_EvosMoves
-	dw MISSINGNO_5E_EvosMoves
-	dw MISSINGNO_5F_EvosMoves
-	dw SANDSHREW_EvosMoves
-	dw SANDSLASH_EvosMoves
-	dw OMANYTE_EvosMoves
-	dw OMASTAR_EvosMoves
-	dw JIGGLYPUFF_EvosMoves
-	dw WIGGLYTUFF_EvosMoves
-	dw EEVEE_EvosMoves
-	dw FLAREON_EvosMoves
-	dw JOLTEON_EvosMoves
-	dw VAPOREON_EvosMoves
-	dw MACHOP_EvosMoves
-	dw ZUBAT_EvosMoves
-	dw EKANS_EvosMoves
-	dw PARAS_EvosMoves
-	dw POLIWHIRL_EvosMoves
-	dw POLIWRATH_EvosMoves
-	dw WEEDLE_EvosMoves
-	dw KAKUNA_EvosMoves
-	dw BEEDRILL_EvosMoves
-	dw MISSINGNO_73_EvosMoves
-	dw DODRIO_EvosMoves
-	dw PRIMEAPE_EvosMoves
-	dw DUGTRIO_EvosMoves
-	dw VENOMOTH_EvosMoves
-	dw DEWGONG_EvosMoves
-	dw MISSINGNO_79_EvosMoves
-	dw MISSINGNO_7A_EvosMoves
-	dw CATERPIE_EvosMoves
-	dw METAPOD_EvosMoves
-	dw BUTTERFREE_EvosMoves
-	dw MACHAMP_EvosMoves
-	dw MISSINGNO_7F_EvosMoves
-	dw GOLDUCK_EvosMoves
-	dw HYPNO_EvosMoves
-	dw GOLBAT_EvosMoves
-	dw MEWTWO_EvosMoves
-	dw SNORLAX_EvosMoves
-	dw MAGIKARP_EvosMoves
-	dw MISSINGNO_86_EvosMoves
-	dw MISSINGNO_87_EvosMoves
-	dw MUK_EvosMoves
-	dw MISSINGNO_8A_EvosMoves
-	dw KINGLER_EvosMoves
-	dw CLOYSTER_EvosMoves
-	dw MISSINGNO_8C_EvosMoves
-	dw ELECTRODE_EvosMoves
-	dw CLEFABLE_EvosMoves
-	dw WEEZING_EvosMoves
-	dw PERSIAN_EvosMoves
-	dw MAROWAK_EvosMoves
-	dw MISSINGNO_92_EvosMoves
-	dw HAUNTER_EvosMoves
-	dw ABRA_EvosMoves
-	dw ALAKAZAM_EvosMoves
-	dw PIDGEOTTO_EvosMoves
-	dw PIDGEOT_EvosMoves
-	dw STARMIE_EvosMoves
-	dw BULBASAUR_EvosMoves
-	dw VENUSAUR_EvosMoves
-	dw TENTACRUEL_EvosMoves
-	dw MISSINGNO_9C_EvosMoves
-	dw GOLDEEN_EvosMoves
-	dw SEAKING_EvosMoves
-	dw MISSINGNO_9F_EvosMoves
-	dw MISSINGNO_A0_EvosMoves
-	dw MISSINGNO_A1_EvosMoves
-	dw MISSINGNO_A2_EvosMoves
-	dw PONYTA_EvosMoves
-	dw RAPIDASH_EvosMoves
-	dw RATTATA_EvosMoves
-	dw RATICATE_EvosMoves
-	dw NIDORINO_EvosMoves
-	dw NIDORINA_EvosMoves
-	dw GEODUDE_EvosMoves
-	dw PORYGON_EvosMoves
-	dw AERODACTYL_EvosMoves
-	dw MISSINGNO_AC_EvosMoves
-	dw MAGNEMITE_EvosMoves
-	dw MISSINGNO_AE_EvosMoves
-	dw MISSINGNO_AF_EvosMoves
-	dw CHARMANDER_EvosMoves
-	dw SQUIRTLE_EvosMoves
-	dw CHARMELEON_EvosMoves
-	dw WARTORTLE_EvosMoves
-	dw CHARIZARD_EvosMoves
-	dw MISSINGNO_B5_EvosMoves
-	dw FOSSIL_KABUTOPS_EvosMoves
-	dw FOSSIL_AERODACTYL_EvosMoves
-	dw MON_GHOST_EvosMoves
-	dw ODDISH_EvosMoves
-	dw GLOOM_EvosMoves
-	dw VILEPLUME_EvosMoves
-	dw BELLSPROUT_EvosMoves
-	dw WEEPINBELL_EvosMoves
-	dw VICTREEBEL_EvosMoves
+	dw RhydonEvosMoves
+	dw KangaskhanEvosMoves
+	dw NidoranMEvosMoves
+	dw ClefairyEvosMoves
+	dw SpearowEvosMoves
+	dw VoltorbEvosMoves
+	dw NidokingEvosMoves
+	dw SlowbroEvosMoves
+	dw IvysaurEvosMoves
+	dw ExeggutorEvosMoves
+	dw LickitungEvosMoves
+	dw ExeggcuteEvosMoves
+	dw GrimerEvosMoves
+	dw GengarEvosMoves
+	dw NidoranFEvosMoves
+	dw NidoqueenEvosMoves
+	dw CuboneEvosMoves
+	dw RhyhornEvosMoves
+	dw LaprasEvosMoves
+	dw ArcanineEvosMoves
+	dw MewEvosMoves
+	dw GyaradosEvosMoves
+	dw ShellderEvosMoves
+	dw TentacoolEvosMoves
+	dw GastlyEvosMoves
+	dw ScytherEvosMoves
+	dw StaryuEvosMoves
+	dw BlastoiseEvosMoves
+	dw PinsirEvosMoves
+	dw TangelaEvosMoves
+	dw MissingNo1FEvosMoves
+	dw MissingNo20EvosMoves
+	dw GrowlitheEvosMoves
+	dw OnixEvosMoves
+	dw FearowEvosMoves
+	dw PidgeyEvosMoves
+	dw SlowpokeEvosMoves
+	dw KadabraEvosMoves
+	dw GravelerEvosMoves
+	dw ChanseyEvosMoves
+	dw MachokeEvosMoves
+	dw MrMimeEvosMoves
+	dw HitmonleeEvosMoves
+	dw HitmonchanEvosMoves
+	dw ArbokEvosMoves
+	dw ParasectEvosMoves
+	dw PsyduckEvosMoves
+	dw DrowzeeEvosMoves
+	dw GolemEvosMoves
+	dw MissingNo32EvosMoves
+	dw MagmarEvosMoves
+	dw MissingNo34EvosMoves
+	dw ElectabuzzEvosMoves
+	dw MagnetonEvosMoves
+	dw KoffingEvosMoves
+	dw MissingNo38EvosMoves
+	dw MankeyEvosMoves
+	dw SeelEvosMoves
+	dw DiglettEvosMoves
+	dw TaurosEvosMoves
+	dw MissingNo3DEvosMoves
+	dw MissingNo3EEvosMoves
+	dw MissingNo3FEvosMoves
+	dw FarfetchdEvosMoves
+	dw VenonatEvosMoves
+	dw DragoniteEvosMoves
+	dw MissingNo43EvosMoves
+	dw MissingNo44EvosMoves
+	dw MissingNo45EvosMoves
+	dw DoduoEvosMoves
+	dw PoliwagEvosMoves
+	dw JynxEvosMoves
+	dw MoltresEvosMoves
+	dw ArticunoEvosMoves
+	dw ZapdosEvosMoves
+	dw DittoEvosMoves
+	dw MeowthEvosMoves
+	dw KrabbyEvosMoves
+	dw MissingNo4FEvosMoves
+	dw MissingNo50EvosMoves
+	dw MissingNo51EvosMoves
+	dw VulpixEvosMoves
+	dw NinetalesEvosMoves
+	dw PikachuEvosMoves
+	dw RaichuEvosMoves
+	dw MissingNo56EvosMoves
+	dw MissingNo57EvosMoves
+	dw DratiniEvosMoves
+	dw DragonairEvosMoves
+	dw KabutoEvosMoves
+	dw KabutopsEvosMoves
+	dw HorseaEvosMoves
+	dw SeadraEvosMoves
+	dw MissingNo5EEvosMoves
+	dw MissingNo5FEvosMoves
+	dw SandshrewEvosMoves
+	dw SandslashEvosMoves
+	dw OmanyteEvosMoves
+	dw OmastarEvosMoves
+	dw JigglypuffEvosMoves
+	dw WigglytuffEvosMoves
+	dw EeveeEvosMoves
+	dw FlareonEvosMoves
+	dw JolteonEvosMoves
+	dw VaporeonEvosMoves
+	dw MachopEvosMoves
+	dw ZubatEvosMoves
+	dw EkansEvosMoves
+	dw ParasEvosMoves
+	dw PoliwhirlEvosMoves
+	dw PoliwrathEvosMoves
+	dw WeedleEvosMoves
+	dw KakunaEvosMoves
+	dw BeedrillEvosMoves
+	dw MissingNo73EvosMoves
+	dw DodrioEvosMoves
+	dw PrimeapeEvosMoves
+	dw DugtrioEvosMoves
+	dw VenomothEvosMoves
+	dw DewgongEvosMoves
+	dw MissingNo79EvosMoves
+	dw MissingNo7AEvosMoves
+	dw CaterpieEvosMoves
+	dw MetapodEvosMoves
+	dw ButterfreeEvosMoves
+	dw MachampEvosMoves
+	dw MissingNo7FEvosMoves
+	dw GolduckEvosMoves
+	dw HypnoEvosMoves
+	dw GolbatEvosMoves
+	dw MewtwoEvosMoves
+	dw SnorlaxEvosMoves
+	dw MagikarpEvosMoves
+	dw MissingNo86EvosMoves
+	dw MissingNo87EvosMoves
+	dw MukEvosMoves
+	dw MissingNo8AEvosMoves
+	dw KinglerEvosMoves
+	dw CloysterEvosMoves
+	dw MissingNo8CEvosMoves
+	dw ElectrodeEvosMoves
+	dw ClefableEvosMoves
+	dw WeezingEvosMoves
+	dw PersianEvosMoves
+	dw MarowakEvosMoves
+	dw MissingNo92EvosMoves
+	dw HaunterEvosMoves
+	dw AbraEvosMoves
+	dw AlakazamEvosMoves
+	dw PidgeottoEvosMoves
+	dw PidgeotEvosMoves
+	dw StarmieEvosMoves
+	dw BulbasaurEvosMoves
+	dw VenusaurEvosMoves
+	dw TentacruelEvosMoves
+	dw MissingNo9CEvosMoves
+	dw GoldeenEvosMoves
+	dw SeakingEvosMoves
+	dw MissingNo9FEvosMoves
+	dw MissingNoA0EvosMoves
+	dw MissingNoA1EvosMoves
+	dw MissingNoA2EvosMoves
+	dw PonytaEvosMoves
+	dw RapidashEvosMoves
+	dw RattataEvosMoves
+	dw RaticateEvosMoves
+	dw NidorinoEvosMoves
+	dw NidorinaEvosMoves
+	dw GeodudeEvosMoves
+	dw PorygonEvosMoves
+	dw AerodactylEvosMoves
+	dw MissingNoACEvosMoves
+	dw MagnemiteEvosMoves
+	dw MissingNoAEEvosMoves
+	dw MissingNoAFEvosMoves
+	dw CharmanderEvosMoves
+	dw SquirtleEvosMoves
+	dw CharmeleonEvosMoves
+	dw WartortleEvosMoves
+	dw CharizardEvosMoves
+	dw MissingNoB5EvosMoves
+	dw FossilKabutopsEvosMoves
+	dw FossilAerodactylEvosMoves
+	dw MonGhostEvosMoves
+	dw OddishEvosMoves
+	dw GloomEvosMoves
+	dw VileplumeEvosMoves
+	dw BellsproutEvosMoves
+	dw WeepinbellEvosMoves
+	dw VictreebelEvosMoves
 
-RHYDON_EvosMoves
+RhydonEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -202,7 +202,7 @@ RHYDON_EvosMoves
 	db 64,TAKE_DOWN
 	db 0
 
-KANGASKHAN_EvosMoves
+KangaskhanEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -213,7 +213,7 @@ KANGASKHAN_EvosMoves
 	db 46,DIZZY_PUNCH
 	db 0
 
-NIDORAN_M_EvosMoves
+NidoranMEvosMoves:
 ;Evolutions
 	db EV_LEVEL,16,NIDORINO
 	db 0
@@ -226,7 +226,7 @@ NIDORAN_M_EvosMoves
 	db 43,DOUBLE_KICK
 	db 0
 
-CLEFAIRY_EvosMoves
+ClefairyEvosMoves:
 ;Evolutions
 	db EV_ITEM,MOON_STONE,1,CLEFABLE
 	db 0
@@ -239,7 +239,7 @@ CLEFAIRY_EvosMoves
 	db 48,LIGHT_SCREEN
 	db 0
 
-SPEAROW_EvosMoves
+SpearowEvosMoves:
 ;Evolutions
 	db EV_LEVEL,20,FEAROW
 	db 0
@@ -251,7 +251,7 @@ SPEAROW_EvosMoves
 	db 36,AGILITY
 	db 0
 
-VOLTORB_EvosMoves
+VoltorbEvosMoves:
 ;Evolutions
 	db EV_LEVEL,30,ELECTRODE
 	db 0
@@ -263,7 +263,7 @@ VOLTORB_EvosMoves
 	db 43,EXPLOSION
 	db 0
 
-NIDOKING_EvosMoves
+NidokingEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -272,7 +272,7 @@ NIDOKING_EvosMoves
 	db 23,THRASH
 	db 0
 
-SLOWBRO_EvosMoves
+SlowbroEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -285,7 +285,7 @@ SLOWBRO_EvosMoves
 	db 55,PSYCHIC_M
 	db 0
 
-IVYSAUR_EvosMoves
+IvysaurEvosMoves:
 ;Evolutions
 	db EV_LEVEL,32,VENUSAUR
 	db 0
@@ -299,14 +299,14 @@ IVYSAUR_EvosMoves
 	db 54,SOLARBEAM
 	db 0
 
-EXEGGUTOR_EvosMoves
+ExeggutorEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 28,STOMP
 	db 0
 
-LICKITUNG_EvosMoves
+LickitungEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -317,7 +317,7 @@ LICKITUNG_EvosMoves
 	db 39,SCREECH
 	db 0
 
-EXEGGCUTE_EvosMoves
+ExeggcuteEvosMoves:
 ;Evolutions
 	db EV_ITEM,LEAF_STONE,1,EXEGGUTOR
 	db 0
@@ -330,7 +330,7 @@ EXEGGCUTE_EvosMoves
 	db 48,SLEEP_POWDER
 	db 0
 
-GRIMER_EvosMoves
+GrimerEvosMoves:
 ;Evolutions
 	db EV_LEVEL,38,MUK
 	db 0
@@ -343,7 +343,7 @@ GRIMER_EvosMoves
 	db 55,ACID_ARMOR
 	db 0
 
-GENGAR_EvosMoves
+GengarEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -351,7 +351,7 @@ GENGAR_EvosMoves
 	db 38,DREAM_EATER
 	db 0
 
-NIDORAN_F_EvosMoves
+NidoranFEvosMoves:
 ;Evolutions
 	db EV_LEVEL,16,NIDORINA
 	db 0
@@ -364,7 +364,7 @@ NIDORAN_F_EvosMoves
 	db 43,DOUBLE_KICK
 	db 0
 
-NIDOQUEEN_EvosMoves
+NidoqueenEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -373,7 +373,7 @@ NIDOQUEEN_EvosMoves
 	db 23,BODY_SLAM
 	db 0
 
-CUBONE_EvosMoves
+CuboneEvosMoves:
 ;Evolutions
 	db EV_LEVEL,28,MAROWAK
 	db 0
@@ -385,7 +385,7 @@ CUBONE_EvosMoves
 	db 46,RAGE
 	db 0
 
-RHYHORN_EvosMoves
+RhyhornEvosMoves:
 ;Evolutions
 	db EV_LEVEL,42,RHYDON
 	db 0
@@ -398,7 +398,7 @@ RHYHORN_EvosMoves
 	db 55,TAKE_DOWN
 	db 0
 
-LAPRAS_EvosMoves
+LaprasEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -410,13 +410,13 @@ LAPRAS_EvosMoves
 	db 46,HYDRO_PUMP
 	db 0
 
-ARCANINE_EvosMoves
+ArcanineEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MEW_EvosMoves
+MewEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -426,7 +426,7 @@ MEW_EvosMoves
 	db 40,PSYCHIC_M
 	db 0
 
-GYARADOS_EvosMoves
+GyaradosEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -437,7 +437,7 @@ GYARADOS_EvosMoves
 	db 52,HYPER_BEAM
 	db 0
 
-SHELLDER_EvosMoves
+ShellderEvosMoves:
 ;Evolutions
 	db EV_ITEM,WATER_STONE,1,CLOYSTER
 	db 0
@@ -449,7 +449,7 @@ SHELLDER_EvosMoves
 	db 50,ICE_BEAM
 	db 0
 
-TENTACOOL_EvosMoves
+TentacoolEvosMoves:
 ;Evolutions
 	db EV_LEVEL,30,TENTACRUEL
 	db 0
@@ -464,7 +464,7 @@ TENTACOOL_EvosMoves
 	db 48,HYDRO_PUMP
 	db 0
 
-GASTLY_EvosMoves
+GastlyEvosMoves:
 ;Evolutions
 	db EV_LEVEL,25,HAUNTER
 	db 0
@@ -473,7 +473,7 @@ GASTLY_EvosMoves
 	db 35,DREAM_EATER
 	db 0
 
-SCYTHER_EvosMoves
+ScytherEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -485,7 +485,7 @@ SCYTHER_EvosMoves
 	db 42,AGILITY
 	db 0
 
-STARYU_EvosMoves
+StaryuEvosMoves:
 ;Evolutions
 	db EV_ITEM,WATER_STONE,1,STARMIE
 	db 0
@@ -499,7 +499,7 @@ STARYU_EvosMoves
 	db 47,HYDRO_PUMP
 	db 0
 
-BLASTOISE_EvosMoves
+BlastoiseEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -511,7 +511,7 @@ BLASTOISE_EvosMoves
 	db 52,HYDRO_PUMP
 	db 0
 
-PINSIR_EvosMoves
+PinsirEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -523,7 +523,7 @@ PINSIR_EvosMoves
 	db 54,SWORDS_DANCE
 	db 0
 
-TANGELA_EvosMoves
+TangelaEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -535,19 +535,19 @@ TANGELA_EvosMoves
 	db 49,GROWTH
 	db 0
 
-MISSINGNO_1F_EvosMoves
+MissingNo1FEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_20_EvosMoves
+MissingNo20EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-GROWLITHE_EvosMoves
+GrowlitheEvosMoves:
 ;Evolutions
 	db EV_ITEM,FIRE_STONE,1,ARCANINE
 	db 0
@@ -559,7 +559,7 @@ GROWLITHE_EvosMoves
 	db 50,FLAMETHROWER
 	db 0
 
-ONIX_EvosMoves
+OnixEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -570,7 +570,7 @@ ONIX_EvosMoves
 	db 43,HARDEN
 	db 0
 
-FEAROW_EvosMoves
+FearowEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -581,7 +581,7 @@ FEAROW_EvosMoves
 	db 43,AGILITY
 	db 0
 
-PIDGEY_EvosMoves
+PidgeyEvosMoves:
 ;Evolutions
 	db EV_LEVEL,18,PIDGEOTTO
 	db 0
@@ -594,7 +594,7 @@ PIDGEY_EvosMoves
 	db 44,MIRROR_MOVE
 	db 0
 
-SLOWPOKE_EvosMoves
+SlowpokeEvosMoves:
 ;Evolutions
 	db EV_LEVEL,37,SLOWBRO
 	db 0
@@ -607,7 +607,7 @@ SLOWPOKE_EvosMoves
 	db 48,PSYCHIC_M
 	db 0
 
-KADABRA_EvosMoves
+KadabraEvosMoves:
 ;Evolutions
 	db EV_TRADE,1,ALAKAZAM
 	db 0
@@ -620,7 +620,7 @@ KADABRA_EvosMoves
 	db 42,REFLECT
 	db 0
 
-GRAVELER_EvosMoves
+GravelerEvosMoves:
 ;Evolutions
 	db EV_TRADE,1,GOLEM
 	db 0
@@ -633,7 +633,7 @@ GRAVELER_EvosMoves
 	db 43,EXPLOSION
 	db 0
 
-CHANSEY_EvosMoves
+ChanseyEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -645,7 +645,7 @@ CHANSEY_EvosMoves
 	db 54,DOUBLE_EDGE
 	db 0
 
-MACHOKE_EvosMoves
+MachokeEvosMoves:
 ;Evolutions
 	db EV_TRADE,1,MACHAMP
 	db 0
@@ -657,7 +657,7 @@ MACHOKE_EvosMoves
 	db 52,SUBMISSION
 	db 0
 
-MR_MIME_EvosMoves
+MrMimeEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -668,7 +668,7 @@ MR_MIME_EvosMoves
 	db 47,SUBSTITUTE
 	db 0
 
-HITMONLEE_EvosMoves
+HitmonleeEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -679,7 +679,7 @@ HITMONLEE_EvosMoves
 	db 53,MEGA_KICK
 	db 0
 
-HITMONCHAN_EvosMoves
+HitmonchanEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -690,7 +690,7 @@ HITMONCHAN_EvosMoves
 	db 53,COUNTER
 	db 0
 
-ARBOK_EvosMoves
+ArbokEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -701,7 +701,7 @@ ARBOK_EvosMoves
 	db 47,ACID
 	db 0
 
-PARASECT_EvosMoves
+ParasectEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -712,7 +712,7 @@ PARASECT_EvosMoves
 	db 48,GROWTH
 	db 0
 
-PSYDUCK_EvosMoves
+PsyduckEvosMoves:
 ;Evolutions
 	db EV_LEVEL,33,GOLDUCK
 	db 0
@@ -724,7 +724,7 @@ PSYDUCK_EvosMoves
 	db 52,HYDRO_PUMP
 	db 0
 
-DROWZEE_EvosMoves
+DrowzeeEvosMoves:
 ;Evolutions
 	db EV_LEVEL,26,HYPNO
 	db 0
@@ -737,7 +737,7 @@ DROWZEE_EvosMoves
 	db 37,MEDITATE
 	db 0
 
-GOLEM_EvosMoves
+GolemEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -749,13 +749,13 @@ GOLEM_EvosMoves
 	db 43,EXPLOSION
 	db 0
 
-MISSINGNO_32_EvosMoves
+MissingNo32EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MAGMAR_EvosMoves
+MagmarEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -767,13 +767,13 @@ MAGMAR_EvosMoves
 	db 55,FLAMETHROWER
 	db 0
 
-MISSINGNO_34_EvosMoves
+MissingNo34EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-ELECTABUZZ_EvosMoves
+ElectabuzzEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -784,7 +784,7 @@ ELECTABUZZ_EvosMoves
 	db 54,THUNDER
 	db 0
 
-MAGNETON_EvosMoves
+MagnetonEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -796,7 +796,7 @@ MAGNETON_EvosMoves
 	db 54,SCREECH
 	db 0
 
-KOFFING_EvosMoves
+KoffingEvosMoves:
 ;Evolutions
 	db EV_LEVEL,35,WEEZING
 	db 0
@@ -808,13 +808,13 @@ KOFFING_EvosMoves
 	db 48,EXPLOSION
 	db 0
 
-MISSINGNO_38_EvosMoves
+MissingNo38EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MANKEY_EvosMoves
+MankeyEvosMoves:
 ;Evolutions
 	db EV_LEVEL,28,PRIMEAPE
 	db 0
@@ -826,7 +826,7 @@ MANKEY_EvosMoves
 	db 39,THRASH
 	db 0
 
-SEEL_EvosMoves
+SeelEvosMoves:
 ;Evolutions
 	db EV_LEVEL,34,DEWGONG
 	db 0
@@ -838,7 +838,7 @@ SEEL_EvosMoves
 	db 50,ICE_BEAM
 	db 0
 
-DIGLETT_EvosMoves
+DiglettEvosMoves:
 ;Evolutions
 	db EV_LEVEL,26,DUGTRIO
 	db 0
@@ -850,7 +850,7 @@ DIGLETT_EvosMoves
 	db 40,EARTHQUAKE
 	db 0
 
-TAUROS_EvosMoves
+TaurosEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -861,25 +861,25 @@ TAUROS_EvosMoves
 	db 51,TAKE_DOWN
 	db 0
 
-MISSINGNO_3D_EvosMoves
+MissingNo3DEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_3E_EvosMoves
+MissingNo3EEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_3F_EvosMoves
+MissingNo3FEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-FARFETCHD_EvosMoves
+FarfetchdEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -890,7 +890,7 @@ FARFETCHD_EvosMoves
 	db 39,SLASH
 	db 0
 
-VENONAT_EvosMoves
+VenonatEvosMoves:
 ;Evolutions
 	db EV_LEVEL,31,VENOMOTH
 	db 0
@@ -903,7 +903,7 @@ VENONAT_EvosMoves
 	db 43,PSYCHIC_M
 	db 0
 
-DRAGONITE_EvosMoves
+DragoniteEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -914,25 +914,25 @@ DRAGONITE_EvosMoves
 	db 60,HYPER_BEAM
 	db 0
 
-MISSINGNO_43_EvosMoves
+MissingNo43EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_44_EvosMoves
+MissingNo44EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_45_EvosMoves
+MissingNo45EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-DODUO_EvosMoves
+DoduoEvosMoves:
 ;Evolutions
 	db EV_LEVEL,31,DODRIO
 	db 0
@@ -945,7 +945,7 @@ DODUO_EvosMoves
 	db 44,AGILITY
 	db 0
 
-POLIWAG_EvosMoves
+PoliwagEvosMoves:
 ;Evolutions
 	db EV_LEVEL,25,POLIWHIRL
 	db 0
@@ -958,7 +958,7 @@ POLIWAG_EvosMoves
 	db 45,HYDRO_PUMP
 	db 0
 
-JYNX_EvosMoves
+JynxEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -970,7 +970,7 @@ JYNX_EvosMoves
 	db 58,BLIZZARD
 	db 0
 
-MOLTRES_EvosMoves
+MoltresEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -979,7 +979,7 @@ MOLTRES_EvosMoves
 	db 60,SKY_ATTACK
 	db 0
 
-ARTICUNO_EvosMoves
+ArticunoEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -988,7 +988,7 @@ ARTICUNO_EvosMoves
 	db 60,MIST
 	db 0
 
-ZAPDOS_EvosMoves
+ZapdosEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -997,13 +997,13 @@ ZAPDOS_EvosMoves
 	db 60,LIGHT_SCREEN
 	db 0
 
-DITTO_EvosMoves
+DittoEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MEOWTH_EvosMoves
+MeowthEvosMoves:
 ;Evolutions
 	db EV_LEVEL,28,PERSIAN
 	db 0
@@ -1015,7 +1015,7 @@ MEOWTH_EvosMoves
 	db 44,SLASH
 	db 0
 
-KRABBY_EvosMoves
+KrabbyEvosMoves:
 ;Evolutions
 	db EV_LEVEL,28,KINGLER
 	db 0
@@ -1027,25 +1027,25 @@ KRABBY_EvosMoves
 	db 40,HARDEN
 	db 0
 
-MISSINGNO_4F_EvosMoves
+MissingNo4FEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_50_EvosMoves
+MissingNo50EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_51_EvosMoves
+MissingNo51EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-VULPIX_EvosMoves
+VulpixEvosMoves:
 ;Evolutions
 	db EV_ITEM,FIRE_STONE,1,NINETALES
 	db 0
@@ -1057,13 +1057,13 @@ VULPIX_EvosMoves
 	db 42,FIRE_SPIN
 	db 0
 
-NINETALES_EvosMoves
+NinetalesEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-PIKACHU_EvosMoves
+PikachuEvosMoves:
 ;Evolutions
 	db EV_ITEM,THUNDER_STONE,1,RAICHU
 	db 0
@@ -1075,25 +1075,25 @@ PIKACHU_EvosMoves
 	db 43,THUNDER
 	db 0
 
-RAICHU_EvosMoves
+RaichuEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_56_EvosMoves
+MissingNo56EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_57_EvosMoves
+MissingNo57EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-DRATINI_EvosMoves
+DratiniEvosMoves:
 ;Evolutions
 	db EV_LEVEL,30,DRAGONAIR
 	db 0
@@ -1105,7 +1105,7 @@ DRATINI_EvosMoves
 	db 50,HYPER_BEAM
 	db 0
 
-DRAGONAIR_EvosMoves
+DragonairEvosMoves:
 ;Evolutions
 	db EV_LEVEL,55,DRAGONITE
 	db 0
@@ -1117,7 +1117,7 @@ DRAGONAIR_EvosMoves
 	db 55,HYPER_BEAM
 	db 0
 
-KABUTO_EvosMoves
+KabutoEvosMoves:
 ;Evolutions
 	db EV_LEVEL,40,KABUTOPS
 	db 0
@@ -1128,7 +1128,7 @@ KABUTO_EvosMoves
 	db 49,HYDRO_PUMP
 	db 0
 
-KABUTOPS_EvosMoves
+KabutopsEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1138,7 +1138,7 @@ KABUTOPS_EvosMoves
 	db 53,HYDRO_PUMP
 	db 0
 
-HORSEA_EvosMoves
+HorseaEvosMoves:
 ;Evolutions
 	db EV_LEVEL,32,SEADRA
 	db 0
@@ -1150,7 +1150,7 @@ HORSEA_EvosMoves
 	db 45,HYDRO_PUMP
 	db 0
 
-SEADRA_EvosMoves
+SeadraEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1161,19 +1161,19 @@ SEADRA_EvosMoves
 	db 52,HYDRO_PUMP
 	db 0
 
-MISSINGNO_5E_EvosMoves
+MissingNo5EEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_5F_EvosMoves
+MissingNo5FEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-SANDSHREW_EvosMoves
+SandshrewEvosMoves:
 ;Evolutions
 	db EV_LEVEL,22,SANDSLASH
 	db 0
@@ -1185,7 +1185,7 @@ SANDSHREW_EvosMoves
 	db 38,FURY_SWIPES
 	db 0
 
-SANDSLASH_EvosMoves
+SandslashEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1196,7 +1196,7 @@ SANDSLASH_EvosMoves
 	db 47,FURY_SWIPES
 	db 0
 
-OMANYTE_EvosMoves
+OmanyteEvosMoves:
 ;Evolutions
 	db EV_LEVEL,40,OMASTAR
 	db 0
@@ -1207,7 +1207,7 @@ OMANYTE_EvosMoves
 	db 53,HYDRO_PUMP
 	db 0
 
-OMASTAR_EvosMoves
+OmastarEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1217,7 +1217,7 @@ OMASTAR_EvosMoves
 	db 49,HYDRO_PUMP
 	db 0
 
-JIGGLYPUFF_EvosMoves
+JigglypuffEvosMoves:
 ;Evolutions
 	db EV_ITEM,MOON_STONE,1,WIGGLYTUFF
 	db 0
@@ -1231,26 +1231,27 @@ JIGGLYPUFF_EvosMoves
 	db 39,DOUBLE_EDGE
 	db 0
 
-WIGGLYTUFF_EvosMoves
+WigglytuffEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-EEVEE_EvosMoves
+EeveeEvosMoves:
 ;Evolutions
 	db EV_ITEM,FIRE_STONE,1,FLAREON
 	db EV_ITEM,THUNDER_STONE,1,JOLTEON
 	db EV_ITEM,WATER_STONE,1,VAPOREON
 	db 0
-EEVEE_EvosEnd
+EeveeEvosEnd:
+;Learnset
 	db 27,QUICK_ATTACK
 	db 31,TAIL_WHIP
 	db 37,BITE
 	db 45,TAKE_DOWN
 	db 0
 
-FLAREON_EvosMoves
+FlareonEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1264,7 +1265,7 @@ FLAREON_EvosMoves
 	db 54,FLAMETHROWER
 	db 0
 
-JOLTEON_EvosMoves
+JolteonEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1278,7 +1279,7 @@ JOLTEON_EvosMoves
 	db 54,THUNDER
 	db 0
 
-VAPOREON_EvosMoves
+VaporeonEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1292,7 +1293,7 @@ VAPOREON_EvosMoves
 	db 54,HYDRO_PUMP
 	db 0
 
-MACHOP_EvosMoves
+MachopEvosMoves:
 ;Evolutions
 	db EV_LEVEL,28,MACHOKE
 	db 0
@@ -1304,7 +1305,7 @@ MACHOP_EvosMoves
 	db 46,SUBMISSION
 	db 0
 
-ZUBAT_EvosMoves
+ZubatEvosMoves:
 ;Evolutions
 	db EV_LEVEL,22,GOLBAT
 	db 0
@@ -1316,7 +1317,7 @@ ZUBAT_EvosMoves
 	db 36,HAZE
 	db 0
 
-EKANS_EvosMoves
+EkansEvosMoves:
 ;Evolutions
 	db EV_LEVEL,22,ARBOK
 	db 0
@@ -1328,7 +1329,7 @@ EKANS_EvosMoves
 	db 38,ACID
 	db 0
 
-PARAS_EvosMoves
+ParasEvosMoves:
 ;Evolutions
 	db EV_LEVEL,24,PARASECT
 	db 0
@@ -1340,7 +1341,7 @@ PARAS_EvosMoves
 	db 41,GROWTH
 	db 0
 
-POLIWHIRL_EvosMoves
+PoliwhirlEvosMoves:
 ;Evolutions
 	db EV_ITEM,WATER_STONE,1,POLIWRATH
 	db 0
@@ -1353,7 +1354,7 @@ POLIWHIRL_EvosMoves
 	db 49,HYDRO_PUMP
 	db 0
 
-POLIWRATH_EvosMoves
+PoliwrathEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1361,21 +1362,21 @@ POLIWRATH_EvosMoves
 	db 19,WATER_GUN
 	db 0
 
-WEEDLE_EvosMoves
+WeedleEvosMoves:
 ;Evolutions
 	db EV_LEVEL,7,KAKUNA
 	db 0
 ;Learnset
 	db 0
 
-KAKUNA_EvosMoves
+KakunaEvosMoves:
 ;Evolutions
 	db EV_LEVEL,10,BEEDRILL
 	db 0
 ;Learnset
 	db 0
 
-BEEDRILL_EvosMoves
+BeedrillEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1387,13 +1388,13 @@ BEEDRILL_EvosMoves
 	db 35,AGILITY
 	db 0
 
-MISSINGNO_73_EvosMoves
+MissingNo73EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-DODRIO_EvosMoves
+DodrioEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1405,7 +1406,7 @@ DODRIO_EvosMoves
 	db 51,AGILITY
 	db 0
 
-PRIMEAPE_EvosMoves
+PrimeapeEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1416,7 +1417,7 @@ PRIMEAPE_EvosMoves
 	db 46,THRASH
 	db 0
 
-DUGTRIO_EvosMoves
+DugtrioEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1427,7 +1428,7 @@ DUGTRIO_EvosMoves
 	db 47,EARTHQUAKE
 	db 0
 
-VENOMOTH_EvosMoves
+VenomothEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1439,7 +1440,7 @@ VENOMOTH_EvosMoves
 	db 50,PSYCHIC_M
 	db 0
 
-DEWGONG_EvosMoves
+DewgongEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1450,33 +1451,33 @@ DEWGONG_EvosMoves
 	db 56,ICE_BEAM
 	db 0
 
-MISSINGNO_79_EvosMoves
+MissingNo79EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_7A_EvosMoves
+MissingNo7AEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-CATERPIE_EvosMoves
+CaterpieEvosMoves:
 ;Evolutions
 	db EV_LEVEL,7,METAPOD
 	db 0
 ;Learnset
 	db 0
 
-METAPOD_EvosMoves
+MetapodEvosMoves:
 ;Evolutions
 	db EV_LEVEL,10,BUTTERFREE
 	db 0
 ;Learnset
 	db 0
 
-BUTTERFREE_EvosMoves
+ButterfreeEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1489,7 +1490,7 @@ BUTTERFREE_EvosMoves
 	db 32,PSYBEAM
 	db 0
 
-MACHAMP_EvosMoves
+MachampEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1500,13 +1501,13 @@ MACHAMP_EvosMoves
 	db 52,SUBMISSION
 	db 0
 
-MISSINGNO_7F_EvosMoves
+MissingNo7FEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-GOLDUCK_EvosMoves
+GolduckEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1517,7 +1518,7 @@ GOLDUCK_EvosMoves
 	db 59,HYDRO_PUMP
 	db 0
 
-HYPNO_EvosMoves
+HypnoEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1529,7 +1530,7 @@ HYPNO_EvosMoves
 	db 43,MEDITATE
 	db 0
 
-GOLBAT_EvosMoves
+GolbatEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1540,7 +1541,7 @@ GOLBAT_EvosMoves
 	db 43,HAZE
 	db 0
 
-MEWTWO_EvosMoves
+MewtwoEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1551,7 +1552,7 @@ MEWTWO_EvosMoves
 	db 81,AMNESIA
 	db 0
 
-SNORLAX_EvosMoves
+SnorlaxEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1561,7 +1562,7 @@ SNORLAX_EvosMoves
 	db 56,HYPER_BEAM
 	db 0
 
-MAGIKARP_EvosMoves
+MagikarpEvosMoves:
 ;Evolutions
 	db EV_LEVEL,20,GYARADOS
 	db 0
@@ -1569,19 +1570,19 @@ MAGIKARP_EvosMoves
 	db 15,TACKLE
 	db 0
 
-MISSINGNO_86_EvosMoves
+MissingNo86EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_87_EvosMoves
+MissingNo87EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MUK_EvosMoves
+MukEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1593,13 +1594,13 @@ MUK_EvosMoves
 	db 60,ACID_ARMOR
 	db 0
 
-MISSINGNO_8A_EvosMoves
+MissingNo8AEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-KINGLER_EvosMoves
+KinglerEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1610,20 +1611,20 @@ KINGLER_EvosMoves
 	db 49,HARDEN
 	db 0
 
-CLOYSTER_EvosMoves
+CloysterEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 50,SPIKE_CANNON
 	db 0
 
-MISSINGNO_8C_EvosMoves
+MissingNo8CEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-ELECTRODE_EvosMoves
+ElectrodeEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1634,13 +1635,13 @@ ELECTRODE_EvosMoves
 	db 50,EXPLOSION
 	db 0
 
-CLEFABLE_EvosMoves
+ClefableEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-WEEZING_EvosMoves
+WeezingEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1651,7 +1652,7 @@ WEEZING_EvosMoves
 	db 53,EXPLOSION
 	db 0
 
-PERSIAN_EvosMoves
+PersianEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1662,7 +1663,7 @@ PERSIAN_EvosMoves
 	db 51,SLASH
 	db 0
 
-MAROWAK_EvosMoves
+MarowakEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1673,13 +1674,13 @@ MAROWAK_EvosMoves
 	db 55,RAGE
 	db 0
 
-MISSINGNO_92_EvosMoves
+MissingNo92EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-HAUNTER_EvosMoves
+HaunterEvosMoves:
 ;Evolutions
 	db EV_TRADE,1,GENGAR
 	db 0
@@ -1688,14 +1689,14 @@ HAUNTER_EvosMoves
 	db 38,DREAM_EATER
 	db 0
 
-ABRA_EvosMoves
+AbraEvosMoves:
 ;Evolutions
 	db EV_LEVEL,16,KADABRA
 	db 0
 ;Learnset
 	db 0
 
-ALAKAZAM_EvosMoves
+AlakazamEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1707,7 +1708,7 @@ ALAKAZAM_EvosMoves
 	db 42,REFLECT
 	db 0
 
-PIDGEOTTO_EvosMoves
+PidgeottoEvosMoves:
 ;Evolutions
 	db EV_LEVEL,36,PIDGEOT
 	db 0
@@ -1720,7 +1721,7 @@ PIDGEOTTO_EvosMoves
 	db 49,MIRROR_MOVE
 	db 0
 
-PIDGEOT_EvosMoves
+PidgeotEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1732,13 +1733,13 @@ PIDGEOT_EvosMoves
 	db 54,MIRROR_MOVE
 	db 0
 
-STARMIE_EvosMoves
+StarmieEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-BULBASAUR_EvosMoves
+BulbasaurEvosMoves:
 ;Evolutions
 	db EV_LEVEL,16,IVYSAUR
 	db 0
@@ -1752,7 +1753,7 @@ BULBASAUR_EvosMoves
 	db 48,SOLARBEAM
 	db 0
 
-VENUSAUR_EvosMoves
+VenusaurEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1765,7 +1766,7 @@ VENUSAUR_EvosMoves
 	db 65,SOLARBEAM
 	db 0
 
-TENTACRUEL_EvosMoves
+TentacruelEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1779,13 +1780,13 @@ TENTACRUEL_EvosMoves
 	db 50,HYDRO_PUMP
 	db 0
 
-MISSINGNO_9C_EvosMoves
+MissingNo9CEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-GOLDEEN_EvosMoves
+GoldeenEvosMoves:
 ;Evolutions
 	db EV_LEVEL,33,SEAKING
 	db 0
@@ -1798,7 +1799,7 @@ GOLDEEN_EvosMoves
 	db 54,AGILITY
 	db 0
 
-SEAKING_EvosMoves
+SeakingEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1810,31 +1811,31 @@ SEAKING_EvosMoves
 	db 54,AGILITY
 	db 0
 
-MISSINGNO_9F_EvosMoves
+MissingNo9FEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_A0_EvosMoves
+MissingNoA0EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_A1_EvosMoves
+MissingNoA1EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_A2_EvosMoves
+MissingNoA2EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-PONYTA_EvosMoves
+PonytaEvosMoves:
 ;Evolutions
 	db EV_LEVEL,40,RAPIDASH
 	db 0
@@ -1847,7 +1848,7 @@ PONYTA_EvosMoves
 	db 48,AGILITY
 	db 0
 
-RAPIDASH_EvosMoves
+RapidashEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1859,7 +1860,7 @@ RAPIDASH_EvosMoves
 	db 55,AGILITY
 	db 0
 
-RATTATA_EvosMoves
+RattataEvosMoves:
 ;Evolutions
 	db EV_LEVEL,20,RATICATE
 	db 0
@@ -1870,7 +1871,7 @@ RATTATA_EvosMoves
 	db 34,SUPER_FANG
 	db 0
 
-RATICATE_EvosMoves
+RaticateEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1880,7 +1881,7 @@ RATICATE_EvosMoves
 	db 41,SUPER_FANG
 	db 0
 
-NIDORINO_EvosMoves
+NidorinoEvosMoves:
 ;Evolutions
 	db EV_ITEM,MOON_STONE,1,NIDOKING
 	db 0
@@ -1893,7 +1894,7 @@ NIDORINO_EvosMoves
 	db 50,DOUBLE_KICK
 	db 0
 
-NIDORINA_EvosMoves
+NidorinaEvosMoves:
 ;Evolutions
 	db EV_ITEM,MOON_STONE,1,NIDOQUEEN
 	db 0
@@ -1906,7 +1907,7 @@ NIDORINA_EvosMoves
 	db 50,DOUBLE_KICK
 	db 0
 
-GEODUDE_EvosMoves
+GeodudeEvosMoves:
 ;Evolutions
 	db EV_LEVEL,25,GRAVELER
 	db 0
@@ -1919,7 +1920,7 @@ GEODUDE_EvosMoves
 	db 36,EXPLOSION
 	db 0
 
-PORYGON_EvosMoves
+PorygonEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1929,7 +1930,7 @@ PORYGON_EvosMoves
 	db 42,TRI_ATTACK
 	db 0
 
-AERODACTYL_EvosMoves
+AerodactylEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -1939,13 +1940,13 @@ AERODACTYL_EvosMoves
 	db 54,HYPER_BEAM
 	db 0
 
-MISSINGNO_AC_EvosMoves
+MissingNoACEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MAGNEMITE_EvosMoves
+MagnemiteEvosMoves:
 ;Evolutions
 	db EV_LEVEL,30,MAGNETON
 	db 0
@@ -1958,19 +1959,19 @@ MAGNEMITE_EvosMoves
 	db 47,SCREECH
 	db 0
 
-MISSINGNO_AE_EvosMoves
+MissingNoAEEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MISSINGNO_AF_EvosMoves
+MissingNoAFEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-CHARMANDER_EvosMoves
+CharmanderEvosMoves:
 ;Evolutions
 	db EV_LEVEL,16,CHARMELEON
 	db 0
@@ -1983,7 +1984,7 @@ CHARMANDER_EvosMoves
 	db 46,FIRE_SPIN
 	db 0
 
-SQUIRTLE_EvosMoves
+SquirtleEvosMoves:
 ;Evolutions
 	db EV_LEVEL,16,WARTORTLE
 	db 0
@@ -1996,7 +1997,7 @@ SQUIRTLE_EvosMoves
 	db 42,HYDRO_PUMP
 	db 0
 
-CHARMELEON_EvosMoves
+CharmeleonEvosMoves:
 ;Evolutions
 	db EV_LEVEL,36,CHARIZARD
 	db 0
@@ -2009,7 +2010,7 @@ CHARMELEON_EvosMoves
 	db 56,FIRE_SPIN
 	db 0
 
-WARTORTLE_EvosMoves
+WartortleEvosMoves:
 ;Evolutions
 	db EV_LEVEL,36,BLASTOISE
 	db 0
@@ -2022,7 +2023,7 @@ WARTORTLE_EvosMoves
 	db 47,HYDRO_PUMP
 	db 0
 
-CHARIZARD_EvosMoves
+CharizardEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -2034,31 +2035,31 @@ CHARIZARD_EvosMoves
 	db 55,FIRE_SPIN
 	db 0
 
-MISSINGNO_B5_EvosMoves
+MissingNoB5EvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-FOSSIL_KABUTOPS_EvosMoves
+FossilKabutopsEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-FOSSIL_AERODACTYL_EvosMoves
+FossilAerodactylEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-MON_GHOST_EvosMoves
+MonGhostEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
 	db 0
 
-ODDISH_EvosMoves
+OddishEvosMoves:
 ;Evolutions
 	db EV_LEVEL,21,GLOOM
 	db 0
@@ -2071,7 +2072,7 @@ ODDISH_EvosMoves
 	db 46,SOLARBEAM
 	db 0
 
-GLOOM_EvosMoves
+GloomEvosMoves:
 ;Evolutions
 	db EV_ITEM,LEAF_STONE,1,VILEPLUME
 	db 0
@@ -2084,7 +2085,7 @@ GLOOM_EvosMoves
 	db 52,SOLARBEAM
 	db 0
 
-VILEPLUME_EvosMoves
+VileplumeEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset
@@ -2093,7 +2094,7 @@ VILEPLUME_EvosMoves
 	db 19,SLEEP_POWDER
 	db 0
 
-BELLSPROUT_EvosMoves
+BellsproutEvosMoves:
 ;Evolutions
 	db EV_LEVEL,21,WEEPINBELL
 	db 0
@@ -2107,7 +2108,7 @@ BELLSPROUT_EvosMoves
 	db 42,SLAM
 	db 0
 
-WEEPINBELL_EvosMoves
+WeepinbellEvosMoves:
 ;Evolutions
 	db EV_ITEM,LEAF_STONE,1,VICTREEBEL
 	db 0
@@ -2121,7 +2122,7 @@ WEEPINBELL_EvosMoves
 	db 49,SLAM
 	db 0
 
-VICTREEBEL_EvosMoves
+VictreebelEvosMoves:
 ;Evolutions
 	db 0
 ;Learnset

--- a/engine/menu/party_menu.asm
+++ b/engine/menu/party_menu.asm
@@ -150,7 +150,7 @@ RedrawPartyMenu_:
 	ld l, a
 	ld de, wcd6d
 	ld a, BANK(EvosMovesPointerTable)
-	ld bc, EEVEE_EvosEnd - EEVEE_EvosMoves
+	ld bc, EeveeEvosEnd - EeveeEvosMoves
 	call FarCopyData
 	ld hl, wcd6d
 	ld de, .notAbleToEvolveText

--- a/engine/menu/party_menu.asm
+++ b/engine/menu/party_menu.asm
@@ -150,7 +150,7 @@ RedrawPartyMenu_:
 	ld l, a
 	ld de, wcd6d
 	ld a, BANK(EvosMovesPointerTable)
-	ld bc, Mon133_EvosEnd - Mon133_EvosMoves
+	ld bc, EEVEE_EvosEnd - EEVEE_EvosMoves
 	call FarCopyData
 	ld hl, wcd6d
 	ld de, .notAbleToEvolveText


### PR DESCRIPTION
In data/evos_moves.asm, I noticed that all of the pointers were of the form Mon###_EvosMoves, where ### was the Pokemon's Pokedex number. That's cumbersome to work with, so I replaced those instances with the names as they appear in constants/pokemon_constants.asm. I did a test build and verified both ROMs against the checksum.