### PR TITLE
Deobfuscate exit warps on indoor maps

### DIFF
--- a/constants/map_constants.asm
+++ b/constants/map_constants.asm
@@ -253,3 +253,8 @@ ENDM
 	mapconst LORELEIS_ROOM,                  6,  5 ; $F5
 	mapconst BRUNOS_ROOM,                    6,  5 ; $F6
 	mapconst AGATHAS_ROOM,                   6,  5 ; $F7
+
+
+; Indoor maps, such as houses, use this as the Map ID in their exit warps
+; This map ID takes the player back to the last outdoor map they were on, stored in wLastMap
+LAST_MAP EQU -1

--- a/data/maps/objects/BikeShop.asm
+++ b/data/maps/objects/BikeShop.asm
@@ -2,8 +2,8 @@ BikeShop_Object:
 	db $e ; border block
 
 	db 2 ; warps
-	warp 2, 7, 4, -1
-	warp 3, 7, 4, -1
+	warp 2, 7, 4, LAST_MAP
+	warp 3, 7, 4, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/BillsHouse.asm
+++ b/data/maps/objects/BillsHouse.asm
@@ -2,8 +2,8 @@ BillsHouse_Object:
 	db $d ; border block
 
 	db 2 ; warps
-	warp 2, 7, 0, -1
-	warp 3, 7, 0, -1
+	warp 2, 7, 0, LAST_MAP
+	warp 3, 7, 0, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/BluesHouse.asm
+++ b/data/maps/objects/BluesHouse.asm
@@ -2,8 +2,8 @@ BluesHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 1, -1
-	warp 3, 7, 1, -1
+	warp 2, 7, 1, LAST_MAP
+	warp 3, 7, 1, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeladonChiefHouse.asm
+++ b/data/maps/objects/CeladonChiefHouse.asm
@@ -2,8 +2,8 @@ CeladonChiefHouse_Object:
 	db $f ; border block
 
 	db 2 ; warps
-	warp 2, 7, 11, -1
-	warp 3, 7, 11, -1
+	warp 2, 7, 11, LAST_MAP
+	warp 3, 7, 11, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeladonDiner.asm
+++ b/data/maps/objects/CeladonDiner.asm
@@ -2,8 +2,8 @@ CeladonDiner_Object:
 	db $f ; border block
 
 	db 2 ; warps
-	warp 3, 7, 10, -1
-	warp 4, 7, 10, -1
+	warp 3, 7, 10, LAST_MAP
+	warp 4, 7, 10, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeladonGym.asm
+++ b/data/maps/objects/CeladonGym.asm
@@ -2,8 +2,8 @@ CeladonGym_Object:
 	db $3 ; border block
 
 	db 2 ; warps
-	warp 4, 17, 6, -1
-	warp 5, 17, 6, -1
+	warp 4, 17, 6, LAST_MAP
+	warp 5, 17, 6, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeladonHotel.asm
+++ b/data/maps/objects/CeladonHotel.asm
@@ -2,8 +2,8 @@ CeladonHotel_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 12, -1
-	warp 4, 7, 12, -1
+	warp 3, 7, 12, LAST_MAP
+	warp 4, 7, 12, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeladonMansion1F.asm
+++ b/data/maps/objects/CeladonMansion1F.asm
@@ -2,9 +2,9 @@ CeladonMansion1F_Object:
 	db $f ; border block
 
 	db 5 ; warps
-	warp 4, 11, 2, -1
-	warp 5, 11, 2, -1
-	warp 4, 0, 4, -1
+	warp 4, 11, 2, LAST_MAP
+	warp 5, 11, 2, LAST_MAP
+	warp 4, 0, 4, LAST_MAP
 	warp 7, 1, 1, CELADON_MANSION_2F
 	warp 2, 1, 2, CELADON_MANSION_2F
 

--- a/data/maps/objects/CeladonMart1F.asm
+++ b/data/maps/objects/CeladonMart1F.asm
@@ -2,10 +2,10 @@ CeladonMart1F_Object:
 	db $f ; border block
 
 	db 6 ; warps
-	warp 2, 7, 0, -1
-	warp 3, 7, 0, -1
-	warp 16, 7, 1, -1
-	warp 17, 7, 1, -1
+	warp 2, 7, 0, LAST_MAP
+	warp 3, 7, 0, LAST_MAP
+	warp 16, 7, 1, LAST_MAP
+	warp 17, 7, 1, LAST_MAP
 	warp 12, 1, 0, CELADON_MART_2F
 	warp 1, 1, 0, CELADON_MART_ELEVATOR
 

--- a/data/maps/objects/CeladonPokecenter.asm
+++ b/data/maps/objects/CeladonPokecenter.asm
@@ -2,8 +2,8 @@ CeladonPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 5, -1
-	warp 4, 7, 5, -1
+	warp 3, 7, 5, LAST_MAP
+	warp 4, 7, 5, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeruleanBadgeHouse.asm
+++ b/data/maps/objects/CeruleanBadgeHouse.asm
@@ -2,9 +2,9 @@ CeruleanBadgeHouse_Object:
 	db $c ; border block
 
 	db 3 ; warps
-	warp 2, 0, 9, -1
-	warp 2, 7, 8, -1
-	warp 3, 7, 8, -1
+	warp 2, 0, 9, LAST_MAP
+	warp 2, 7, 8, LAST_MAP
+	warp 3, 7, 8, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeruleanCave1F.asm
+++ b/data/maps/objects/CeruleanCave1F.asm
@@ -2,8 +2,8 @@ CeruleanCave1F_Object:
 	db $7d ; border block
 
 	db 9 ; warps
-	warp 24, 17, 6, -1
-	warp 25, 17, 6, -1
+	warp 24, 17, 6, LAST_MAP
+	warp 25, 17, 6, LAST_MAP
 	warp 27, 1, 0, CERULEAN_CAVE_2F
 	warp 23, 7, 1, CERULEAN_CAVE_2F
 	warp 18, 9, 2, CERULEAN_CAVE_2F

--- a/data/maps/objects/CeruleanGym.asm
+++ b/data/maps/objects/CeruleanGym.asm
@@ -2,8 +2,8 @@ CeruleanGym_Object:
 	db $3 ; border block
 
 	db 2 ; warps
-	warp 4, 13, 3, -1
-	warp 5, 13, 3, -1
+	warp 4, 13, 3, LAST_MAP
+	warp 5, 13, 3, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeruleanMart.asm
+++ b/data/maps/objects/CeruleanMart.asm
@@ -2,8 +2,8 @@ CeruleanMart_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 5, -1
-	warp 4, 7, 5, -1
+	warp 3, 7, 5, LAST_MAP
+	warp 4, 7, 5, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeruleanPokecenter.asm
+++ b/data/maps/objects/CeruleanPokecenter.asm
@@ -2,8 +2,8 @@ CeruleanPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 2, -1
-	warp 4, 7, 2, -1
+	warp 3, 7, 2, LAST_MAP
+	warp 4, 7, 2, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeruleanTradeHouse.asm
+++ b/data/maps/objects/CeruleanTradeHouse.asm
@@ -2,8 +2,8 @@ CeruleanTradeHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 1, -1
-	warp 3, 7, 1, -1
+	warp 2, 7, 1, LAST_MAP
+	warp 3, 7, 1, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CeruleanTrashedHouse.asm
+++ b/data/maps/objects/CeruleanTrashedHouse.asm
@@ -2,9 +2,9 @@ CeruleanTrashedHouse_Object:
 	db $a ; border block
 
 	db 3 ; warps
-	warp 2, 7, 0, -1
-	warp 3, 7, 0, -1
-	warp 3, 0, 7, -1
+	warp 2, 7, 0, LAST_MAP
+	warp 3, 7, 0, LAST_MAP
+	warp 3, 0, 7, LAST_MAP
 
 	db 1 ; signs
 	sign 3, 0, 3 ; CeruleanHouseTrashedText3

--- a/data/maps/objects/CinnabarGym.asm
+++ b/data/maps/objects/CinnabarGym.asm
@@ -2,8 +2,8 @@ CinnabarGym_Object:
 	db $2e ; border block
 
 	db 2 ; warps
-	warp 16, 17, 1, -1
-	warp 17, 17, 1, -1
+	warp 16, 17, 1, LAST_MAP
+	warp 17, 17, 1, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CinnabarLab.asm
+++ b/data/maps/objects/CinnabarLab.asm
@@ -2,8 +2,8 @@ CinnabarLab_Object:
 	db $17 ; border block
 
 	db 5 ; warps
-	warp 2, 7, 2, -1
-	warp 3, 7, 2, -1
+	warp 2, 7, 2, LAST_MAP
+	warp 3, 7, 2, LAST_MAP
 	warp 8, 4, 0, CINNABAR_LAB_TRADE_ROOM
 	warp 12, 4, 0, CINNABAR_LAB_METRONOME_ROOM
 	warp 16, 4, 0, CINNABAR_LAB_FOSSIL_ROOM

--- a/data/maps/objects/CinnabarMart.asm
+++ b/data/maps/objects/CinnabarMart.asm
@@ -2,8 +2,8 @@ CinnabarMart_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 4, -1
-	warp 4, 7, 4, -1
+	warp 3, 7, 4, LAST_MAP
+	warp 4, 7, 4, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CinnabarPokecenter.asm
+++ b/data/maps/objects/CinnabarPokecenter.asm
@@ -2,8 +2,8 @@ CinnabarPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 3, -1
-	warp 4, 7, 3, -1
+	warp 3, 7, 3, LAST_MAP
+	warp 4, 7, 3, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/CopycatsHouse1F.asm
+++ b/data/maps/objects/CopycatsHouse1F.asm
@@ -2,8 +2,8 @@ CopycatsHouse1F_Object:
 	db $a ; border block
 
 	db 3 ; warps
-	warp 2, 7, 0, -1
-	warp 3, 7, 0, -1
+	warp 2, 7, 0, LAST_MAP
+	warp 3, 7, 0, LAST_MAP
 	warp 7, 1, 0, COPYCATS_HOUSE_2F
 
 	db 0 ; signs

--- a/data/maps/objects/Daycare.asm
+++ b/data/maps/objects/Daycare.asm
@@ -2,8 +2,8 @@ Daycare_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 4, -1
-	warp 3, 7, 4, -1
+	warp 2, 7, 4, LAST_MAP
+	warp 3, 7, 4, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/DiglettsCaveRoute11.asm
+++ b/data/maps/objects/DiglettsCaveRoute11.asm
@@ -2,8 +2,8 @@ DiglettsCaveRoute11_Object:
 	db $7d ; border block
 
 	db 3 ; warps
-	warp 2, 7, 4, -1
-	warp 3, 7, 4, -1
+	warp 2, 7, 4, LAST_MAP
+	warp 3, 7, 4, LAST_MAP
 	warp 4, 4, 1, DIGLETTS_CAVE
 
 	db 0 ; signs

--- a/data/maps/objects/DiglettsCaveRoute2.asm
+++ b/data/maps/objects/DiglettsCaveRoute2.asm
@@ -2,8 +2,8 @@ DiglettsCaveRoute2_Object:
 	db $7d ; border block
 
 	db 3 ; warps
-	warp 2, 7, 0, -1
-	warp 3, 7, 0, -1
+	warp 2, 7, 0, LAST_MAP
+	warp 3, 7, 0, LAST_MAP
 	warp 4, 4, 0, DIGLETTS_CAVE
 
 	db 0 ; signs

--- a/data/maps/objects/FightingDojo.asm
+++ b/data/maps/objects/FightingDojo.asm
@@ -2,8 +2,8 @@ FightingDojo_Object:
 	db $3 ; border block
 
 	db 2 ; warps
-	warp 4, 11, 1, -1
-	warp 5, 11, 1, -1
+	warp 4, 11, 1, LAST_MAP
+	warp 5, 11, 1, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/FuchsiaBillsGrandpasHouse.asm
+++ b/data/maps/objects/FuchsiaBillsGrandpasHouse.asm
@@ -2,8 +2,8 @@ FuchsiaBillsGrandpasHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 1, -1
-	warp 3, 7, 1, -1
+	warp 2, 7, 1, LAST_MAP
+	warp 3, 7, 1, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/FuchsiaGoodRodHouse.asm
+++ b/data/maps/objects/FuchsiaGoodRodHouse.asm
@@ -2,9 +2,9 @@ FuchsiaGoodRodHouse_Object:
 	db $c ; border block
 
 	db 3 ; warps
-	warp 2, 0, 8, -1
-	warp 2, 7, 7, -1
-	warp 3, 7, 7, -1
+	warp 2, 0, 8, LAST_MAP
+	warp 2, 7, 7, LAST_MAP
+	warp 3, 7, 7, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/FuchsiaGym.asm
+++ b/data/maps/objects/FuchsiaGym.asm
@@ -2,8 +2,8 @@ FuchsiaGym_Object:
 	db $3 ; border block
 
 	db 2 ; warps
-	warp 4, 17, 5, -1
-	warp 5, 17, 5, -1
+	warp 4, 17, 5, LAST_MAP
+	warp 5, 17, 5, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/FuchsiaMart.asm
+++ b/data/maps/objects/FuchsiaMart.asm
@@ -2,8 +2,8 @@ FuchsiaMart_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 0, -1
-	warp 4, 7, 0, -1
+	warp 3, 7, 0, LAST_MAP
+	warp 4, 7, 0, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/FuchsiaMeetingRoom.asm
+++ b/data/maps/objects/FuchsiaMeetingRoom.asm
@@ -2,8 +2,8 @@ FuchsiaMeetingRoom_Object:
 	db $17 ; border block
 
 	db 2 ; warps
-	warp 4, 7, 6, -1
-	warp 5, 7, 6, -1
+	warp 4, 7, 6, LAST_MAP
+	warp 5, 7, 6, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/FuchsiaPokecenter.asm
+++ b/data/maps/objects/FuchsiaPokecenter.asm
@@ -2,8 +2,8 @@ FuchsiaPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 2, -1
-	warp 4, 7, 2, -1
+	warp 3, 7, 2, LAST_MAP
+	warp 4, 7, 2, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/GameCorner.asm
+++ b/data/maps/objects/GameCorner.asm
@@ -2,8 +2,8 @@ GameCorner_Object:
 	db $f ; border block
 
 	db 3 ; warps
-	warp 15, 17, 7, -1
-	warp 16, 17, 7, -1
+	warp 15, 17, 7, LAST_MAP
+	warp 16, 17, 7, LAST_MAP
 	warp 17, 4, 1, ROCKET_HIDEOUT_B1F
 
 	db 1 ; signs

--- a/data/maps/objects/GameCornerPrizeRoom.asm
+++ b/data/maps/objects/GameCornerPrizeRoom.asm
@@ -2,8 +2,8 @@ GameCornerPrizeRoom_Object:
 	db $f ; border block
 
 	db 2 ; warps
-	warp 4, 7, 9, -1
-	warp 5, 7, 9, -1
+	warp 4, 7, 9, LAST_MAP
+	warp 5, 7, 9, LAST_MAP
 
 	db 3 ; signs
 	sign 2, 2, 3 ; CeladonPrizeRoomText3

--- a/data/maps/objects/IndigoPlateauLobby.asm
+++ b/data/maps/objects/IndigoPlateauLobby.asm
@@ -2,8 +2,8 @@ IndigoPlateauLobby_Object:
 	db $0 ; border block
 
 	db 3 ; warps
-	warp 7, 11, 0, -1
-	warp 8, 11, 1, -1
+	warp 7, 11, 0, LAST_MAP
+	warp 8, 11, 1, LAST_MAP
 	warp 8, 0, 0, LORELEIS_ROOM
 
 	db 0 ; signs

--- a/data/maps/objects/LavenderCuboneHouse.asm
+++ b/data/maps/objects/LavenderCuboneHouse.asm
@@ -2,8 +2,8 @@ LavenderCuboneHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 4, -1
-	warp 3, 7, 4, -1
+	warp 2, 7, 4, LAST_MAP
+	warp 3, 7, 4, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/LavenderMart.asm
+++ b/data/maps/objects/LavenderMart.asm
@@ -2,8 +2,8 @@ LavenderMart_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 3, -1
-	warp 4, 7, 3, -1
+	warp 3, 7, 3, LAST_MAP
+	warp 4, 7, 3, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/LavenderPokecenter.asm
+++ b/data/maps/objects/LavenderPokecenter.asm
@@ -2,8 +2,8 @@ LavenderPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 0, -1
-	warp 4, 7, 0, -1
+	warp 3, 7, 0, LAST_MAP
+	warp 4, 7, 0, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/MrFujisHouse.asm
+++ b/data/maps/objects/MrFujisHouse.asm
@@ -2,8 +2,8 @@ MrFujisHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 2, -1
-	warp 3, 7, 2, -1
+	warp 2, 7, 2, LAST_MAP
+	warp 3, 7, 2, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/MrPsychicsHouse.asm
+++ b/data/maps/objects/MrPsychicsHouse.asm
@@ -2,8 +2,8 @@ MrPsychicsHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 7, -1
-	warp 3, 7, 7, -1
+	warp 2, 7, 7, LAST_MAP
+	warp 3, 7, 7, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/MtMoon1F.asm
+++ b/data/maps/objects/MtMoon1F.asm
@@ -2,8 +2,8 @@ MtMoon1F_Object:
 	db $3 ; border block
 
 	db 5 ; warps
-	warp 14, 35, 1, -1
-	warp 15, 35, 1, -1
+	warp 14, 35, 1, LAST_MAP
+	warp 15, 35, 1, LAST_MAP
 	warp 5, 5, 0, MT_MOON_B1F
 	warp 17, 11, 2, MT_MOON_B1F
 	warp 25, 15, 3, MT_MOON_B1F

--- a/data/maps/objects/MtMoonB1F.asm
+++ b/data/maps/objects/MtMoonB1F.asm
@@ -9,7 +9,7 @@ MtMoonB1F_Object:
 	warp 21, 17, 1, MT_MOON_B2F
 	warp 13, 27, 2, MT_MOON_B2F
 	warp 23, 3, 3, MT_MOON_B2F
-	warp 27, 3, 2, -1
+	warp 27, 3, 2, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/MtMoonPokecenter.asm
+++ b/data/maps/objects/MtMoonPokecenter.asm
@@ -2,8 +2,8 @@ MtMoonPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 0, -1
-	warp 4, 7, 0, -1
+	warp 3, 7, 0, LAST_MAP
+	warp 4, 7, 0, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/Museum1F.asm
+++ b/data/maps/objects/Museum1F.asm
@@ -2,10 +2,10 @@ Museum1F_Object:
 	db $a ; border block
 
 	db 5 ; warps
-	warp 10, 7, 0, -1
-	warp 11, 7, 0, -1
-	warp 16, 7, 1, -1
-	warp 17, 7, 1, -1
+	warp 10, 7, 0, LAST_MAP
+	warp 11, 7, 0, LAST_MAP
+	warp 16, 7, 1, LAST_MAP
+	warp 17, 7, 1, LAST_MAP
 	warp 7, 7, 0, MUSEUM_2F
 
 	db 0 ; signs

--- a/data/maps/objects/NameRatersHouse.asm
+++ b/data/maps/objects/NameRatersHouse.asm
@@ -2,8 +2,8 @@ NameRatersHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 5, -1
-	warp 3, 7, 5, -1
+	warp 2, 7, 5, LAST_MAP
+	warp 3, 7, 5, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/OaksLab.asm
+++ b/data/maps/objects/OaksLab.asm
@@ -2,8 +2,8 @@ OaksLab_Object:
 	db $3 ; border block
 
 	db 2 ; warps
-	warp 4, 11, 2, -1
-	warp 5, 11, 2, -1
+	warp 4, 11, 2, LAST_MAP
+	warp 5, 11, 2, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/PewterGym.asm
+++ b/data/maps/objects/PewterGym.asm
@@ -2,8 +2,8 @@ PewterGym_Object:
 	db $3 ; border block
 
 	db 2 ; warps
-	warp 4, 13, 2, -1
-	warp 5, 13, 2, -1
+	warp 4, 13, 2, LAST_MAP
+	warp 5, 13, 2, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/PewterMart.asm
+++ b/data/maps/objects/PewterMart.asm
@@ -2,8 +2,8 @@ PewterMart_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 4, -1
-	warp 4, 7, 4, -1
+	warp 3, 7, 4, LAST_MAP
+	warp 4, 7, 4, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/PewterNidoranHouse.asm
+++ b/data/maps/objects/PewterNidoranHouse.asm
@@ -2,8 +2,8 @@ PewterNidoranHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 3, -1
-	warp 3, 7, 3, -1
+	warp 2, 7, 3, LAST_MAP
+	warp 3, 7, 3, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/PewterPokecenter.asm
+++ b/data/maps/objects/PewterPokecenter.asm
@@ -2,8 +2,8 @@ PewterPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 6, -1
-	warp 4, 7, 6, -1
+	warp 3, 7, 6, LAST_MAP
+	warp 4, 7, 6, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/PewterSpeechHouse.asm
+++ b/data/maps/objects/PewterSpeechHouse.asm
@@ -2,8 +2,8 @@ PewterSpeechHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 5, -1
-	warp 3, 7, 5, -1
+	warp 2, 7, 5, LAST_MAP
+	warp 3, 7, 5, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/PokemonFanClub.asm
+++ b/data/maps/objects/PokemonFanClub.asm
@@ -2,8 +2,8 @@ PokemonFanClub_Object:
 	db $d ; border block
 
 	db 2 ; warps
-	warp 2, 7, 1, -1
-	warp 3, 7, 1, -1
+	warp 2, 7, 1, LAST_MAP
+	warp 3, 7, 1, LAST_MAP
 
 	db 2 ; signs
 	sign 1, 0, 7 ; FanClubText7

--- a/data/maps/objects/PokemonMansion1F.asm
+++ b/data/maps/objects/PokemonMansion1F.asm
@@ -2,14 +2,14 @@ PokemonMansion1F_Object:
 	db $2e ; border block
 
 	db 8 ; warps
-	warp 4, 27, 0, -1
-	warp 5, 27, 0, -1
-	warp 6, 27, 0, -1
-	warp 7, 27, 0, -1
+	warp 4, 27, 0, LAST_MAP
+	warp 5, 27, 0, LAST_MAP
+	warp 6, 27, 0, LAST_MAP
+	warp 7, 27, 0, LAST_MAP
 	warp 5, 10, 0, POKEMON_MANSION_2F
 	warp 21, 23, 0, POKEMON_MANSION_B1F
-	warp 26, 27, 0, -1
-	warp 27, 27, 0, -1
+	warp 26, 27, 0, LAST_MAP
+	warp 27, 27, 0, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/PokemonTower1F.asm
+++ b/data/maps/objects/PokemonTower1F.asm
@@ -2,8 +2,8 @@ PokemonTower1F_Object:
 	db $1 ; border block
 
 	db 3 ; warps
-	warp 10, 17, 1, -1
-	warp 11, 17, 1, -1
+	warp 10, 17, 1, LAST_MAP
+	warp 11, 17, 1, LAST_MAP
 	warp 18, 9, 1, POKEMON_TOWER_2F
 
 	db 0 ; signs

--- a/data/maps/objects/PowerPlant.asm
+++ b/data/maps/objects/PowerPlant.asm
@@ -2,9 +2,9 @@ PowerPlant_Object:
 	db $2e ; border block
 
 	db 3 ; warps
-	warp 4, 35, 3, -1
-	warp 5, 35, 3, -1
-	warp 0, 11, 3, -1
+	warp 4, 35, 3, LAST_MAP
+	warp 5, 35, 3, LAST_MAP
+	warp 0, 11, 3, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/RedsHouse1F.asm
+++ b/data/maps/objects/RedsHouse1F.asm
@@ -2,8 +2,8 @@ RedsHouse1F_Object:
 	db $a ; border block
 
 	db 3 ; warps
-	warp 2, 7, 0, -1 ; exit1
-	warp 3, 7, 0, -1 ; exit2
+	warp 2, 7, 0, LAST_MAP ; exit1
+	warp 3, 7, 0, LAST_MAP ; exit2
 	warp 7, 1, 0, REDS_HOUSE_2F ; staircase
 
 	db 1 ; signs

--- a/data/maps/objects/RockTunnel1F.asm
+++ b/data/maps/objects/RockTunnel1F.asm
@@ -2,10 +2,10 @@ RockTunnel1F_Object:
 	db $3 ; border block
 
 	db 8 ; warps
-	warp 15, 3, 1, -1
-	warp 15, 0, 1, -1
-	warp 15, 33, 2, -1
-	warp 15, 35, 2, -1
+	warp 15, 3, 1, LAST_MAP
+	warp 15, 0, 1, LAST_MAP
+	warp 15, 33, 2, LAST_MAP
+	warp 15, 35, 2, LAST_MAP
 	warp 37, 3, 0, ROCK_TUNNEL_B1F
 	warp 5, 3, 1, ROCK_TUNNEL_B1F
 	warp 17, 11, 2, ROCK_TUNNEL_B1F

--- a/data/maps/objects/RockTunnelPokecenter.asm
+++ b/data/maps/objects/RockTunnelPokecenter.asm
@@ -2,8 +2,8 @@ RockTunnelPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 0, -1
-	warp 4, 7, 0, -1
+	warp 3, 7, 0, LAST_MAP
+	warp 4, 7, 0, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/Route11Gate1F.asm
+++ b/data/maps/objects/Route11Gate1F.asm
@@ -2,10 +2,10 @@ Route11Gate1F_Object:
 	db $a ; border block
 
 	db 5 ; warps
-	warp 0, 4, 0, -1
-	warp 0, 5, 1, -1
-	warp 7, 4, 2, -1
-	warp 7, 5, 3, -1
+	warp 0, 4, 0, LAST_MAP
+	warp 0, 5, 1, LAST_MAP
+	warp 7, 4, 2, LAST_MAP
+	warp 7, 5, 3, LAST_MAP
 	warp 6, 8, 0, ROUTE_11_GATE_2F
 
 	db 0 ; signs

--- a/data/maps/objects/Route12Gate1F.asm
+++ b/data/maps/objects/Route12Gate1F.asm
@@ -2,10 +2,10 @@ Route12Gate1F_Object:
 	db $a ; border block
 
 	db 5 ; warps
-	warp 4, 0, 0, -1
-	warp 5, 0, 1, -1
-	warp 4, 7, 2, -1
-	warp 5, 7, 2, -1
+	warp 4, 0, 0, LAST_MAP
+	warp 5, 0, 1, LAST_MAP
+	warp 4, 7, 2, LAST_MAP
+	warp 5, 7, 2, LAST_MAP
 	warp 8, 6, 0, ROUTE_12_GATE_2F
 
 	db 0 ; signs

--- a/data/maps/objects/Route12SuperRodHouse.asm
+++ b/data/maps/objects/Route12SuperRodHouse.asm
@@ -2,8 +2,8 @@ Route12SuperRodHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 3, -1
-	warp 3, 7, 3, -1
+	warp 2, 7, 3, LAST_MAP
+	warp 3, 7, 3, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/Route15Gate1F.asm
+++ b/data/maps/objects/Route15Gate1F.asm
@@ -2,10 +2,10 @@ Route15Gate1F_Object:
 	db $a ; border block
 
 	db 5 ; warps
-	warp 0, 4, 0, -1
-	warp 0, 5, 1, -1
-	warp 7, 4, 2, -1
-	warp 7, 5, 3, -1
+	warp 0, 4, 0, LAST_MAP
+	warp 0, 5, 1, LAST_MAP
+	warp 7, 4, 2, LAST_MAP
+	warp 7, 5, 3, LAST_MAP
 	warp 6, 8, 0, ROUTE_15_GATE_2F
 
 	db 0 ; signs

--- a/data/maps/objects/Route16FlyHouse.asm
+++ b/data/maps/objects/Route16FlyHouse.asm
@@ -2,8 +2,8 @@ Route16FlyHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 8, -1
-	warp 3, 7, 8, -1
+	warp 2, 7, 8, LAST_MAP
+	warp 3, 7, 8, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/Route16Gate1F.asm
+++ b/data/maps/objects/Route16Gate1F.asm
@@ -2,14 +2,14 @@ Route16Gate1F_Object:
 	db $a ; border block
 
 	db 9 ; warps
-	warp 0, 8, 0, -1
-	warp 0, 9, 1, -1
-	warp 7, 8, 2, -1
-	warp 7, 9, 2, -1
-	warp 0, 2, 4, -1
-	warp 0, 3, 5, -1
-	warp 7, 2, 6, -1
-	warp 7, 3, 7, -1
+	warp 0, 8, 0, LAST_MAP
+	warp 0, 9, 1, LAST_MAP
+	warp 7, 8, 2, LAST_MAP
+	warp 7, 9, 2, LAST_MAP
+	warp 0, 2, 4, LAST_MAP
+	warp 0, 3, 5, LAST_MAP
+	warp 7, 2, 6, LAST_MAP
+	warp 7, 3, 7, LAST_MAP
 	warp 6, 12, 0, ROUTE_16_GATE_2F
 
 	db 0 ; signs

--- a/data/maps/objects/Route18Gate1F.asm
+++ b/data/maps/objects/Route18Gate1F.asm
@@ -2,10 +2,10 @@ Route18Gate1F_Object:
 	db $a ; border block
 
 	db 5 ; warps
-	warp 0, 4, 0, -1
-	warp 0, 5, 1, -1
-	warp 7, 4, 2, -1
-	warp 7, 5, 3, -1
+	warp 0, 4, 0, LAST_MAP
+	warp 0, 5, 1, LAST_MAP
+	warp 7, 4, 2, LAST_MAP
+	warp 7, 5, 3, LAST_MAP
 	warp 6, 8, 0, ROUTE_18_GATE_2F
 
 	db 0 ; signs

--- a/data/maps/objects/Route22Gate.asm
+++ b/data/maps/objects/Route22Gate.asm
@@ -2,10 +2,10 @@ Route22Gate_Object:
 	db $a ; border block
 
 	db 4 ; warps
-	warp 4, 7, 0, -1
-	warp 5, 7, 0, -1
-	warp 4, 0, 0, -1
-	warp 5, 0, 1, -1
+	warp 4, 7, 0, LAST_MAP
+	warp 5, 7, 0, LAST_MAP
+	warp 4, 0, 0, LAST_MAP
+	warp 5, 0, 1, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/Route2Gate.asm
+++ b/data/maps/objects/Route2Gate.asm
@@ -2,10 +2,10 @@ Route2Gate_Object:
 	db $a ; border block
 
 	db 4 ; warps
-	warp 4, 0, 3, -1
-	warp 5, 0, 3, -1
-	warp 4, 7, 4, -1
-	warp 5, 7, 4, -1
+	warp 4, 0, 3, LAST_MAP
+	warp 5, 0, 3, LAST_MAP
+	warp 4, 7, 4, LAST_MAP
+	warp 5, 7, 4, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/Route2TradeHouse.asm
+++ b/data/maps/objects/Route2TradeHouse.asm
@@ -2,8 +2,8 @@ Route2TradeHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 2, -1
-	warp 3, 7, 2, -1
+	warp 2, 7, 2, LAST_MAP
+	warp 3, 7, 2, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/Route5Gate.asm
+++ b/data/maps/objects/Route5Gate.asm
@@ -2,10 +2,10 @@ Route5Gate_Object:
 	db $a ; border block
 
 	db 4 ; warps
-	warp 3, 5, 2, -1
-	warp 4, 5, 2, -1
-	warp 3, 0, 1, -1
-	warp 4, 0, 0, -1
+	warp 3, 5, 2, LAST_MAP
+	warp 4, 5, 2, LAST_MAP
+	warp 3, 0, 1, LAST_MAP
+	warp 4, 0, 0, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/Route6Gate.asm
+++ b/data/maps/objects/Route6Gate.asm
@@ -2,10 +2,10 @@ Route6Gate_Object:
 	db $a ; border block
 
 	db 4 ; warps
-	warp 3, 5, 2, -1
-	warp 4, 5, 2, -1
-	warp 3, 0, 1, -1
-	warp 4, 0, 1, -1
+	warp 3, 5, 2, LAST_MAP
+	warp 4, 5, 2, LAST_MAP
+	warp 3, 0, 1, LAST_MAP
+	warp 4, 0, 1, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/Route7Gate.asm
+++ b/data/maps/objects/Route7Gate.asm
@@ -2,10 +2,10 @@ Route7Gate_Object:
 	db $a ; border block
 
 	db 4 ; warps
-	warp 0, 3, 3, -1
-	warp 0, 4, 3, -1
-	warp 5, 3, 0, -1
-	warp 5, 4, 1, -1
+	warp 0, 3, 3, LAST_MAP
+	warp 0, 4, 3, LAST_MAP
+	warp 5, 3, 0, LAST_MAP
+	warp 5, 4, 1, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/Route8Gate.asm
+++ b/data/maps/objects/Route8Gate.asm
@@ -2,10 +2,10 @@ Route8Gate_Object:
 	db $a ; border block
 
 	db 4 ; warps
-	warp 0, 3, 0, -1
-	warp 0, 4, 1, -1
-	warp 5, 3, 2, -1
-	warp 5, 4, 3, -1
+	warp 0, 3, 0, LAST_MAP
+	warp 0, 4, 1, LAST_MAP
+	warp 5, 3, 2, LAST_MAP
+	warp 5, 4, 3, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/SafariZoneGate.asm
+++ b/data/maps/objects/SafariZoneGate.asm
@@ -2,8 +2,8 @@ SafariZoneGate_Object:
 	db $a ; border block
 
 	db 4 ; warps
-	warp 3, 5, 4, -1
-	warp 4, 5, 4, -1
+	warp 3, 5, 4, LAST_MAP
+	warp 4, 5, 4, LAST_MAP
 	warp 3, 0, 0, SAFARI_ZONE_CENTER
 	warp 4, 0, 1, SAFARI_ZONE_CENTER
 

--- a/data/maps/objects/SaffronGym.asm
+++ b/data/maps/objects/SaffronGym.asm
@@ -2,8 +2,8 @@ SaffronGym_Object:
 	db $2e ; border block
 
 	db 32 ; warps
-	warp 8, 17, 2, -1
-	warp 9, 17, 2, -1
+	warp 8, 17, 2, LAST_MAP
+	warp 9, 17, 2, LAST_MAP
 	warp 1, 3, 22, SAFFRON_GYM
 	warp 5, 3, 15, SAFFRON_GYM
 	warp 1, 5, 18, SAFFRON_GYM

--- a/data/maps/objects/SaffronMart.asm
+++ b/data/maps/objects/SaffronMart.asm
@@ -2,8 +2,8 @@ SaffronMart_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 4, -1
-	warp 4, 7, 4, -1
+	warp 3, 7, 4, LAST_MAP
+	warp 4, 7, 4, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/SaffronPidgeyHouse.asm
+++ b/data/maps/objects/SaffronPidgeyHouse.asm
@@ -2,8 +2,8 @@ SaffronPidgeyHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 3, -1
-	warp 3, 7, 3, -1
+	warp 2, 7, 3, LAST_MAP
+	warp 3, 7, 3, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/SaffronPokecenter.asm
+++ b/data/maps/objects/SaffronPokecenter.asm
@@ -2,8 +2,8 @@ SaffronPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 6, -1
-	warp 4, 7, 6, -1
+	warp 3, 7, 6, LAST_MAP
+	warp 4, 7, 6, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/SeafoamIslands1F.asm
+++ b/data/maps/objects/SeafoamIslands1F.asm
@@ -2,10 +2,10 @@ SeafoamIslands1F_Object:
 	db $7d ; border block
 
 	db 7 ; warps
-	warp 4, 17, 0, -1
-	warp 5, 17, 0, -1
-	warp 26, 17, 1, -1
-	warp 27, 17, 1, -1
+	warp 4, 17, 0, LAST_MAP
+	warp 5, 17, 0, LAST_MAP
+	warp 26, 17, 1, LAST_MAP
+	warp 27, 17, 1, LAST_MAP
 	warp 7, 5, 1, SEAFOAM_ISLANDS_B1F
 	warp 25, 3, 6, SEAFOAM_ISLANDS_B1F
 	warp 23, 15, 4, SEAFOAM_ISLANDS_B1F

--- a/data/maps/objects/SilphCo11F.asm
+++ b/data/maps/objects/SilphCo11F.asm
@@ -4,7 +4,7 @@ SilphCo11F_Object:
 	db 4 ; warps
 	warp 9, 0, 1, SILPH_CO_10F
 	warp 13, 0, 0, SILPH_CO_ELEVATOR
-	warp 5, 5, 9, -1
+	warp 5, 5, 9, LAST_MAP
 	warp 3, 2, 3, SILPH_CO_7F
 
 	db 0 ; signs

--- a/data/maps/objects/SilphCo1F.asm
+++ b/data/maps/objects/SilphCo1F.asm
@@ -2,8 +2,8 @@ SilphCo1F_Object:
 	db $2e ; border block
 
 	db 5 ; warps
-	warp 10, 17, 5, -1
-	warp 11, 17, 5, -1
+	warp 10, 17, 5, LAST_MAP
+	warp 11, 17, 5, LAST_MAP
 	warp 26, 0, 0, SILPH_CO_2F
 	warp 20, 0, 0, SILPH_CO_ELEVATOR
 	warp 16, 10, 6, SILPH_CO_3F

--- a/data/maps/objects/UndergroundPathRoute5.asm
+++ b/data/maps/objects/UndergroundPathRoute5.asm
@@ -2,8 +2,8 @@ UndergroundPathRoute5_Object:
 	db $a ; border block
 
 	db 3 ; warps
-	warp 3, 7, 3, -1
-	warp 4, 7, 3, -1
+	warp 3, 7, 3, LAST_MAP
+	warp 4, 7, 3, LAST_MAP
 	warp 4, 4, 0, UNDERGROUND_PATH_NORTH_SOUTH
 
 	db 0 ; signs

--- a/data/maps/objects/UndergroundPathRoute6.asm
+++ b/data/maps/objects/UndergroundPathRoute6.asm
@@ -2,8 +2,8 @@ UndergroundPathRoute6_Object:
 	db $a ; border block
 
 	db 3 ; warps
-	warp 3, 7, 3, -1
-	warp 4, 7, 3, -1
+	warp 3, 7, 3, LAST_MAP
+	warp 4, 7, 3, LAST_MAP
 	warp 4, 4, 1, UNDERGROUND_PATH_NORTH_SOUTH
 
 	db 0 ; signs

--- a/data/maps/objects/UndergroundPathRoute7.asm
+++ b/data/maps/objects/UndergroundPathRoute7.asm
@@ -2,8 +2,8 @@ UndergroundPathRoute7_Object:
 	db $a ; border block
 
 	db 3 ; warps
-	warp 3, 7, 4, -1
-	warp 4, 7, 4, -1
+	warp 3, 7, 4, LAST_MAP
+	warp 4, 7, 4, LAST_MAP
 	warp 4, 4, 0, UNDERGROUND_PATH_WEST_EAST
 
 	db 0 ; signs

--- a/data/maps/objects/UndergroundPathRoute7Copy.asm
+++ b/data/maps/objects/UndergroundPathRoute7Copy.asm
@@ -2,8 +2,8 @@ UndergroundPathRoute7Copy_Object:
 	db $a ; border block
 
 	db 3 ; warps
-	warp 3, 7, 5, -1
-	warp 4, 7, 5, -1
+	warp 3, 7, 5, LAST_MAP
+	warp 4, 7, 5, LAST_MAP
 	warp 4, 4, 0, UNDERGROUND_PATH_WEST_EAST
 
 	db 0 ; signs

--- a/data/maps/objects/UndergroundPathRoute8.asm
+++ b/data/maps/objects/UndergroundPathRoute8.asm
@@ -2,8 +2,8 @@ UndergroundPathRoute8_Object:
 	db $a ; border block
 
 	db 3 ; warps
-	warp 3, 7, 4, -1
-	warp 4, 7, 4, -1
+	warp 3, 7, 4, LAST_MAP
+	warp 4, 7, 4, LAST_MAP
 	warp 4, 4, 1, UNDERGROUND_PATH_WEST_EAST
 
 	db 0 ; signs

--- a/data/maps/objects/VermilionDock.asm
+++ b/data/maps/objects/VermilionDock.asm
@@ -2,7 +2,7 @@ VermilionDock_Object:
 	db $f ; border block
 
 	db 2 ; warps
-	warp 14, 0, 5, -1
+	warp 14, 0, 5, LAST_MAP
 	warp 14, 2, 1, SS_ANNE_1F
 
 	db 0 ; signs

--- a/data/maps/objects/VermilionGym.asm
+++ b/data/maps/objects/VermilionGym.asm
@@ -2,8 +2,8 @@ VermilionGym_Object:
 	db $3 ; border block
 
 	db 2 ; warps
-	warp 4, 17, 3, -1
-	warp 5, 17, 3, -1
+	warp 4, 17, 3, LAST_MAP
+	warp 5, 17, 3, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/VermilionMart.asm
+++ b/data/maps/objects/VermilionMart.asm
@@ -2,8 +2,8 @@ VermilionMart_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 2, -1
-	warp 4, 7, 2, -1
+	warp 3, 7, 2, LAST_MAP
+	warp 4, 7, 2, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/VermilionOldRodHouse.asm
+++ b/data/maps/objects/VermilionOldRodHouse.asm
@@ -2,8 +2,8 @@ VermilionOldRodHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 8, -1
-	warp 3, 7, 8, -1
+	warp 2, 7, 8, LAST_MAP
+	warp 3, 7, 8, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/VermilionPidgeyHouse.asm
+++ b/data/maps/objects/VermilionPidgeyHouse.asm
@@ -2,8 +2,8 @@ VermilionPidgeyHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 4, -1
-	warp 3, 7, 4, -1
+	warp 2, 7, 4, LAST_MAP
+	warp 3, 7, 4, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/VermilionPokecenter.asm
+++ b/data/maps/objects/VermilionPokecenter.asm
@@ -2,8 +2,8 @@ VermilionPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 0, -1
-	warp 4, 7, 0, -1
+	warp 3, 7, 0, LAST_MAP
+	warp 4, 7, 0, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/VermilionTradeHouse.asm
+++ b/data/maps/objects/VermilionTradeHouse.asm
@@ -2,8 +2,8 @@ VermilionTradeHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 7, -1
-	warp 3, 7, 7, -1
+	warp 2, 7, 7, LAST_MAP
+	warp 3, 7, 7, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/VictoryRoad1F.asm
+++ b/data/maps/objects/VictoryRoad1F.asm
@@ -2,8 +2,8 @@ VictoryRoad1F_Object:
 	db $7d ; border block
 
 	db 3 ; warps
-	warp 8, 17, 2, -1
-	warp 9, 17, 2, -1
+	warp 8, 17, 2, LAST_MAP
+	warp 9, 17, 2, LAST_MAP
 	warp 1, 1, 0, VICTORY_ROAD_2F
 
 	db 0 ; signs

--- a/data/maps/objects/VictoryRoad2F.asm
+++ b/data/maps/objects/VictoryRoad2F.asm
@@ -3,8 +3,8 @@ VictoryRoad2F_Object:
 
 	db 7 ; warps
 	warp 0, 8, 2, VICTORY_ROAD_1F
-	warp 29, 7, 3, -1
-	warp 29, 8, 3, -1
+	warp 29, 7, 3, LAST_MAP
+	warp 29, 8, 3, LAST_MAP
 	warp 23, 7, 0, VICTORY_ROAD_3F
 	warp 25, 14, 2, VICTORY_ROAD_3F
 	warp 27, 7, 1, VICTORY_ROAD_3F

--- a/data/maps/objects/ViridianForestNorthGate.asm
+++ b/data/maps/objects/ViridianForestNorthGate.asm
@@ -2,8 +2,8 @@ ViridianForestNorthGate_Object:
 	db $a ; border block
 
 	db 4 ; warps
-	warp 4, 0, 1, -1
-	warp 5, 0, 1, -1
+	warp 4, 0, 1, LAST_MAP
+	warp 5, 0, 1, LAST_MAP
 	warp 4, 7, 0, VIRIDIAN_FOREST
 	warp 5, 7, 0, VIRIDIAN_FOREST
 

--- a/data/maps/objects/ViridianForestSouthGate.asm
+++ b/data/maps/objects/ViridianForestSouthGate.asm
@@ -4,8 +4,8 @@ ViridianForestSouthGate_Object:
 	db 4 ; warps
 	warp 4, 0, 3, VIRIDIAN_FOREST
 	warp 5, 0, 4, VIRIDIAN_FOREST
-	warp 4, 7, 5, -1
-	warp 5, 7, 5, -1
+	warp 4, 7, 5, LAST_MAP
+	warp 5, 7, 5, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/ViridianGym.asm
+++ b/data/maps/objects/ViridianGym.asm
@@ -2,8 +2,8 @@ ViridianGym_Object:
 	db $3 ; border block
 
 	db 2 ; warps
-	warp 16, 17, 4, -1
-	warp 17, 17, 4, -1
+	warp 16, 17, 4, LAST_MAP
+	warp 17, 17, 4, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/ViridianMart.asm
+++ b/data/maps/objects/ViridianMart.asm
@@ -2,8 +2,8 @@ ViridianMart_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 1, -1
-	warp 4, 7, 1, -1
+	warp 3, 7, 1, LAST_MAP
+	warp 4, 7, 1, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/ViridianNicknameHouse.asm
+++ b/data/maps/objects/ViridianNicknameHouse.asm
@@ -2,8 +2,8 @@ ViridianNicknameHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 3, -1
-	warp 3, 7, 3, -1
+	warp 2, 7, 3, LAST_MAP
+	warp 3, 7, 3, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/ViridianPokecenter.asm
+++ b/data/maps/objects/ViridianPokecenter.asm
@@ -2,8 +2,8 @@ ViridianPokecenter_Object:
 	db $0 ; border block
 
 	db 2 ; warps
-	warp 3, 7, 0, -1
-	warp 4, 7, 0, -1
+	warp 3, 7, 0, LAST_MAP
+	warp 4, 7, 0, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/ViridianSchoolHouse.asm
+++ b/data/maps/objects/ViridianSchoolHouse.asm
@@ -2,8 +2,8 @@ ViridianSchoolHouse_Object:
 	db $a ; border block
 
 	db 2 ; warps
-	warp 2, 7, 2, -1
-	warp 3, 7, 2, -1
+	warp 2, 7, 2, LAST_MAP
+	warp 3, 7, 2, LAST_MAP
 
 	db 0 ; signs
 

--- a/data/maps/objects/WardensHouse.asm
+++ b/data/maps/objects/WardensHouse.asm
@@ -2,8 +2,8 @@ WardensHouse_Object:
 	db $17 ; border block
 
 	db 2 ; warps
-	warp 4, 7, 3, -1
-	warp 5, 7, 3, -1
+	warp 4, 7, 3, LAST_MAP
+	warp 5, 7, 3, LAST_MAP
 
 	db 2 ; signs
 	sign 4, 3, 4 ; FuchsiaHouse2Text4

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -507,7 +507,7 @@ WarpFound2::
 ; not all these maps are necessarily indoors, though
 .indoorMaps
 	ldh a, [hWarpDestinationMap] ; destination map
-	cp $ff
+	cp LAST_MAP
 	jr z, .goBackOutside
 ; if not going back to the previous map
 	ld [wCurMap], a


### PR DESCRIPTION
Because it was rather unintuitive to new users what exactly the "-1" in the exit warps on indoor maps actually meant or did, this gives that value a named constant, derived from the WRAM address that the code takes the map ID from when this value is used in a warp.