### PR TITLE
fix OAMFLAG_VFLIPPED

### DIFF
--- a/constants/oam_constants.asm
+++ b/constants/oam_constants.asm
@@ -1,7 +1,7 @@
 ; OAM flags used by this game
 OAMFLAG_ENDOFDATA   EQU %00000001 ; pseudo OAM flag, only used by game logic
 OAMFLAG_CANBEMASKED EQU %00000010 ; pseudo OAM flag, only used by game logic
-OAMFLAG_VFLIPPED    EQU %00100000 ; OAM flag flips the sprite vertically.
+OAMFLAG_HFLIPPED    EQU %00100000 ; OAM flag flips the sprite horizontally.
 ; Used for making left facing sprites face right and to alternate between left and right foot animation when walking up or down
 
 ; OAM attribute flags

--- a/constants/oam_constants.asm
+++ b/constants/oam_constants.asm
@@ -12,6 +12,6 @@ OAM_PRIORITY  EQU 7 ; 0: OBJ above BG, 1: OBJ behind BG (colors 1-3)
 
 ; OAM attribute masks
 OAM_OBP1      EQU 1 << OAM_OBP_NUM  ; OBJ palette 1
-OAM_HFLIP     EQU 1 << OAM_X_FLIP   ; horizontal flip. Used for making left facing sprites face right and to alternate between left and right foot animation when walking up or down
+OAM_HFLIP     EQU 1 << OAM_X_FLIP   ; horizontal flip
 OAM_VFLIP     EQU 1 << OAM_Y_FLIP   ; vertical flip
 OAM_BEHIND_BG EQU 1 << OAM_PRIORITY ; behind bg (except color 0)

--- a/constants/oam_constants.asm
+++ b/constants/oam_constants.asm
@@ -1,8 +1,6 @@
 ; OAM flags used by this game
 OAMFLAG_ENDOFDATA   EQU %00000001 ; pseudo OAM flag, only used by game logic
 OAMFLAG_CANBEMASKED EQU %00000010 ; pseudo OAM flag, only used by game logic
-OAMFLAG_HFLIPPED    EQU %00100000 ; OAM flag flips the sprite horizontally.
-; Used for making left facing sprites face right and to alternate between left and right foot animation when walking up or down
 
 ; OAM attribute flags
 OAM_PALETTE   EQU %111
@@ -14,6 +12,6 @@ OAM_PRIORITY  EQU 7 ; 0: OBJ above BG, 1: OBJ behind BG (colors 1-3)
 
 ; OAM attribute masks
 OAM_OBP1      EQU 1 << OAM_OBP_NUM  ; OBJ palette 1
-OAM_HFLIP     EQU 1 << OAM_X_FLIP   ; horizontal flip
+OAM_HFLIP     EQU 1 << OAM_X_FLIP   ; horizontal flip. Used for making left facing sprites face right and to alternate between left and right foot animation when walking up or down
 OAM_VFLIP     EQU 1 << OAM_Y_FLIP   ; vertical flip
 OAM_BEHIND_BG EQU 1 << OAM_PRIORITY ; behind bg (except color 0)

--- a/data/sprites/facings.asm
+++ b/data/sprites/facings.asm
@@ -53,7 +53,7 @@ SpriteFacingAndAnimationTable:
 
 .FlippedOAM:
 	; y, x, attributes
-	db 0, 8, OAMFLAG_HFLIPPED ; top left
-	db 0, 0, OAMFLAG_HFLIPPED ; top right
-	db 8, 8, OAMFLAG_HFLIPPED | OAMFLAG_CANBEMASKED ; bottom left
-	db 8, 0, OAMFLAG_HFLIPPED | OAMFLAG_CANBEMASKED | OAMFLAG_ENDOFDATA ; bottom right
+	db 0, 8, OAM_HFLIP ; top left
+	db 0, 0, OAM_HFLIP ; top right
+	db 8, 8, OAM_HFLIP | OAMFLAG_CANBEMASKED ; bottom left
+	db 8, 0, OAM_HFLIP | OAMFLAG_CANBEMASKED | OAMFLAG_ENDOFDATA ; bottom right

--- a/data/sprites/facings.asm
+++ b/data/sprites/facings.asm
@@ -53,7 +53,7 @@ SpriteFacingAndAnimationTable:
 
 .FlippedOAM:
 	; y, x, attributes
-	db 0, 8, OAMFLAG_VFLIPPED ; top left
-	db 0, 0, OAMFLAG_VFLIPPED ; top right
-	db 8, 8, OAMFLAG_VFLIPPED | OAMFLAG_CANBEMASKED ; bottom left
-	db 8, 0, OAMFLAG_VFLIPPED | OAMFLAG_CANBEMASKED | OAMFLAG_ENDOFDATA ; bottom right
+	db 0, 8, OAMFLAG_HFLIPPED ; top left
+	db 0, 0, OAMFLAG_HFLIPPED ; top right
+	db 8, 8, OAMFLAG_HFLIPPED | OAMFLAG_CANBEMASKED ; bottom left
+	db 8, 0, OAMFLAG_HFLIPPED | OAMFLAG_CANBEMASKED | OAMFLAG_ENDOFDATA ; bottom right


### PR DESCRIPTION
OAMFLAG_VFLIPPED(%00100000) is a incorrect label because bit5 is Horizontally mirrored flag.
I renamed OAMFLAG_VFLIPPED into OAMFLAG_HFLIPPED and modified a comment with label.
ref: https://discord.com/channels/442462691542695948/442462691542695957/738204519355252816