### PR TITLE
Replace hard-coded values in the Seafoam Islands with appropriate constants.

### DIFF
--- a/scripts/SeafoamIslands1F.asm
+++ b/scripts/SeafoamIslands1F.asm
@@ -32,7 +32,7 @@ SeafoamIslands1F_Script:
 	ld [wMissableObjectIndex], a
 	predef_jump ShowObject
 .asm_4483b
-	ld a, $9f
+	ld a, SEAFOAM_ISLANDS_B1F
 	ld [wDungeonWarpDestinationMap], a
 	ld hl, Seafoam1HolesCoords
 	jp IsPlayerOnDungeonWarp

--- a/scripts/SeafoamIslandsB1F.asm
+++ b/scripts/SeafoamIslandsB1F.asm
@@ -31,7 +31,7 @@ SeafoamIslandsB1F_Script:
 	ld [wMissableObjectIndex], a
 	predef_jump ShowObject
 .asm_46362
-	ld a, $a0
+	ld a, SEAFOAM_ISLANDS_B2F
 	ld [wDungeonWarpDestinationMap], a
 	ld hl, Seafoam2HolesCoords
 	jp IsPlayerOnDungeonWarp

--- a/scripts/SeafoamIslandsB2F.asm
+++ b/scripts/SeafoamIslandsB2F.asm
@@ -31,7 +31,7 @@ SeafoamIslandsB2F_Script:
 	ld [wMissableObjectIndex], a
 	predef_jump ShowObject
 .asm_4649e
-	ld a, $a1
+	ld a, SEAFOAM_ISLANDS_B3F
 	ld [wDungeonWarpDestinationMap], a
 	ld hl, Seafoam3HolesCoords
 	jp IsPlayerOnDungeonWarp

--- a/scripts/SeafoamIslandsB3F.asm
+++ b/scripts/SeafoamIslandsB3F.asm
@@ -32,7 +32,7 @@ SeafoamIslandsB3F_Script:
 	predef ShowObject
 	jr .asm_465ed
 .asm_465dc
-	ld a, $a2
+	ld a, SEAFOAM_ISLANDS_B4F
 	ld [wDungeonWarpDestinationMap], a
 	ld hl, Seafoam4HolesCoords
 	call IsPlayerOnDungeonWarp


### PR DESCRIPTION
Changed Special Warp references from being hard-coded to the already-defined constants.