### PR TITLE
make comments consistent throughout all mapHeader files

### DIFF
--- a/data/mapHeaders/blueshouse.asm
+++ b/data/mapHeaders/blueshouse.asm
@@ -1,6 +1,6 @@
 BluesHouse_h:
 	db HOUSE ; tileset
-	db BLUES_HOUSE_HEIGHT, BLUES_HOUSE_WIDTH ; dimensions
-	dw BluesHouseBlocks, BluesHouseTextPointers, BluesHouseScript
-	db 0
-	dw BluesHouseObject
+	db BLUES_HOUSE_HEIGHT, BLUES_HOUSE_WIDTH ; dimensions (y, x)
+	dw BluesHouseBlocks, BluesHouseTextPointers, BluesHouseScript ; blocks, texts, scripts
+	db 0 ; connections
+	dw BluesHouseObject ; objects

--- a/data/mapHeaders/gary.asm
+++ b/data/mapHeaders/gary.asm
@@ -1,6 +1,6 @@
 Gary_h:
-	db GYM ;tileset
-	db CHAMPIONS_ROOM_HEIGHT, CHAMPIONS_ROOM_WIDTH ; Height, Width
-	dw GaryBlocks, GaryTextPointers, GaryScript
-	db $0 ;No Connections
-	dw GaryObject
+	db GYM ; tileset
+	db CHAMPIONS_ROOM_HEIGHT, CHAMPIONS_ROOM_WIDTH ; dimensions (y, x)
+	dw GaryBlocks, GaryTextPointers, GaryScript ; blocks, texts, scripts
+	db $0 ; connections
+	dw GaryObject ; objects

--- a/data/mapHeaders/pallettown.asm
+++ b/data/mapHeaders/pallettown.asm
@@ -1,8 +1,8 @@
 PalletTown_h:
 	db OVERWORLD ; tileset
-	db PALLET_TOWN_HEIGHT, PALLET_TOWN_WIDTH ; dimensions
-	dw PalletTownBlocks, PalletTownTextPointers, PalletTownScript
+	db PALLET_TOWN_HEIGHT, PALLET_TOWN_WIDTH ; dimensions (y, x)
+	dw PalletTownBlocks, PalletTownTextPointers, PalletTownScript ; blocks, texts, scripts
 	db NORTH | SOUTH ; connections
 	NORTH_MAP_CONNECTION PALLET_TOWN, ROUTE_1, 0, 0, Route1Blocks
 	SOUTH_MAP_CONNECTION PALLET_TOWN, ROUTE_21, 0, 0, Route21Blocks, 1
-	dw PalletTownObject
+	dw PalletTownObject ; objects

--- a/data/mapHeaders/redshouse1f.asm
+++ b/data/mapHeaders/redshouse1f.asm
@@ -1,6 +1,6 @@
 RedsHouse1F_h:
 	db REDS_HOUSE_1 ; tileset
-	db REDS_HOUSE_1F_HEIGHT, REDS_HOUSE_1F_WIDTH ; dimensions
-	dw RedsHouse1FBlocks, RedsHouse1FTextPointers, RedsHouse1FScript
-	db 0 ; no connections
-	dw RedsHouse1FObject
+	db REDS_HOUSE_1F_HEIGHT, REDS_HOUSE_1F_WIDTH ; dimensions (y, x)
+	dw RedsHouse1FBlocks, RedsHouse1FTextPointers, RedsHouse1FScript ; blocks, texts, scripts
+	db 0 ; connections
+	dw RedsHouse1FObject ; objects

--- a/data/mapHeaders/redshouse2f.asm
+++ b/data/mapHeaders/redshouse2f.asm
@@ -1,6 +1,6 @@
 RedsHouse2F_h:
 	db REDS_HOUSE_2 ; tileset
-	db REDS_HOUSE_2F_HEIGHT, REDS_HOUSE_2F_WIDTH ; dimensions
-	dw RedsHouse2FBlocks, RedsHouse2FTextPointers, RedsHouse2FScript
-	db $00 ; no connections
-	dw RedsHouse2FObject
+	db REDS_HOUSE_2F_HEIGHT, REDS_HOUSE_2F_WIDTH ; dimensions (y, x)
+	dw RedsHouse2FBlocks, RedsHouse2FTextPointers, RedsHouse2FScript ; blocks, texts, scripts
+	db $00 ; connections
+	dw RedsHouse2FObject ; objects

--- a/data/mapHeaders/route2.asm
+++ b/data/mapHeaders/route2.asm
@@ -1,8 +1,8 @@
 Route2_h:
-	db 00 ; Tileset
-	db ROUTE_2_HEIGHT,ROUTE_2_WIDTH ;Height,Width blocks (1 block = 4x4 tiles)
-	dw Route2Blocks, Route2TextPointers, Route2Script
-	db NORTH | SOUTH ;Connection Byte
+	db 00 ; tileset
+	db ROUTE_2_HEIGHT, ROUTE_2_WIDTH ; dimensions (y, x)
+	dw Route2Blocks, Route2TextPointers, Route2Script ; blocks, texts, scripts
+	db NORTH | SOUTH ; connections
 	NORTH_MAP_CONNECTION ROUTE_2, PEWTER_CITY, -3, 2, PewterCityBlocks
 	SOUTH_MAP_CONNECTION ROUTE_2, VIRIDIAN_CITY, -3, 2, ViridianCityBlocks, 1
-	dw Route2Object ;Object Data Pointer
+	dw Route2Object ; objects

--- a/data/mapHeaders/route4.asm
+++ b/data/mapHeaders/route4.asm
@@ -1,7 +1,7 @@
 Route4_h:
 	db OVERWORLD ; tileset
 	db ROUTE_4_HEIGHT, ROUTE_4_WIDTH ; dimensions (y, x)
-	dw Route4Blocks, Route4TextPointers, Route4Script; blocks, texts, scripts
+	dw Route4Blocks, Route4TextPointers, Route4Script ; blocks, texts, scripts
 	db SOUTH | EAST ; connections
 	SOUTH_MAP_CONNECTION ROUTE_4, ROUTE_3, -3, 22, Route3Blocks
 	EAST_MAP_CONNECTION ROUTE_4, CERULEAN_CITY, -3, 1, CeruleanCityBlocks, 1


### PR DESCRIPTION
There's a couple inconsistencies among the comments in the map headers that I found while writing a reader/writer for mapHeader files. This is to fix them (if a change should be made to one of the comments I can do that very easily).