### PR TITLE
Add comment with Cerulean Cave's landmark in Stadium

### DIFF
--- a/data/maps/names.asm
+++ b/data/maps/names.asm
@@ -50,5 +50,5 @@ RocketHQName:        db "ROCKET HQ@"
 SilphCoName:         db "SILPH CO.@"
 PokemonMansionName:  db "<PKMN> MANSION@"
 SafariZoneName:      db "SAFARI ZONE@"
-CeruleanCaveName:    db "CERULEAN CAVE@"
+CeruleanCaveName:    db "CERULEAN CAVE@" ; "UNKNOWN DUNGEON" in pokestadium/stadium1
 PowerPlantName:      db "POWER PLANT@"


### PR DESCRIPTION
Just a small note to clarify that the landmark has a different English name [in a related game of the same generation](https://github.com/pret/pokestadium/blob/126fcca0b9b15a499e4e0b781bba0475c5a4ca03/stadium1/text/0x7853b0.txt#L109). This follows up from the research in #201, which [was completed](https://bulbapedia.bulbagarden.net/wiki/Cerulean_Cave#Names) in the meantime by DanielCM from the TCRF Discord.
