### PR TITLE
fix comment in ItemUseBall

### DIFF
--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -286,8 +286,8 @@ ItemUseBall:
 	ld b, 4
 	call Divide
 
-; If W > 255, store 255 in [hQuotient + 3].
-; Let X = min(W, 255) = [hQuotient + 3].
+; If W <= 255, store 255 in [hQuotient + 3].
+; Let X = (W > 255 ? W : 255) = [hQuotient + 3].
 	ldh a, [hQuotient + 2]
 	and a
 	jr z, .skip3


### PR DESCRIPTION
"W > 255" is a mistake. "W <= 255" is correct because Divide stores the result in big endian.

https://discord.com/channels/442462691542695948/442462691542695957/757384781066403861