### PR TITLE
fix ExecuteCurMapScriptInTable's comment

### DIFF
--- a/home/trainers.asm
+++ b/home/trainers.asm
@@ -6,8 +6,9 @@ StoreTrainerHeaderPointer::
 	ld [wTrainerHeaderPtr+1], a
 	ret
 
-; executes the current map script from the function pointer array provided in hl.
+; executes the current map script from the function pointer array provided in de.
 ; a: map script index to execute (unless overridden by [wd733] bit 4)
+; hl: trainer header pointer
 ExecuteCurMapScriptInTable::
 	push af
 	push de


### PR DESCRIPTION
map script's jumptable is provided in de. And trainer header is provided in hl.

An example is below.

```asm
; scripts/AgathasRoom.asm
ld hl, AgathaTrainerHeader0
ld de, AgathasRoom_ScriptPointers
ld a, [wAgathasRoomCurScript]
call ExecuteCurMapScriptInTable
```