### PR TITLE
Link to RGBDS install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,8 @@
 # Linux
 
-	sudo apt-get install make git gcc
+Install [**RGBDS**](https://github.com/rednex/rgbds/blob/master/README.rst#1-installing-rgbds)
 
-	sudo apt-get install byacc flex pkg-config libpng-dev
-	git clone https://github.com/rednex/rgbds
-	cd rgbds
-	sudo make install
-	cd ..
+Then in a terminal, run:
 
 	git clone https://github.com/pret/pokered
 	cd pokered


### PR DESCRIPTION
RGBDS now distributes *nix binaries, which
1. Allows users to use stable releases (`master` is sometimes broken)
2. Doesn't force the user to install the libs required to build RGBDS