### PR TITLE
The `def_trainers` macro checks that trainers' event flag bits are correct

### DIFF
--- a/macros/scripts/events.asm
+++ b/macros/scripts/events.asm
@@ -242,28 +242,6 @@ ResetEvents: MACRO
 ENDM
 
 
-;\1 = event index
-;\2 = number of bytes away from the base address (optional, for matching the ROM)
-dbEventFlagBit: MACRO
-	IF _NARG > 1
-		db ((\1) % 8) + ((\2) * 8)
-	ELSE
-		db ((\1) % 8)
-	ENDC
-ENDM
-
-
-;\1 = event index
-;\2 = number of bytes away from the base address (optional, for matching the ROM)
-dwEventFlagAddress: MACRO
-	IF _NARG > 1
-		dw wEventFlags + ((\1) / 8) - (\2)
-	ELSE
-		dw wEventFlags + ((\1) / 8)
-	ENDC
-ENDM
-
-
 ;\1 = start
 ;\2 = end
 SetEventRange: MACRO

--- a/macros/scripts/maps.asm
+++ b/macros/scripts/maps.asm
@@ -92,23 +92,30 @@ warp_to: MACRO
 ENDM
 
 
+;\1 first bit offset / first object id
+def_trainers: MACRO
+IF _NARG == 1
+CURRENT_TRAINER_BIT = \1
+ELSE
+CURRENT_TRAINER_BIT = 1
+ENDC
+ENDM
+
 ;\1 event flag
 ;\2 view range
 ;\3 TextBeforeBattle
 ;\4 TextAfterBattle
 ;\5 TextEndBattle
 trainer: MACRO
-	IF _NARG > 5
-		dbEventFlagBit \1, \2
-		db (\3 << 4)
-		dwEventFlagAddress \1, \2
-		SHIFT
-	ELSE
-		dbEventFlagBit \1
-		db (\2 << 4)
-		dwEventFlagAddress \1
-	ENDC
+_ev_bit = \1 % 8
+_cur_bit = CURRENT_TRAINER_BIT % 8
+	ASSERT _ev_bit == _cur_bit, \
+		"Expected \1 to be bit {d:_cur_bit}, got {d:_ev_bit}"
+	db CURRENT_TRAINER_BIT
+	db \2 << 4
+	dw wEventFlags + (\1 - CURRENT_TRAINER_BIT) / 8
 	dw \3, \5, \4, \4
+CURRENT_TRAINER_BIT = CURRENT_TRAINER_BIT + 1
 ENDM
 
 ;\1 x position

--- a/scripts/AgathasRoom.asm
+++ b/scripts/AgathasRoom.asm
@@ -1,7 +1,7 @@
 AgathasRoom_Script:
 	call AgathaShowOrHideExitBlock
 	call EnableAutoTextBoxDrawing
-	ld hl, AgathaTrainerHeader0
+	ld hl, AgathasRoomTrainerHeaders
 	ld de, AgathasRoom_ScriptPointers
 	ld a, [wAgathasRoomCurScript]
 	call ExecuteCurMapScriptInTable
@@ -120,13 +120,15 @@ AgathasRoom_TextPointers:
 	dw AgathaText1
 	dw AgathaDontRunAwayText
 
-AgathaTrainerHeader0:
+AgathasRoomTrainerHeaders:
+	def_trainers
+AgathasRoomTrainerHeader0:
 	trainer EVENT_BEAT_AGATHAS_ROOM_TRAINER_0, 0, AgathaBeforeBattleText, AgathaEndBattleText, AgathaAfterBattleText
 	db -1 ; end
 
 AgathaText1:
 	text_asm
-	ld hl, AgathaTrainerHeader0
+	ld hl, AgathasRoomTrainerHeader0
 	call TalkToTrainer
 	jp TextScriptEnd
 

--- a/scripts/BrunosRoom.asm
+++ b/scripts/BrunosRoom.asm
@@ -1,7 +1,7 @@
 BrunosRoom_Script:
 	call BrunoShowOrHideExitBlock
 	call EnableAutoTextBoxDrawing
-	ld hl, BrunoTrainerHeader0
+	ld hl, BrunosRoomTrainerHeaders
 	ld de, BrunosRoom_ScriptPointers
 	ld a, [wBrunosRoomCurScript]
 	call ExecuteCurMapScriptInTable
@@ -117,13 +117,15 @@ BrunosRoom_TextPointers:
 	dw BrunoText1
 	dw BrunoDontRunAwayText
 
-BrunoTrainerHeader0:
+BrunosRoomTrainerHeaders:
+	def_trainers
+BrunosRoomTrainerHeader0:
 	trainer EVENT_BEAT_BRUNOS_ROOM_TRAINER_0, 0, BrunoBeforeBattleText, BrunoEndBattleText, BrunoAfterBattleText
 	db -1 ; end
 
 BrunoText1:
 	text_asm
-	ld hl, BrunoTrainerHeader0
+	ld hl, BrunosRoomTrainerHeader0
 	call TalkToTrainer
 	jp TextScriptEnd
 

--- a/scripts/CeladonGym.asm
+++ b/scripts/CeladonGym.asm
@@ -4,7 +4,7 @@ CeladonGym_Script:
 	res 6, [hl]
 	call nz, .LoadNames
 	call EnableAutoTextBoxDrawing
-	ld hl, CeladonGymTrainerHeader0
+	ld hl, CeladonGymTrainerHeaders
 	ld de, CeladonGym_ScriptPointers
 	ld a, [wCeladonGymCurScript]
 	call ExecuteCurMapScriptInTable
@@ -83,6 +83,8 @@ CeladonGym_TextPointers:
 	dw TM21Text
 	dw TM21NoRoomText
 
+CeladonGymTrainerHeaders:
+	def_trainers 2
 CeladonGymTrainerHeader0:
 	trainer EVENT_BEAT_CELADON_GYM_TRAINER_0, 2, CeladonGymBattleText2, CeladonGymEndBattleText2, CeladonGymAfterBattleText2
 CeladonGymTrainerHeader1:
@@ -96,7 +98,7 @@ CeladonGymTrainerHeader4:
 CeladonGymTrainerHeader5:
 	trainer EVENT_BEAT_CELADON_GYM_TRAINER_5, 2, CeladonGymBattleText7, CeladonGymEndBattleText7, CeladonGymAfterBattleText7
 CeladonGymTrainerHeader6:
-	trainer EVENT_BEAT_CELADON_GYM_TRAINER_6, 1, 3, CeladonGymBattleText8, CeladonGymEndBattleText8, CeladonGymAfterBattleText8
+	trainer EVENT_BEAT_CELADON_GYM_TRAINER_6, 3, CeladonGymBattleText8, CeladonGymEndBattleText8, CeladonGymAfterBattleText8
 	db -1 ; end
 
 CeladonGymText1:

--- a/scripts/CeruleanCaveB1F.asm
+++ b/scripts/CeruleanCaveB1F.asm
@@ -1,6 +1,6 @@
 CeruleanCaveB1F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, MewtwoTrainerHeader
+	ld hl, CeruleanCaveB1FTrainerHeaders
 	ld de, CeruleanCaveB1F_ScriptPointers
 	ld a, [wCeruleanCaveB1FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -17,6 +17,8 @@ CeruleanCaveB1F_TextPointers:
 	dw PickUpItemText
 	dw PickUpItemText
 
+CeruleanCaveB1FTrainerHeaders:
+	def_trainers
 MewtwoTrainerHeader:
 	trainer EVENT_BEAT_MEWTWO, 0, MewtwoBattleText, MewtwoBattleText, MewtwoBattleText
 	db -1 ; end

--- a/scripts/CeruleanGym.asm
+++ b/scripts/CeruleanGym.asm
@@ -4,7 +4,7 @@ CeruleanGym_Script:
 	res 6, [hl]
 	call nz, .LoadNames
 	call EnableAutoTextBoxDrawing
-	ld hl, CeruleanGymTrainerHeader0
+	ld hl, CeruleanGymTrainerHeaders
 	ld de, CeruleanGym_ScriptPointers
 	ld a, [wCeruleanGymCurScript]
 	call ExecuteCurMapScriptInTable
@@ -79,6 +79,8 @@ CeruleanGym_TextPointers:
 	dw CeruleanGymText6
 	dw CeruleanGymText7
 
+CeruleanGymTrainerHeaders:
+	def_trainers 2
 CeruleanGymTrainerHeader0:
 	trainer EVENT_BEAT_CERULEAN_GYM_TRAINER_0, 3, CeruleanGymBattleText1, CeruleanGymEndBattleText1, CeruleanGymAfterBattleText1
 CeruleanGymTrainerHeader1:

--- a/scripts/FightingDojo.asm
+++ b/scripts/FightingDojo.asm
@@ -1,6 +1,6 @@
 FightingDojo_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, FightingDojoTrainerHeader0
+	ld hl, FightingDojoTrainerHeaders
 	ld de, FightingDojo_ScriptPointers
 	ld a, [wFightingDojoCurScript]
 	call ExecuteCurMapScriptInTable
@@ -90,6 +90,8 @@ FightingDojo_TextPointers:
 	dw FightingDojoText7
 	dw FightingDojoText8
 
+FightingDojoTrainerHeaders:
+	def_trainers 2
 FightingDojoTrainerHeader0:
 	trainer EVENT_BEAT_FIGHTING_DOJO_TRAINER_0, 4, FightingDojoBattleText1, FightingDojoEndBattleText1, FightingDojoAfterBattleText1
 FightingDojoTrainerHeader1:

--- a/scripts/FuchsiaGym.asm
+++ b/scripts/FuchsiaGym.asm
@@ -1,7 +1,7 @@
 FuchsiaGym_Script:
 	call .LoadNames
 	call EnableAutoTextBoxDrawing
-	ld hl, FuchsiaGymTrainerHeader0
+	ld hl, FuchsiaGymTrainerHeaders
 	ld de, FuchsiaGym_ScriptPointers
 	ld a, [wFuchsiaGymCurScript]
 	call ExecuteCurMapScriptInTable
@@ -84,6 +84,8 @@ FuchsiaGym_TextPointers:
 	dw FuchsiaGymText10
 	dw FuchsiaGymText11
 
+FuchsiaGymTrainerHeaders:
+	def_trainers 2
 FuchsiaGymTrainerHeader0:
 	trainer EVENT_BEAT_FUCHSIA_GYM_TRAINER_0, 2, FuchsiaGymBattleText1, FuchsiaGymEndBattleText1, FuchsiaGymAfterBattleText1
 FuchsiaGymTrainerHeader1:

--- a/scripts/LancesRoom.asm
+++ b/scripts/LancesRoom.asm
@@ -1,7 +1,7 @@
 LancesRoom_Script:
 	call LanceShowOrHideEntranceBlocks
 	call EnableAutoTextBoxDrawing
-	ld hl, LanceTrainerHeader0
+	ld hl, LancesRoomTrainerHeaders
 	ld de, LancesRoom_ScriptPointers
 	ld a, [wLancesRoomCurScript]
 	call ExecuteCurMapScriptInTable
@@ -128,13 +128,15 @@ LanceScript3:
 LancesRoom_TextPointers:
 	dw LanceText1
 
-LanceTrainerHeader0:
+LancesRoomTrainerHeaders:
+	def_trainers
+LancesRoomTrainerHeader0:
 	trainer EVENT_BEAT_LANCES_ROOM_TRAINER_0, 0, LanceBeforeBattleText, LanceEndBattleText, LanceAfterBattleText
 	db -1 ; end
 
 LanceText1:
 	text_asm
-	ld hl, LanceTrainerHeader0
+	ld hl, LancesRoomTrainerHeader0
 	call TalkToTrainer
 	jp TextScriptEnd
 

--- a/scripts/LoreleisRoom.asm
+++ b/scripts/LoreleisRoom.asm
@@ -1,7 +1,7 @@
 LoreleisRoom_Script:
 	call LoreleiShowOrHideExitBlock
 	call EnableAutoTextBoxDrawing
-	ld hl, LoreleiTrainerHeader0
+	ld hl, LoreleisRoomTrainerHeaders
 	ld de, LoreleisRoom_ScriptPointers
 	ld a, [wLoreleisRoomCurScript]
 	call ExecuteCurMapScriptInTable
@@ -119,13 +119,15 @@ LoreleisRoom_TextPointers:
 	dw LoreleiText1
 	dw LoreleiDontRunAwayText
 
-LoreleiTrainerHeader0:
+LoreleisRoomTrainerHeaders:
+	def_trainers
+LoreleisRoomTrainerHeader0:
 	trainer EVENT_BEAT_LORELEIS_ROOM_TRAINER_0, 0, LoreleiBeforeBattleText, LoreleiEndBattleText, LoreleiAfterBattleText
 	db -1 ; end
 
 LoreleiText1:
 	text_asm
-	ld hl, LoreleiTrainerHeader0
+	ld hl, LoreleisRoomTrainerHeader0
 	call TalkToTrainer
 	jp TextScriptEnd
 

--- a/scripts/MtMoon1F.asm
+++ b/scripts/MtMoon1F.asm
@@ -1,6 +1,6 @@
 MtMoon1F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, MtMoon1TrainerHeader0
+	ld hl, MtMoon1TrainerHeaders
 	ld de, MtMoon1F_ScriptPointers
 	ld a, [wMtMoon1FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -28,6 +28,8 @@ MtMoon1F_TextPointers:
 	dw PickUpItemText
 	dw MtMoon1Text14
 
+MtMoon1TrainerHeaders:
+	def_trainers
 MtMoon1TrainerHeader0:
 	trainer EVENT_BEAT_MT_MOON_1_TRAINER_0, 2, MtMoon1BattleText2, MtMoon1EndBattleText2, MtMoon1AfterBattleText2
 MtMoon1TrainerHeader1:

--- a/scripts/MtMoonB2F.asm
+++ b/scripts/MtMoonB2F.asm
@@ -1,6 +1,6 @@
 MtMoonB2F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, MtMoon3TrainerHeader0
+	ld hl, MtMoon3TrainerHeaders
 	ld de, MtMoonB2F_ScriptPointers
 	ld a, [wMtMoonB2FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -166,6 +166,8 @@ MtMoonB2F_TextPointers:
 	dw PickUpItemText
 	dw MtMoon3Text_49f99
 
+MtMoon3TrainerHeaders:
+	def_trainers 2
 MtMoon3TrainerHeader0:
 	trainer EVENT_BEAT_MT_MOON_3_TRAINER_0, 4, MtMoon3BattleText2, MtMoon3EndBattleText2, MtMoon3AfterBattleText2
 MtMoon3TrainerHeader1:

--- a/scripts/PewterGym.asm
+++ b/scripts/PewterGym.asm
@@ -4,7 +4,7 @@ PewterGym_Script:
 	res 6, [hl]
 	call nz, .LoadNames
 	call EnableAutoTextBoxDrawing
-	ld hl, PewterGymTrainerHeader0
+	ld hl, PewterGymTrainerHeaders
 	ld de, PewterGym_ScriptPointers
 	ld a, [wPewterGymCurScript]
 	call ExecuteCurMapScriptInTable
@@ -86,6 +86,8 @@ PewterGym_TextPointers:
 	dw PewterGymText5
 	dw PewterGymText6
 
+PewterGymTrainerHeaders:
+	def_trainers 2
 PewterGymTrainerHeader0:
 	trainer EVENT_BEAT_PEWTER_GYM_TRAINER_0, 5, PewterGymBattleText1, PewterGymEndBattleText1, PewterGymAfterBattleText1
 	db -1 ; end

--- a/scripts/PokemonMansion1F.asm
+++ b/scripts/PokemonMansion1F.asm
@@ -1,7 +1,7 @@
 PokemonMansion1F_Script:
 	call Mansion1Subscript1
 	call EnableAutoTextBoxDrawing
-	ld hl, Mansion1TrainerHeader0
+	ld hl, Mansion1TrainerHeaders
 	ld de, PokemonMansion1F_ScriptPointers
 	ld a, [wPokemonMansion1FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -66,6 +66,8 @@ PokemonMansion1F_TextPointers:
 	dw PickUpItemText
 	dw Mansion1Text4
 
+Mansion1TrainerHeaders:
+	def_trainers
 Mansion1TrainerHeader0:
 	trainer EVENT_BEAT_MANSION_1_TRAINER_0, 3, Mansion1BattleText2, Mansion1EndBattleText2, Mansion1AfterBattleText2
 	db -1 ; end

--- a/scripts/PokemonMansion2F.asm
+++ b/scripts/PokemonMansion2F.asm
@@ -1,7 +1,7 @@
 PokemonMansion2F_Script:
 	call Mansion2Script_51fee
 	call EnableAutoTextBoxDrawing
-	ld hl, Mansion2TrainerHeader0
+	ld hl, Mansion2TrainerHeaders
 	ld de, PokemonMansion2F_ScriptPointers
 	ld a, [wPokemonMansion2FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -63,6 +63,8 @@ PokemonMansion2F_TextPointers:
 	dw Mansion2Text4
 	dw Mansion2Text5
 
+Mansion2TrainerHeaders:
+	def_trainers
 Mansion2TrainerHeader0:
 	trainer EVENT_BEAT_MANSION_2_TRAINER_0, 0, Mansion2BattleText1, Mansion2EndBattleText1, Mansion2AfterBattleText1
 	db -1 ; end

--- a/scripts/PokemonMansion3F.asm
+++ b/scripts/PokemonMansion3F.asm
@@ -1,7 +1,7 @@
 PokemonMansion3F_Script:
 	call Mansion3Script_52204
 	call EnableAutoTextBoxDrawing
-	ld hl, Mansion3TrainerHeader0
+	ld hl, Mansion3TrainerHeaders
 	ld de, PokemonMansion3F_ScriptPointers
 	ld a, [wPokemonMansion3FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -90,6 +90,8 @@ PokemonMansion3F_TextPointers:
 	dw Mansion3Text5
 	dw Mansion3Text6
 
+Mansion3TrainerHeaders:
+	def_trainers
 Mansion3TrainerHeader0:
 	trainer EVENT_BEAT_MANSION_3_TRAINER_0, 0, Mansion3BattleText1, Mansion3EndBattleText1, Mansion3AfterBattleText1
 Mansion3TrainerHeader1:

--- a/scripts/PokemonMansionB1F.asm
+++ b/scripts/PokemonMansionB1F.asm
@@ -1,7 +1,7 @@
 PokemonMansionB1F_Script:
 	call Mansion4Script_523cf
 	call EnableAutoTextBoxDrawing
-	ld hl, Mansion4TrainerHeader0
+	ld hl, Mansion4TrainerHeaders
 	ld de, PokemonMansionB1F_ScriptPointers
 	ld a, [wPokemonMansionB1FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -69,6 +69,8 @@ PokemonMansionB1F_TextPointers:
 	dw PickUpItemText
 	dw Mansion3Text6
 
+Mansion4TrainerHeaders:
+	def_trainers
 Mansion4TrainerHeader0:
 	trainer EVENT_BEAT_MANSION_4_TRAINER_0, 0, Mansion4BattleText1, Mansion4EndBattleText1, Mansion4AfterBattleText1
 Mansion4TrainerHeader1:

--- a/scripts/PokemonTower3F.asm
+++ b/scripts/PokemonTower3F.asm
@@ -1,6 +1,6 @@
 PokemonTower3F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, PokemonTower3TrainerHeader0
+	ld hl, PokemonTower3TrainerHeaders
 	ld de, PokemonTower3F_ScriptPointers
 	ld a, [wPokemonTower3FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -18,6 +18,8 @@ PokemonTower3F_TextPointers:
 	dw PokemonTower3Text3
 	dw PickUpItemText
 
+PokemonTower3TrainerHeaders:
+	def_trainers
 PokemonTower3TrainerHeader0:
 	trainer EVENT_BEAT_POKEMONTOWER_3_TRAINER_0, 2, PokemonTower3BattleText1, PokemonTower3EndBattleText1, PokemonTower3AfterBattleText1
 PokemonTower3TrainerHeader1:

--- a/scripts/PokemonTower4F.asm
+++ b/scripts/PokemonTower4F.asm
@@ -1,6 +1,6 @@
 PokemonTower4F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, PokemonTower4TrainerHeader0
+	ld hl, PokemonTower4TrainerHeaders
 	ld de, PokemonTower4F_ScriptPointers
 	ld a, [wPokemonTower4FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -20,6 +20,8 @@ PokemonTower4F_TextPointers:
 	dw PickUpItemText
 	dw PickUpItemText
 
+PokemonTower4TrainerHeaders:
+	def_trainers
 PokemonTower4TrainerHeader0:
 	trainer EVENT_BEAT_POKEMONTOWER_4_TRAINER_0, 2, PokemonTower4BattleText1, PokemonTower4EndBattleText1, PokemonTower4AfterBattleText1
 PokemonTower4TrainerHeader1:

--- a/scripts/PokemonTower5F.asm
+++ b/scripts/PokemonTower5F.asm
@@ -1,6 +1,6 @@
 PokemonTower5F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, PokemonTower5TrainerHeader0
+	ld hl, PokemonTower5TrainerHeaders
 	ld de, PokemonTower5F_ScriptPointers
 	ld a, [wPokemonTower5FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -57,6 +57,8 @@ PokemonTower5F_TextPointers:
 	dw PickUpItemText
 	dw PokemonTower5Text7
 
+PokemonTower5TrainerHeaders:
+	def_trainers 2
 PokemonTower5TrainerHeader0:
 	trainer EVENT_BEAT_POKEMONTOWER_5_TRAINER_0, 2, PokemonTower5BattleText1, PokemonTower5EndBattleText1, PokemonTower5AfterBattleText1
 PokemonTower5TrainerHeader1:

--- a/scripts/PokemonTower6F.asm
+++ b/scripts/PokemonTower6F.asm
@@ -1,6 +1,6 @@
 PokemonTower6F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, PokemonTower6TrainerHeader0
+	ld hl, PokemonTower6TrainerHeaders
 	ld de, PokemonTower6F_ScriptPointers
 	ld a, [wPokemonTower6FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -104,6 +104,8 @@ PokemonTower6F_TextPointers:
 	dw PokemonTower6Text6
 	dw PokemonTower6Text7
 
+PokemonTower6TrainerHeaders:
+	def_trainers
 PokemonTower6TrainerHeader0:
 	trainer EVENT_BEAT_POKEMONTOWER_6_TRAINER_0, 3, PokemonTower6BattleText1, PokemonTower6EndBattleText1, PokemonTower6AfterBattleText1
 PokemonTower6TrainerHeader1:

--- a/scripts/PokemonTower7F.asm
+++ b/scripts/PokemonTower7F.asm
@@ -1,6 +1,6 @@
 PokemonTower7F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, PokemonTower7TrainerHeader0
+	ld hl, PokemonTower7TrainerHeaders
 	ld de, PokemonTower7F_ScriptPointers
 	ld a, [wPokemonTower7FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -192,6 +192,8 @@ PokemonTower7F_TextPointers:
 	dw PokemonTower7Text3
 	dw PokemonTower7FujiText
 
+PokemonTower7TrainerHeaders:
+	def_trainers
 PokemonTower7TrainerHeader0:
 	trainer EVENT_BEAT_POKEMONTOWER_7_TRAINER_0, 3, PokemonTower7BattleText1, PokemonTower7EndBattleText1, PokemonTower7AfterBattleText1
 PokemonTower7TrainerHeader1:

--- a/scripts/PowerPlant.asm
+++ b/scripts/PowerPlant.asm
@@ -1,6 +1,6 @@
 PowerPlant_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Voltorb0TrainerHeader
+	ld hl, PowerPlantTrainerHeaders
 	ld de, PowerPlant_ScriptPointers
 	ld a, [wPowerPlantCurScript]
 	call ExecuteCurMapScriptInTable
@@ -28,6 +28,8 @@ PowerPlant_TextPointers:
 	dw PickUpItemText
 	dw PickUpItemText
 
+PowerPlantTrainerHeaders:
+	def_trainers
 Voltorb0TrainerHeader:
 	trainer EVENT_BEAT_POWER_PLANT_VOLTORB_0, 0, VoltorbBattleText, VoltorbBattleText, VoltorbBattleText
 Voltorb1TrainerHeader:
@@ -43,9 +45,9 @@ Voltorb5TrainerHeader:
 Voltorb6TrainerHeader:
 	trainer EVENT_BEAT_POWER_PLANT_VOLTORB_6, 0, VoltorbBattleText, VoltorbBattleText, VoltorbBattleText
 Voltorb7TrainerHeader:
-	trainer EVENT_BEAT_POWER_PLANT_VOLTORB_7, 1, 0, VoltorbBattleText, VoltorbBattleText, VoltorbBattleText
+	trainer EVENT_BEAT_POWER_PLANT_VOLTORB_7, 0, VoltorbBattleText, VoltorbBattleText, VoltorbBattleText
 ZapdosTrainerHeader:
-	trainer EVENT_BEAT_ZAPDOS, 1, 0, ZapdosBattleText, ZapdosBattleText, ZapdosBattleText
+	trainer EVENT_BEAT_ZAPDOS, 0, ZapdosBattleText, ZapdosBattleText, ZapdosBattleText
 	db -1 ; end
 
 InitVoltorbBattle:

--- a/scripts/RockTunnel1F.asm
+++ b/scripts/RockTunnel1F.asm
@@ -1,6 +1,6 @@
 RockTunnel1F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, RockTunnel1TrainerHeader0
+	ld hl, RockTunnel1TrainerHeaders
 	ld de, RockTunnel1F_ScriptPointers
 	ld a, [wRockTunnel1FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -22,6 +22,8 @@ RockTunnel1F_TextPointers:
 	dw RockTunnel1Text7
 	dw RockTunnel1Text8
 
+RockTunnel1TrainerHeaders:
+	def_trainers
 RockTunnel1TrainerHeader0:
 	trainer EVENT_BEAT_ROCK_TUNNEL_1_TRAINER_0, 4, RockTunnel1BattleText1, RockTunnel1EndBattleText1, RockTunnel1AfterBattleText1
 RockTunnel1TrainerHeader1:

--- a/scripts/RockTunnelB1F.asm
+++ b/scripts/RockTunnelB1F.asm
@@ -1,6 +1,6 @@
 RockTunnelB1F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, RockTunnel2TrainerHeader0
+	ld hl, RockTunnel2TrainerHeaders
 	ld de, RockTunnelB1F_ScriptPointers
 	ld a, [wRockTunnelB1FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -22,6 +22,8 @@ RockTunnelB1F_TextPointers:
 	dw RockTunnel2Text7
 	dw RockTunnel2Text8
 
+RockTunnel2TrainerHeaders:
+	def_trainers
 RockTunnel2TrainerHeader0:
 	trainer EVENT_BEAT_ROCK_TUNNEL_2_TRAINER_0, 4, RockTunnel2BattleText2, RockTunnel2EndBattleText2, RockTunnel2AfterBattleText2
 RockTunnel2TrainerHeader1:
@@ -37,7 +39,7 @@ RockTunnel2TrainerHeader5:
 RockTunnel2TrainerHeader6:
 	trainer EVENT_BEAT_ROCK_TUNNEL_2_TRAINER_6, 3, RockTunnel2BattleText8, RockTunnel2EndBattleText8, RockTunnel2AfterBattleText8
 RockTunnel2TrainerHeader7:
-	trainer EVENT_BEAT_ROCK_TUNNEL_2_TRAINER_7, 1, 3, RockTunnel2BattleText9, RockTunnel2EndBattleText9, RockTunnel2AfterBattleText9
+	trainer EVENT_BEAT_ROCK_TUNNEL_2_TRAINER_7, 3, RockTunnel2BattleText9, RockTunnel2EndBattleText9, RockTunnel2AfterBattleText9
 	db -1 ; end
 
 RockTunnel2Text1:

--- a/scripts/RocketHideoutB1F.asm
+++ b/scripts/RocketHideoutB1F.asm
@@ -1,7 +1,7 @@
 RocketHideoutB1F_Script:
 	call RocketHideout1Script_44be0
 	call EnableAutoTextBoxDrawing
-	ld hl, RocketHideout1TrainerHeader0
+	ld hl, RocketHideout1TrainerHeaders
 	ld de, RocketHideoutB1F_ScriptPointers
 	ld a, [wRocketHideoutB1FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -44,6 +44,8 @@ RocketHideoutB1F_TextPointers:
 	dw PickUpItemText
 	dw PickUpItemText
 
+RocketHideout1TrainerHeaders:
+	def_trainers
 RocketHideout1TrainerHeader0:
 	trainer EVENT_BEAT_ROCKET_HIDEOUT_1_TRAINER_0, 3, RocketHideout1BattleText2, RocketHideout1EndBattleText2, RocketHideout1AfterBattleTxt2
 RocketHideout1TrainerHeader1:

--- a/scripts/RocketHideoutB2F.asm
+++ b/scripts/RocketHideoutB2F.asm
@@ -1,6 +1,6 @@
 RocketHideoutB2F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, RocketHideout2TrainerHeader0
+	ld hl, RocketHideout2TrainerHeaders
 	ld de, RocketHideoutB2F_ScriptPointers
 	ld a, [wRocketHideoutB2FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -276,6 +276,8 @@ RocketHideoutB2F_TextPointers:
 	dw PickUpItemText
 	dw PickUpItemText
 
+RocketHideout2TrainerHeaders:
+	def_trainers
 RocketHideout2TrainerHeader0:
 	trainer EVENT_BEAT_ROCKET_HIDEOUT_2_TRAINER_0, 4, RocketHideout2BattleText2, RocketHideout2EndBattleText2, RocketHideout2AfterBattleTxt2
 	db -1 ; end

--- a/scripts/RocketHideoutB3F.asm
+++ b/scripts/RocketHideoutB3F.asm
@@ -1,6 +1,6 @@
 RocketHideoutB3F_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, RocketHideout3TrainerHeader0
+	ld hl, RocketHideout3TrainerHeaders
 	ld de, RocketHideoutB3F_ScriptPointers
 	ld a, [wRocketHideoutB3FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -130,6 +130,8 @@ RocketHideoutB3F_TextPointers:
 	dw PickUpItemText
 	dw PickUpItemText
 
+RocketHideout3TrainerHeaders:
+	def_trainers
 RocketHideout3TrainerHeader0:
 	trainer EVENT_BEAT_ROCKET_HIDEOUT_3_TRAINER_0, 2, RocketHideout3BattleText2, RocketHideout3EndBattleText2, RocketHideout3AfterBattleTxt2
 RocketHideout3TrainerHeader1:

--- a/scripts/RocketHideoutB4F.asm
+++ b/scripts/RocketHideoutB4F.asm
@@ -1,7 +1,7 @@
 RocketHideoutB4F_Script:
 	call RocketHideout4Script_45473
 	call EnableAutoTextBoxDrawing
-	ld hl, RocketHideout4TrainerHeader0
+	ld hl, RocketHideout4TrainerHeaders
 	ld de, RocketHideoutB4F_ScriptPointers
 	ld a, [wRocketHideoutB4FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -84,6 +84,8 @@ RocketHideoutB4F_TextPointers:
 	dw PickUpItemText
 	dw RocketHideout4Text10
 
+RocketHideout4TrainerHeaders:
+	def_trainers 2
 RocketHideout4TrainerHeader0:
 	trainer EVENT_BEAT_ROCKET_HIDEOUT_4_TRAINER_0, 0, RocketHideout4BattleText2, RocketHideout4EndBattleText2, RocketHideout4AfterBattleText2
 RocketHideout4TrainerHeader1:

--- a/scripts/Route10.asm
+++ b/scripts/Route10.asm
@@ -1,6 +1,6 @@
 Route10_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route10TrainerHeader0
+	ld hl, Route10TrainerHeaders
 	ld de, Route10_ScriptPointers
 	ld a, [wRoute10CurScript]
 	call ExecuteCurMapScriptInTable
@@ -24,6 +24,8 @@ Route10_TextPointers:
 	dw Route10Text9
 	dw Route10Text10
 
+Route10TrainerHeaders:
+	def_trainers
 Route10TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_10_TRAINER_0, 4, Route10BattleText1, Route10EndBattleText1, Route10AfterBattleText1
 Route10TrainerHeader1:

--- a/scripts/Route11.asm
+++ b/scripts/Route11.asm
@@ -1,6 +1,6 @@
 Route11_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route11TrainerHeader0
+	ld hl, Route11TrainerHeaders
 	ld de, Route11_ScriptPointers
 	ld a, [wRoute11CurScript]
 	call ExecuteCurMapScriptInTable
@@ -25,6 +25,8 @@ Route11_TextPointers:
 	dw Route11Text10
 	dw Route11Text11
 
+Route11TrainerHeaders:
+	def_trainers
 Route11TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_11_TRAINER_0, 3, Route11BattleText1, Route11EndBattleText1, Route11AfterBattleText1
 Route11TrainerHeader1:
@@ -40,11 +42,11 @@ Route11TrainerHeader5:
 Route11TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_11_TRAINER_6, 3, Route11BattleText7, Route11EndBattleText7, Route11AfterBattleText7
 Route11TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_11_TRAINER_7, 1, 4, Route11BattleText8, Route11EndBattleText8, Route11AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_11_TRAINER_7, 4, Route11BattleText8, Route11EndBattleText8, Route11AfterBattleText8
 Route11TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_11_TRAINER_8, 1, 3, Route11BattleText9, Route11EndBattleText9, Route11AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_11_TRAINER_8, 3, Route11BattleText9, Route11EndBattleText9, Route11AfterBattleText9
 Route11TrainerHeader9:
-	trainer EVENT_BEAT_ROUTE_11_TRAINER_9, 1, 4, Route11BattleText10, Route11EndBattleText10, Route11AfterBattleText10
+	trainer EVENT_BEAT_ROUTE_11_TRAINER_9, 4, Route11BattleText10, Route11EndBattleText10, Route11AfterBattleText10
 	db -1 ; end
 
 Route11Text1:

--- a/scripts/Route12.asm
+++ b/scripts/Route12.asm
@@ -1,6 +1,6 @@
 Route12_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route12TrainerHeader0
+	ld hl, Route12TrainerHeaders
 	ld de, Route12_ScriptPointers
 	ld a, [wRoute12CurScript]
 	call ExecuteCurMapScriptInTable
@@ -76,6 +76,8 @@ Route12_TextPointers:
 	dw Route12Text13
 	dw Route12Text14
 
+Route12TrainerHeaders:
+	def_trainers 2
 Route12TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_12_TRAINER_0, 4, Route12BattleText1, Route12EndBattleText1, Route12AfterBattleText1
 Route12TrainerHeader1:
@@ -89,7 +91,7 @@ Route12TrainerHeader4:
 Route12TrainerHeader5:
 	trainer EVENT_BEAT_ROUTE_12_TRAINER_5, 4, Route12BattleText6, Route12EndBattleText6, Route12AfterBattleText6
 Route12TrainerHeader6:
-	trainer EVENT_BEAT_ROUTE_12_TRAINER_6, 1, 1, Route12BattleText7, Route12EndBattleText7, Route12AfterBattleText7
+	trainer EVENT_BEAT_ROUTE_12_TRAINER_6, 1, Route12BattleText7, Route12EndBattleText7, Route12AfterBattleText7
 	db -1 ; end
 
 Route12Text1:

--- a/scripts/Route13.asm
+++ b/scripts/Route13.asm
@@ -1,6 +1,6 @@
 Route13_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route13TrainerHeader0
+	ld hl, Route13TrainerHeaders
 	ld de, Route13_ScriptPointers
 	ld a, [wRoute13CurScript]
 	call ExecuteCurMapScriptInTable
@@ -27,6 +27,8 @@ Route13_TextPointers:
 	dw Route13Text12
 	dw Route13Text13
 
+Route13TrainerHeaders:
+	def_trainers
 Route13TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_13_TRAINER_0, 2, Route13BattleText2, Route13EndBattleText2, Route13AfterBattleText2
 Route13TrainerHeader1:
@@ -42,11 +44,11 @@ Route13TrainerHeader5:
 Route13TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_13_TRAINER_6, 4, Route13BattleText8, Route13EndBattleText8, Route13AfterBattleText8
 Route13TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_13_TRAINER_7, 1, 2, Route13BattleText9, Route13EndBattleText9, Route13AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_13_TRAINER_7, 2, Route13BattleText9, Route13EndBattleText9, Route13AfterBattleText9
 Route13TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_13_TRAINER_8, 1, 2, Route13BattleText10, Route13EndBattleText10, Route13AfterBattleText10
+	trainer EVENT_BEAT_ROUTE_13_TRAINER_8, 2, Route13BattleText10, Route13EndBattleText10, Route13AfterBattleText10
 Route13TrainerHeader9:
-	trainer EVENT_BEAT_ROUTE_13_TRAINER_9, 1, 4, Route13BattleText11, Route13EndBattleText11, Route13AfterBattleText11
+	trainer EVENT_BEAT_ROUTE_13_TRAINER_9, 4, Route13BattleText11, Route13EndBattleText11, Route13AfterBattleText11
 	db -1 ; end
 
 Route13Text1:

--- a/scripts/Route14.asm
+++ b/scripts/Route14.asm
@@ -1,6 +1,6 @@
 Route14_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route14TrainerHeader0
+	ld hl, Route14TrainerHeaders
 	ld de, Route14_ScriptPointers
 	ld a, [wRoute14CurScript]
 	call ExecuteCurMapScriptInTable
@@ -25,6 +25,8 @@ Route14_TextPointers:
 	dw Route14Text10
 	dw Route14Text11
 
+Route14TrainerHeaders:
+	def_trainers
 Route14TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_14_TRAINER_0, 2, Route14BattleText1, Route14EndBattleText1, Route14AfterBattleText1
 Route14TrainerHeader1:
@@ -40,11 +42,11 @@ Route14TrainerHeader5:
 Route14TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_14_TRAINER_6, 4, Route14BattleText7, Route14EndBattleText7, Route14AfterBattleText7
 Route14TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_14_TRAINER_7, 1, 4, Route14BattleText8, Route14EndBattleText8, Route14AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_14_TRAINER_7, 4, Route14BattleText8, Route14EndBattleText8, Route14AfterBattleText8
 Route14TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_14_TRAINER_8, 1, 3, Route14BattleText9, Route14EndBattleText9, Route14AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_14_TRAINER_8, 3, Route14BattleText9, Route14EndBattleText9, Route14AfterBattleText9
 Route14TrainerHeader9:
-	trainer EVENT_BEAT_ROUTE_14_TRAINER_9, 1, 4, Route14BattleText10, Route14EndBattleText10, Route14AfterBattleText10
+	trainer EVENT_BEAT_ROUTE_14_TRAINER_9, 4, Route14BattleText10, Route14EndBattleText10, Route14AfterBattleText10
 	db -1 ; end
 
 Route14Text1:

--- a/scripts/Route15.asm
+++ b/scripts/Route15.asm
@@ -1,6 +1,6 @@
 Route15_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route15TrainerHeader0
+	ld hl, Route15TrainerHeaders
 	ld de, Route15_ScriptPointers
 	ld a, [wRoute15CurScript]
 	call ExecuteCurMapScriptInTable
@@ -26,6 +26,8 @@ Route15_TextPointers:
 	dw PickUpItemText
 	dw Route15Text12
 
+Route15TrainerHeaders:
+	def_trainers
 Route15TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_15_TRAINER_0, 2, Route15BattleText1, Route15EndBattleText1, Route15AfterBattleText1
 Route15TrainerHeader1:
@@ -41,11 +43,11 @@ Route15TrainerHeader5:
 Route15TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_15_TRAINER_6, 3, Route15BattleText7, Route15EndBattleText7, Route15AfterBattleText7
 Route15TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_15_TRAINER_7, 1, 3, Route15BattleText8, Route15EndBattleText8, Route15AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_15_TRAINER_7, 3, Route15BattleText8, Route15EndBattleText8, Route15AfterBattleText8
 Route15TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_15_TRAINER_8, 1, 3, Route15BattleText9, Route15EndBattleText9, Route15AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_15_TRAINER_8, 3, Route15BattleText9, Route15EndBattleText9, Route15AfterBattleText9
 Route15TrainerHeader9:
-	trainer EVENT_BEAT_ROUTE_15_TRAINER_9, 1, 3, Route15BattleText10, Route15EndBattleText10, Route15AfterBattleText10
+	trainer EVENT_BEAT_ROUTE_15_TRAINER_9, 3, Route15BattleText10, Route15EndBattleText10, Route15AfterBattleText10
 	db -1 ; end
 
 Route15Text1:

--- a/scripts/Route16.asm
+++ b/scripts/Route16.asm
@@ -1,6 +1,6 @@
 Route16_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route16TrainerHeader0
+	ld hl, Route16TrainerHeaders
 	ld de, Route16_ScriptPointers
 	ld a, [wRoute16CurScript]
 	call ExecuteCurMapScriptInTable
@@ -74,6 +74,8 @@ Route16_TextPointers:
 	dw Route16Text10
 	dw Route16Text11
 
+Route16TrainerHeaders:
+	def_trainers
 Route16TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_16_TRAINER_0, 3, Route16BattleText1, Route16EndBattleText1, Route16AfterBattleText1
 Route16TrainerHeader1:

--- a/scripts/Route17.asm
+++ b/scripts/Route17.asm
@@ -1,6 +1,6 @@
 Route17_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route17TrainerHeader0
+	ld hl, Route17TrainerHeaders
 	ld de, Route17_ScriptPointers
 	ld a, [wRoute17CurScript]
 	call ExecuteCurMapScriptInTable
@@ -30,6 +30,8 @@ Route17_TextPointers:
 	dw Route17Text15
 	dw Route17Text16
 
+Route17TrainerHeaders:
+	def_trainers
 Route17TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_17_TRAINER_0, 3, Route17BattleText1, Route17EndBattleText1, Route17AfterBattleText1
 Route17TrainerHeader1:
@@ -45,11 +47,11 @@ Route17TrainerHeader5:
 Route17TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_17_TRAINER_6, 4, Route17BattleText7, Route17EndBattleText7, Route17AfterBattleText7
 Route17TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_17_TRAINER_7, 1, 2, Route17BattleText8, Route17EndBattleText8, Route17AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_17_TRAINER_7, 2, Route17BattleText8, Route17EndBattleText8, Route17AfterBattleText8
 Route17TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_17_TRAINER_8, 1, 3, Route17BattleText9, Route17EndBattleText9, Route17AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_17_TRAINER_8, 3, Route17BattleText9, Route17EndBattleText9, Route17AfterBattleText9
 Route17TrainerHeader9:
-	trainer EVENT_BEAT_ROUTE_17_TRAINER_9, 1, 4, Route17BattleText10, Route17EndBattleText10, Route17AfterBattleText10
+	trainer EVENT_BEAT_ROUTE_17_TRAINER_9, 4, Route17BattleText10, Route17EndBattleText10, Route17AfterBattleText10
 	db -1 ; end
 
 Route17Text1:

--- a/scripts/Route18.asm
+++ b/scripts/Route18.asm
@@ -1,6 +1,6 @@
 Route18_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route18TrainerHeader0
+	ld hl, Route18TrainerHeaders
 	ld de, Route18_ScriptPointers
 	ld a, [wRoute18CurScript]
 	call ExecuteCurMapScriptInTable
@@ -19,6 +19,8 @@ Route18_TextPointers:
 	dw Route18Text4
 	dw Route18Text5
 
+Route18TrainerHeaders:
+	def_trainers
 Route18TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_18_TRAINER_0, 3, Route18BattleText1, Route18EndBattleText1, Route18AfterBattleText1
 Route18TrainerHeader1:

--- a/scripts/Route19.asm
+++ b/scripts/Route19.asm
@@ -1,6 +1,6 @@
 Route19_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route19TrainerHeader0
+	ld hl, Route19TrainerHeaders
 	ld de, Route19_ScriptPointers
 	ld a, [wRoute19CurScript]
 	call ExecuteCurMapScriptInTable
@@ -25,6 +25,8 @@ Route19_TextPointers:
 	dw Route19Text10
 	dw Route19Text11
 
+Route19TrainerHeaders:
+	def_trainers
 Route19TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_19_TRAINER_0, 4, Route19BattleText1, Route19EndBattleText1, Route19AfterBattleText1
 Route19TrainerHeader1:
@@ -40,11 +42,11 @@ Route19TrainerHeader5:
 Route19TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_19_TRAINER_6, 3, Route19BattleText7, Route19EndBattleText7, Route19AfterBattleText7
 Route19TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_19_TRAINER_7, 1, 4, Route19BattleText8, Route19EndBattleText8, Route19AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_19_TRAINER_7, 4, Route19BattleText8, Route19EndBattleText8, Route19AfterBattleText8
 Route19TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_19_TRAINER_8, 1, 4, Route19BattleText9, Route19EndBattleText9, Route19AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_19_TRAINER_8, 4, Route19BattleText9, Route19EndBattleText9, Route19AfterBattleText9
 Route19TrainerHeader9:
-	trainer EVENT_BEAT_ROUTE_19_TRAINER_9, 1, 4, Route19BattleText10, Route19EndBattleText10, Route19AfterBattleText10
+	trainer EVENT_BEAT_ROUTE_19_TRAINER_9, 4, Route19BattleText10, Route19EndBattleText10, Route19AfterBattleText10
 	db -1 ; end
 
 Route19Text1:

--- a/scripts/Route20.asm
+++ b/scripts/Route20.asm
@@ -2,7 +2,7 @@ Route20_Script:
 	CheckAndResetEvent EVENT_IN_SEAFOAM_ISLANDS
 	call nz, Route20Script_50cc6
 	call EnableAutoTextBoxDrawing
-	ld hl, Route20TrainerHeader0
+	ld hl, Route20TrainerHeaders
 	ld de, Route20_ScriptPointers
 	ld a, [wRoute20CurScript]
 	call ExecuteCurMapScriptInTable
@@ -75,6 +75,8 @@ Route20_TextPointers:
 	dw Route20Text11
 	dw Route20Text12
 
+Route20TrainerHeaders:
+	def_trainers
 Route20TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_20_TRAINER_0, 4, Route20BattleText1, Route20EndBattleText1, Route20AfterBattleText1
 Route20TrainerHeader1:
@@ -90,11 +92,11 @@ Route20TrainerHeader5:
 Route20TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_20_TRAINER_6, 2, Route20BattleText7, Route20EndBattleText7, Route20AfterBattleText7
 Route20TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_20_TRAINER_7, 1, 4, Route20BattleText8, Route20EndBattleText8, Route20AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_20_TRAINER_7, 4, Route20BattleText8, Route20EndBattleText8, Route20AfterBattleText8
 Route20TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_20_TRAINER_8, 1, 3, Route20BattleText9, Route20EndBattleText9, Route20AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_20_TRAINER_8, 3, Route20BattleText9, Route20EndBattleText9, Route20AfterBattleText9
 Route20TrainerHeader9:
-	trainer EVENT_BEAT_ROUTE_20_TRAINER_9, 1, 4, Route20BattleText10, Route20EndBattleText10, Route20AfterBattleText10
+	trainer EVENT_BEAT_ROUTE_20_TRAINER_9, 4, Route20BattleText10, Route20EndBattleText10, Route20AfterBattleText10
 	db -1 ; end
 
 Route20Text1:

--- a/scripts/Route21.asm
+++ b/scripts/Route21.asm
@@ -1,6 +1,6 @@
 Route21_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route21TrainerHeader0
+	ld hl, Route21TrainerHeaders
 	ld de, Route21_ScriptPointers
 	ld a, [wRoute21CurScript]
 	call ExecuteCurMapScriptInTable
@@ -23,6 +23,8 @@ Route21_TextPointers:
 	dw Route21Text8
 	dw Route21Text9
 
+Route21TrainerHeaders:
+	def_trainers
 Route21TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_21_TRAINER_0, 0, Route21BattleText1, Route21EndBattleText1, Route21AfterBattleText1
 Route21TrainerHeader1:
@@ -38,9 +40,9 @@ Route21TrainerHeader5:
 Route21TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_21_TRAINER_6, 3, Route21BattleText7, Route21EndBattleText7, Route21AfterBattleText7
 Route21TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_21_TRAINER_7, 1, 0, Route21BattleText8, Route21EndBattleText8, Route21AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_21_TRAINER_7, 0, Route21BattleText8, Route21EndBattleText8, Route21AfterBattleText8
 Route21TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_21_TRAINER_8, 1, 0, Route21BattleText9, Route21EndBattleText9, Route21AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_21_TRAINER_8, 0, Route21BattleText9, Route21EndBattleText9, Route21AfterBattleText9
 	db -1 ; end
 
 Route21Text1:

--- a/scripts/Route24.asm
+++ b/scripts/Route24.asm
@@ -1,6 +1,6 @@
 Route24_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route24TrainerHeader0
+	ld hl, Route24TrainerHeaders
 	ld de, Route24_ScriptPointers
 	ld a, [wRoute24CurScript]
 	call ExecuteCurMapScriptInTable
@@ -86,6 +86,8 @@ Route24_TextPointers:
 	dw Route24Text7
 	dw PickUpItemText
 
+Route24TrainerHeaders:
+	def_trainers 2
 Route24TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_24_TRAINER_0, 4, Route24BattleText1, Route24EndBattleText1, Route24AfterBattleText1
 Route24TrainerHeader1:

--- a/scripts/Route25.asm
+++ b/scripts/Route25.asm
@@ -1,7 +1,7 @@
 Route25_Script:
 	call Route25Script_515e1
 	call EnableAutoTextBoxDrawing
-	ld hl, Route25TrainerHeader0
+	ld hl, Route25TrainerHeaders
 	ld de, Route25_ScriptPointers
 	ld a, [wRoute25CurScript]
 	call ExecuteCurMapScriptInTable
@@ -53,6 +53,8 @@ Route25_TextPointers:
 	dw PickUpItemText
 	dw Route25Text11
 
+Route25TrainerHeaders:
+	def_trainers
 Route25TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_25_TRAINER_0, 2, Route25BattleText1, Route25EndBattleText1, Route25AfterBattleText1
 Route25TrainerHeader1:
@@ -68,9 +70,9 @@ Route25TrainerHeader5:
 Route25TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_25_TRAINER_6, 3, Route25BattleText7, Route25EndBattleText7, Route25AfterBattleText7
 Route25TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_25_TRAINER_7, 1, 2, Route25BattleText8, Route25EndBattleText8, Route25AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_25_TRAINER_7, 2, Route25BattleText8, Route25EndBattleText8, Route25AfterBattleText8
 Route25TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_25_TRAINER_8, 1, 2, Route25BattleText9, Route25EndBattleText9, Route25AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_25_TRAINER_8, 2, Route25BattleText9, Route25EndBattleText9, Route25AfterBattleText9
 	db -1 ; end
 
 Route25Text1:

--- a/scripts/Route3.asm
+++ b/scripts/Route3.asm
@@ -1,6 +1,6 @@
 Route3_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route3TrainerHeader0
+	ld hl, Route3TrainerHeaders
 	ld de, Route3_ScriptPointers
 	ld a, [wRoute3CurScript]
 	call ExecuteCurMapScriptInTable
@@ -24,6 +24,8 @@ Route3_TextPointers:
 	dw Route3Text9
 	dw Route3Text10
 
+Route3TrainerHeaders:
+	def_trainers 2
 Route3TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_3_TRAINER_0, 2, Route3BattleText1, Route3EndBattleText1, Route3AfterBattleText1
 Route3TrainerHeader1:
@@ -37,9 +39,9 @@ Route3TrainerHeader4:
 Route3TrainerHeader5:
 	trainer EVENT_BEAT_ROUTE_3_TRAINER_5, 3, Route3BattleText6, Route3EndBattleText6, Route3AfterBattleText6
 Route3TrainerHeader6:
-	trainer EVENT_BEAT_ROUTE_3_TRAINER_6, 1, 3, Route3BattleText7, Route3EndBattleText7, Route3AfterBattleText7
+	trainer EVENT_BEAT_ROUTE_3_TRAINER_6, 3, Route3BattleText7, Route3EndBattleText7, Route3AfterBattleText7
 Route3TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_3_TRAINER_7, 1, 2, Route3BattleText8, Route3EndBattleText8, Route3AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_3_TRAINER_7, 2, Route3BattleText8, Route3EndBattleText8, Route3AfterBattleText8
 	db -1 ; end
 
 Route3Text1:

--- a/scripts/Route4.asm
+++ b/scripts/Route4.asm
@@ -1,6 +1,6 @@
 Route4_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route4TrainerHeader0
+	ld hl, Route4TrainerHeaders
 	ld de, Route4_ScriptPointers
 	ld a, [wRoute4CurScript]
 	call ExecuteCurMapScriptInTable
@@ -20,6 +20,8 @@ Route4_TextPointers:
 	dw Route4Text5
 	dw Route4Text6
 
+Route4TrainerHeaders:
+	def_trainers 2
 Route4TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_4_TRAINER_0, 3, Route4BattleText1, Route4EndBattleText1, Route4AfterBattleText1
 	db -1 ; end

--- a/scripts/Route6.asm
+++ b/scripts/Route6.asm
@@ -1,6 +1,6 @@
 Route6_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route6TrainerHeader0
+	ld hl, Route6TrainerHeaders
 	ld de, Route6_ScriptPointers
 	ld a, [wRoute6CurScript]
 	call ExecuteCurMapScriptInTable
@@ -21,6 +21,8 @@ Route6_TextPointers:
 	dw Route6Text6
 	dw Route6Text7
 
+Route6TrainerHeaders:
+	def_trainers
 Route6TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_6_TRAINER_0, 0, Route6BattleText1, Route6EndBattleText1, Route6AfterBattleText1
 Route6TrainerHeader1:

--- a/scripts/Route8.asm
+++ b/scripts/Route8.asm
@@ -1,6 +1,6 @@
 Route8_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route8TrainerHeader0
+	ld hl, Route8TrainerHeaders
 	ld de, Route8_ScriptPointers
 	ld a, [wRoute8CurScript]
 	call ExecuteCurMapScriptInTable
@@ -24,6 +24,8 @@ Route8_TextPointers:
 	dw Route8Text9
 	dw Route8Text10
 
+Route8TrainerHeaders:
+	def_trainers
 Route8TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_8_TRAINER_0, 4, Route8BattleText1, Route8EndBattleText1, Route8AfterBattleText1
 Route8TrainerHeader1:
@@ -39,9 +41,9 @@ Route8TrainerHeader5:
 Route8TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_8_TRAINER_6, 2, Route8BattleText7, Route8EndBattleText7, Route8AfterBattleText7
 Route8TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_8_TRAINER_7, 1, 2, Route8BattleText8, Route8EndBattleText8, Route8AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_8_TRAINER_7, 2, Route8BattleText8, Route8EndBattleText8, Route8AfterBattleText8
 Route8TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_8_TRAINER_8, 1, 4, Route8BattleText9, Route8EndBattleText9, Route8AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_8_TRAINER_8, 4, Route8BattleText9, Route8EndBattleText9, Route8AfterBattleText9
 	db -1 ; end
 
 Route8Text1:

--- a/scripts/Route9.asm
+++ b/scripts/Route9.asm
@@ -1,6 +1,6 @@
 Route9_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, Route9TrainerHeader0
+	ld hl, Route9TrainerHeaders
 	ld de, Route9_ScriptPointers
 	ld a, [wRoute9CurScript]
 	call ExecuteCurMapScriptInTable
@@ -25,6 +25,8 @@ Route9_TextPointers:
 	dw PickUpItemText
 	dw Route9Text11
 
+Route9TrainerHeaders:
+	def_trainers
 Route9TrainerHeader0:
 	trainer EVENT_BEAT_ROUTE_9_TRAINER_0, 3, Route9BattleText1, Route9EndBattleText1, Route9AfterBattleText1
 Route9TrainerHeader1:
@@ -40,9 +42,9 @@ Route9TrainerHeader5:
 Route9TrainerHeader6:
 	trainer EVENT_BEAT_ROUTE_9_TRAINER_6, 4, Route9BattleText7, Route9EndBattleText7, Route9AfterBattleText7
 Route9TrainerHeader7:
-	trainer EVENT_BEAT_ROUTE_9_TRAINER_7, 1, 2, Route9BattleText8, Route9EndBattleText8, Route9AfterBattleText8
+	trainer EVENT_BEAT_ROUTE_9_TRAINER_7, 2, Route9BattleText8, Route9EndBattleText8, Route9AfterBattleText8
 Route9TrainerHeader8:
-	trainer EVENT_BEAT_ROUTE_9_TRAINER_8, 1, 2, Route9BattleText9, Route9EndBattleText9, Route9AfterBattleText9
+	trainer EVENT_BEAT_ROUTE_9_TRAINER_8, 2, Route9BattleText9, Route9EndBattleText9, Route9AfterBattleText9
 	db -1 ; end
 
 Route9Text1:

--- a/scripts/SSAnne1FRooms.asm
+++ b/scripts/SSAnne1FRooms.asm
@@ -1,6 +1,6 @@
 SSAnne1FRooms_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, SSAnne8TrainerHeader0
+	ld hl, SSAnne8TrainerHeaders
 	ld de, SSAnne1FRooms_ScriptPointers
 	ld a, [wSSAnne1FRoomsCurScript]
 	call ExecuteCurMapScriptInTable
@@ -25,6 +25,8 @@ SSAnne1FRooms_TextPointers:
 	dw PickUpItemText
 	dw SSAnne8Text11
 
+SSAnne8TrainerHeaders:
+	def_trainers
 SSAnne8TrainerHeader0:
 	trainer EVENT_BEAT_SS_ANNE_8_TRAINER_0, 2, SSAnne8BattleText1, SSAnne8EndBattleText1, SSAnne8AfterBattleText1
 SSAnne8TrainerHeader1:

--- a/scripts/SSAnne2FRooms.asm
+++ b/scripts/SSAnne2FRooms.asm
@@ -3,7 +3,7 @@ SSAnne2FRooms_Script:
 	ld [wAutoTextBoxDrawingControl], a
 	xor a
 	ld [wDoNotWaitForButtonPressAfterDisplayingText], a
-	ld hl, SSAnne9TrainerHeader0
+	ld hl, SSAnne9TrainerHeaders
 	ld de, SSAnne2FRooms_ScriptPointers
 	ld a, [wSSAnne2FRoomsCurScript]
 	call ExecuteCurMapScriptInTable
@@ -30,6 +30,8 @@ SSAnne2FRooms_TextPointers:
 	dw SSAnne9Text12
 	dw SSAnne9Text13
 
+SSAnne9TrainerHeaders:
+	def_trainers
 SSAnne9TrainerHeader0:
 	trainer EVENT_BEAT_SS_ANNE_9_TRAINER_0, 2, SSAnne9BattleText1, SSAnne9EndBattleText1, SSAnne9AfterBattleText1
 SSAnne9TrainerHeader1:

--- a/scripts/SSAnneB1FRooms.asm
+++ b/scripts/SSAnneB1FRooms.asm
@@ -1,6 +1,6 @@
 SSAnneB1FRooms_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, SSAnne10TrainerHeader0
+	ld hl, SSAnne10TrainerHeaders
 	ld de, SSAnneB1FRooms_ScriptPointers
 	ld a, [wSSAnneB1FRoomsCurScript]
 	call ExecuteCurMapScriptInTable
@@ -25,6 +25,8 @@ SSAnneB1FRooms_TextPointers:
 	dw PickUpItemText
 	dw PickUpItemText
 
+SSAnne10TrainerHeaders:
+	def_trainers
 SSAnne10TrainerHeader0:
 	trainer EVENT_BEAT_SS_ANNE_10_TRAINER_0, 2, SSAnne10BattleText1, SSAnne10EndBattleText1, SSAnne10AfterBattleText1
 SSAnne10TrainerHeader1:

--- a/scripts/SSAnneBow.asm
+++ b/scripts/SSAnneBow.asm
@@ -1,6 +1,6 @@
 SSAnneBow_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, SSAnne5TrainerHeader0
+	ld hl, SSAnne5TrainerHeaders
 	ld de, SSAnneBow_ScriptPointers
 	ld a, [wSSAnneBowCurScript]
 	call ExecuteCurMapScriptInTable
@@ -19,6 +19,8 @@ SSAnneBow_TextPointers:
 	dw SSAnne5Text4
 	dw SSAnne5Text5
 
+SSAnne5TrainerHeaders:
+	def_trainers 4
 SSAnne5TrainerHeader0:
 	trainer EVENT_BEAT_SS_ANNE_5_TRAINER_0, 3, SSAnne5BattleText1, SSAnne5EndBattleText1, SSAnne5AfterBattleText1
 SSAnne5TrainerHeader1:

--- a/scripts/SaffronGym.asm
+++ b/scripts/SaffronGym.asm
@@ -4,7 +4,7 @@ SaffronGym_Script:
 	res 6, [hl]
 	call nz, .LoadNames
 	call EnableAutoTextBoxDrawing
-	ld hl, SaffronGymTrainerHeader0
+	ld hl, SaffronGymTrainerHeaders
 	ld de, SaffronGym_ScriptPointers
 	ld a, [wSaffronGymCurScript]
 	call ExecuteCurMapScriptInTable
@@ -84,6 +84,8 @@ SaffronGym_TextPointers:
 	dw SaffronGymText11
 	dw SaffronGymText12
 
+SaffronGymTrainerHeaders:
+	def_trainers 2
 SaffronGymTrainerHeader0:
 	trainer EVENT_BEAT_SAFFRON_GYM_TRAINER_0, 3, SaffronGymBattleText1, SaffronGymEndBattleText1, SaffronGymAfterBattleText1
 SaffronGymTrainerHeader1:
@@ -97,7 +99,7 @@ SaffronGymTrainerHeader4:
 SaffronGymTrainerHeader5:
 	trainer EVENT_BEAT_SAFFRON_GYM_TRAINER_5, 3, SaffronGymBattleText6, SaffronGymEndBattleText6, SaffronGymAfterBattleText6
 SaffronGymTrainerHeader6:
-	trainer EVENT_BEAT_SAFFRON_GYM_TRAINER_6, 1, 3, SaffronGymBattleText7, SaffronGymEndBattleText7, SaffronGymAfterBattleText7
+	trainer EVENT_BEAT_SAFFRON_GYM_TRAINER_6, 3, SaffronGymBattleText7, SaffronGymEndBattleText7, SaffronGymAfterBattleText7
 	db -1 ; end
 
 SaffronGymText1:

--- a/scripts/SeafoamIslandsB4F.asm
+++ b/scripts/SeafoamIslandsB4F.asm
@@ -137,6 +137,10 @@ SeafoamIslandsB4F_TextPointers:
 	dw SeafoamIslands5Text4
 	dw SeafoamIslands5Text5
 
+; Articuno is object 3, but its event flag is bit 2.
+; This is not a problem because its sight range is 0, and
+; trainer headers were not stored by ExecuteCurMapScriptInTable.
+	def_trainers 2
 ArticunoTrainerHeader:
 	trainer EVENT_BEAT_ARTICUNO, 0, ArticunoBattleText, ArticunoBattleText, ArticunoBattleText
 	db -1 ; end

--- a/scripts/SilphCo10F.asm
+++ b/scripts/SilphCo10F.asm
@@ -1,7 +1,7 @@
 SilphCo10F_Script:
 	call SilphCo10Script_5a14f
 	call EnableAutoTextBoxDrawing
-	ld hl, SilphCo10TrainerHeader0
+	ld hl, SilphCo10TrainerHeaders
 	ld de, SilphCo10F_ScriptPointers
 	ld a, [wSilphCo10FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -47,6 +47,8 @@ SilphCo10F_TextPointers:
 	dw PickUpItemText
 	dw PickUpItemText
 
+SilphCo10TrainerHeaders:
+	def_trainers
 SilphCo10TrainerHeader0:
 	trainer EVENT_BEAT_SILPH_CO_10F_TRAINER_0, 3, SilphCo10BattleText1, SilphCo10EndBattleText1, SilphCo10AfterBattleText1
 SilphCo10TrainerHeader1:

--- a/scripts/SilphCo11F.asm
+++ b/scripts/SilphCo11F.asm
@@ -1,7 +1,7 @@
 SilphCo11F_Script:
 	call SilphCo11Script_62110
 	call EnableAutoTextBoxDrawing
-	ld hl, SilphCo11TrainerHeader0
+	ld hl, SilphCo11TrainerHeaders
 	ld de, SilphCo11F_ScriptPointers
 	ld a, [wSilphCo11FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -280,6 +280,8 @@ SilphCo11F_TextPointers:
 	dw SilphCo11Text5
 	dw SilphCo11Text6
 
+SilphCo11TrainerHeaders:
+	def_trainers 4
 SilphCo11TrainerHeader0:
 	trainer EVENT_BEAT_SILPH_CO_11F_TRAINER_0, 4, SilphCo11BattleText1, SilphCo11EndBattleText1, SilphCo11AfterBattleText1
 SilphCo11TrainerHeader1:

--- a/scripts/SilphCo2F.asm
+++ b/scripts/SilphCo2F.asm
@@ -1,7 +1,7 @@
 SilphCo2F_Script:
 	call SilphCo2Script_59d07
 	call EnableAutoTextBoxDrawing
-	ld hl, SilphCo2TrainerHeader0
+	ld hl, SilphCo2TrainerHeaders
 	ld de, SilphCo2F_ScriptPointers
 	ld a, [wSilphCo2FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -98,6 +98,8 @@ SilphCo2F_TextPointers:
 	dw SilphCo2Text4
 	dw SilphCo2Text5
 
+SilphCo2TrainerHeaders:
+	def_trainers 2
 SilphCo2TrainerHeader0:
 	trainer EVENT_BEAT_SILPH_CO_2F_TRAINER_0, 3, SilphCo2BattleText1, SilphCo2EndBattleText1, SilphCo2AfterBattleText1
 SilphCo2TrainerHeader1:

--- a/scripts/SilphCo3F.asm
+++ b/scripts/SilphCo3F.asm
@@ -1,7 +1,7 @@
 SilphCo3F_Script:
 	call SilphCo3Script_59f71
 	call EnableAutoTextBoxDrawing
-	ld hl, SilphCo3TrainerHeader0
+	ld hl, SilphCo3TrainerHeaders
 	ld de, SilphCo3F_ScriptPointers
 	ld a, [wSilphCo3FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -61,6 +61,8 @@ SilphCo3F_TextPointers:
 	dw SilphCo3Text3
 	dw PickUpItemText
 
+SilphCo3TrainerHeaders:
+	def_trainers 2
 SilphCo3TrainerHeader0:
 	trainer EVENT_BEAT_SILPH_CO_3F_TRAINER_0, 2, SilphCo3BattleText1, SilphCo3EndBattleText1, SilphCo3AfterBattleText1
 SilphCo3TrainerHeader1:

--- a/scripts/SilphCo4F.asm
+++ b/scripts/SilphCo4F.asm
@@ -1,7 +1,7 @@
 SilphCo4F_Script:
 	call SilphCo4Script_19d21
 	call EnableAutoTextBoxDrawing
-	ld hl, SilphCo4TrainerHeader0
+	ld hl, SilphCo4TrainerHeaders
 	ld de, SilphCo4F_ScriptPointers
 	ld a, [wSilphCo4FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -100,6 +100,8 @@ SilphCo4F_TextPointers:
 	dw PickUpItemText
 	dw PickUpItemText
 
+SilphCo4TrainerHeaders:
+	def_trainers 2
 SilphCo4TrainerHeader0:
 	trainer EVENT_BEAT_SILPH_CO_4F_TRAINER_0, 4, SilphCo4BattleText2, SilphCo4EndBattleText2, SilphCo4AfterBattleText2
 SilphCo4TrainerHeader1:

--- a/scripts/SilphCo5F.asm
+++ b/scripts/SilphCo5F.asm
@@ -1,7 +1,7 @@
 SilphCo5F_Script:
 	call SilphCo5Script_19f4d
 	call EnableAutoTextBoxDrawing
-	ld hl, SilphCo5TrainerHeader0
+	ld hl, SilphCo5TrainerHeaders
 	ld de, SilphCo5F_ScriptPointers
 	ld a, [wSilphCo5FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -83,6 +83,8 @@ SilphCo5F_TextPointers:
 	dw SilphCo5Text10
 	dw SilphCo5Text11
 
+SilphCo5TrainerHeaders:
+	def_trainers 2
 SilphCo5TrainerHeader0:
 	trainer EVENT_BEAT_SILPH_CO_5F_TRAINER_0, 1, SilphCo5BattleText2, SilphCo5EndBattleText2, SilphCo5AfterBattleText2
 SilphCo5TrainerHeader1:

--- a/scripts/SilphCo6F.asm
+++ b/scripts/SilphCo6F.asm
@@ -1,7 +1,7 @@
 SilphCo6F_Script:
 	call SilphCo6Script_1a1bf
 	call EnableAutoTextBoxDrawing
-	ld hl, SilphCo6TrainerHeader0
+	ld hl, SilphCo6TrainerHeaders
 	ld de, SilphCo6F_ScriptPointers
 	ld a, [wSilphCo6FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -51,12 +51,14 @@ SilphCo6F_TextPointers:
 	dw PickUpItemText
 	dw PickUpItemText
 
+SilphCo6TrainerHeaders:
+	def_trainers 6
 SilphCo6TrainerHeader0:
 	trainer EVENT_BEAT_SILPH_CO_6F_TRAINER_0, 2, SilphCo6BattleText2, SilphCo6EndBattleText2, SilphCo6AfterBattleText2
 SilphCo6TrainerHeader1:
 	trainer EVENT_BEAT_SILPH_CO_6F_TRAINER_1, 3, SilphCo6BattleText3, SilphCo6EndBattleText3, SilphCo6AfterBattleText3
 SilphCo6TrainerHeader2:
-	trainer EVENT_BEAT_SILPH_CO_6F_TRAINER_2, 1, 2, SilphCo6BattleText4, SilphCo6EndBattleText4, SilphCo6AfterBattleText4
+	trainer EVENT_BEAT_SILPH_CO_6F_TRAINER_2, 2, SilphCo6BattleText4, SilphCo6EndBattleText4, SilphCo6AfterBattleText4
 	db -1 ; end
 
 SilphCo6Script_1a22f:

--- a/scripts/SilphCo7F.asm
+++ b/scripts/SilphCo7F.asm
@@ -1,7 +1,7 @@
 SilphCo7F_Script:
 	call SilphCo7Script_51b77
 	call EnableAutoTextBoxDrawing
-	ld hl, SilphCo7TrainerHeader0
+	ld hl, SilphCo7TrainerHeaders
 	ld de, SilphCo7F_ScriptPointers
 	ld a, [wSilphCo7FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -279,6 +279,8 @@ SilphCo7F_TextPointers:
 	dw SilphCo7Text14
 	dw SilphCo7Text15
 
+SilphCo7TrainerHeaders:
+	def_trainers 5
 SilphCo7TrainerHeader0:
 	trainer EVENT_BEAT_SILPH_CO_7F_TRAINER_0, 2, SilphCo7BattleText1, SilphCo7EndBattleText1, SilphCo7AfterBattleText1
 SilphCo7TrainerHeader1:
@@ -286,7 +288,7 @@ SilphCo7TrainerHeader1:
 SilphCo7TrainerHeader2:
 	trainer EVENT_BEAT_SILPH_CO_7F_TRAINER_2, 3, SilphCo7BattleText3, SilphCo7EndBattleText3, SilphCo7AfterBattleText3
 SilphCo7TrainerHeader3:
-	trainer EVENT_BEAT_SILPH_CO_7F_TRAINER_3, 1, 4, SilphCo7BattleText4, SilphCo7EndBattleText4, SilphCo7AfterBattleText4
+	trainer EVENT_BEAT_SILPH_CO_7F_TRAINER_3, 4, SilphCo7BattleText4, SilphCo7EndBattleText4, SilphCo7AfterBattleText4
 	db -1 ; end
 
 SilphCo7Text1:

--- a/scripts/SilphCo8F.asm
+++ b/scripts/SilphCo8F.asm
@@ -1,7 +1,7 @@
 SilphCo8F_Script:
 	call SilphCo8Script_5651a
 	call EnableAutoTextBoxDrawing
-	ld hl, SilphCo8TrainerHeader0
+	ld hl, SilphCo8TrainerHeaders
 	ld de, SilphCo8F_ScriptPointers
 	ld a, [wSilphCo8FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -81,6 +81,8 @@ SilphCo8F_TextPointers:
 	dw SilphCo8Text3
 	dw SilphCo8Text4
 
+SilphCo8TrainerHeaders:
+	def_trainers 2
 SilphCo8TrainerHeader0:
 	trainer EVENT_BEAT_SILPH_CO_8F_TRAINER_0, 4, SilphCo8BattleText1, SilphCo8EndBattleText1, SilphCo8AfterBattleText1
 SilphCo8TrainerHeader1:

--- a/scripts/SilphCo9F.asm
+++ b/scripts/SilphCo9F.asm
@@ -1,7 +1,7 @@
 SilphCo9F_Script:
 	call SilphCo9Script_5d7d1
 	call EnableAutoTextBoxDrawing
-	ld hl, SilphCo9TrainerHeader0
+	ld hl, SilphCo9TrainerHeaders
 	ld de, SilphCo9F_ScriptPointers
 	ld a, [wSilphCo9FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -129,6 +129,8 @@ SilphCo9F_TextPointers:
 	dw SilphCo9Text3
 	dw SilphCo9Text4
 
+SilphCo9TrainerHeaders:
+	def_trainers 2
 SilphCo9TrainerHeader0:
 	trainer EVENT_BEAT_SILPH_CO_9F_TRAINER_0, 4, SilphCo9BattleText1, SilphCo9EndBattleText1, SilphCo9AfterBattleText1
 SilphCo9TrainerHeader1:

--- a/scripts/VermilionGym.asm
+++ b/scripts/VermilionGym.asm
@@ -9,7 +9,7 @@ VermilionGym_Script:
 	res 6, [hl]
 	call nz, VermilionGymSetDoorTile
 	call EnableAutoTextBoxDrawing
-	ld hl, VermilionGymTrainerHeader0
+	ld hl, VermilionGymTrainerHeaders
 	ld de, VermilionGym_ScriptPointers
 	ld a, [wVermilionGymCurScript]
 	call ExecuteCurMapScriptInTable
@@ -99,6 +99,8 @@ VermilionGym_TextPointers:
 	dw ReceivedTM24Text
 	dw TM24NoRoomText
 
+VermilionGymTrainerHeaders:
+	def_trainers 2
 VermilionGymTrainerHeader0:
 	trainer EVENT_BEAT_VERMILION_GYM_TRAINER_0, 3, VermilionGymBattleText1, VermilionGymEndBattleText1, VermilionGymAfterBattleText1
 VermilionGymTrainerHeader1:

--- a/scripts/VictoryRoad1F.asm
+++ b/scripts/VictoryRoad1F.asm
@@ -4,7 +4,7 @@ VictoryRoad1F_Script:
 	res 5, [hl]
 	call nz, .next
 	call EnableAutoTextBoxDrawing
-	ld hl, VictoryRoad1TrainerHeader0
+	ld hl, VictoryRoad1TrainerHeaders
 	ld de, VictoryRoad1F_ScriptPointers
 	ld a, [wVictoryRoad1FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -47,6 +47,8 @@ VictoryRoad1F_TextPointers:
 	dw BoulderText
 	dw BoulderText
 
+VictoryRoad1TrainerHeaders:
+	def_trainers
 VictoryRoad1TrainerHeader0:
 	trainer EVENT_BEAT_VICTORY_ROAD_1_TRAINER_0, 2, VictoryRoad1BattleText1, VictoryRoad1EndBattleText1, VictoryRoad1AfterBattleText1
 VictoryRoad1TrainerHeader1:

--- a/scripts/VictoryRoad2F.asm
+++ b/scripts/VictoryRoad2F.asm
@@ -8,7 +8,7 @@ VictoryRoad2F_Script:
 	res 5, [hl]
 	call nz, VictoryRoad2Script_517c9
 	call EnableAutoTextBoxDrawing
-	ld hl, VictoryRoad2TrainerHeader0
+	ld hl, VictoryRoad2TrainerHeaders
 	ld de, VictoryRoad2F_ScriptPointers
 	ld a, [wVictoryRoad2FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -81,6 +81,8 @@ VictoryRoad2F_TextPointers:
 	dw BoulderText
 	dw BoulderText
 
+VictoryRoad2TrainerHeaders:
+	def_trainers
 VictoryRoad2TrainerHeader0:
 	trainer EVENT_BEAT_VICTORY_ROAD_2_TRAINER_0, 4, VictoryRoad2BattleText1, VictoryRoad2EndBattleText1, VictoryRoad2AfterBattleText1
 VictoryRoad2TrainerHeader1:

--- a/scripts/VictoryRoad3F.asm
+++ b/scripts/VictoryRoad3F.asm
@@ -1,7 +1,7 @@
 VictoryRoad3F_Script:
 	call VictoryRoad3Script_44996
 	call EnableAutoTextBoxDrawing
-	ld hl, VictoryRoad3TrainerHeader0
+	ld hl, VictoryRoad3TrainerHeaders
 	ld de, VictoryRoad3F_ScriptPointers
 	ld a, [wVictoryRoad3FCurScript]
 	call ExecuteCurMapScriptInTable
@@ -86,6 +86,8 @@ VictoryRoad3F_TextPointers:
 	dw BoulderText
 	dw BoulderText
 
+VictoryRoad3TrainerHeaders:
+	def_trainers
 VictoryRoad3TrainerHeader0:
 	trainer EVENT_BEAT_VICTORY_ROAD_3_TRAINER_0, 1, VictoryRoad3BattleText2, VictoryRoad3EndBattleText2, VictoryRoad3AfterBattleText2
 VictoryRoad3TrainerHeader1:

--- a/scripts/ViridianForest.asm
+++ b/scripts/ViridianForest.asm
@@ -1,6 +1,6 @@
 ViridianForest_Script:
 	call EnableAutoTextBoxDrawing
-	ld hl, ViridianForestTrainerHeader0
+	ld hl, ViridianForestTrainerHeaders
 	ld de, ViridianForest_ScriptPointers
 	ld a, [wViridianForestCurScript]
 	call ExecuteCurMapScriptInTable
@@ -28,6 +28,8 @@ ViridianForest_TextPointers:
 	dw ViridianForestText13
 	dw ViridianForestText14
 
+ViridianForestTrainerHeaders:
+	def_trainers 2
 ViridianForestTrainerHeader0:
 	trainer EVENT_BEAT_VIRIDIAN_FOREST_TRAINER_0, 4, ViridianForestBattleText1, ViridianForestEndBattleText1, ViridianForestAfterBattleText1
 ViridianForestTrainerHeader1:

--- a/scripts/ViridianGym.asm
+++ b/scripts/ViridianGym.asm
@@ -3,7 +3,7 @@ ViridianGym_Script:
 	ld de, .LeaderName
 	call LoadGymLeaderAndCityName
 	call EnableAutoTextBoxDrawing
-	ld hl, ViridianGymTrainerHeader0
+	ld hl, ViridianGymTrainerHeaders
 	ld de, ViridianGym_ScriptPointers
 	ld a, [wViridianGymCurScript]
 	call ExecuteCurMapScriptInTable
@@ -181,6 +181,8 @@ ViridianGym_TextPointers:
 	dw ViridianGymText13
 	dw ViridianGymText14
 
+ViridianGymTrainerHeaders:
+	def_trainers 2
 ViridianGymTrainerHeader0:
 	trainer EVENT_BEAT_VIRIDIAN_GYM_TRAINER_0, 4, ViridianGymBattleText1, ViridianGymEndBattleText1, ViridianGymAfterBattleText1
 ViridianGymTrainerHeader1:
@@ -194,9 +196,9 @@ ViridianGymTrainerHeader4:
 ViridianGymTrainerHeader5:
 	trainer EVENT_BEAT_VIRIDIAN_GYM_TRAINER_5, 4, ViridianGymBattleText6, ViridianGymEndBattleText6, ViridianGymAfterBattleText6
 ViridianGymTrainerHeader6:
-	trainer EVENT_BEAT_VIRIDIAN_GYM_TRAINER_6, 1, 3, ViridianGymBattleText7, ViridianGymEndBattleText7, ViridianGymAfterBattleText7
+	trainer EVENT_BEAT_VIRIDIAN_GYM_TRAINER_6, 3, ViridianGymBattleText7, ViridianGymEndBattleText7, ViridianGymAfterBattleText7
 ViridianGymTrainerHeader7:
-	trainer EVENT_BEAT_VIRIDIAN_GYM_TRAINER_7, 1, 4, ViridianGymBattleText8, ViridianGymEndBattleText8, ViridianGymAfterBattleText8
+	trainer EVENT_BEAT_VIRIDIAN_GYM_TRAINER_7, 4, ViridianGymBattleText8, ViridianGymEndBattleText8, ViridianGymAfterBattleText8
 	db -1 ; end
 
 ViridianGymText1:


### PR DESCRIPTION
This will need porting to pokeyellow.

It does not try to match the bit flag values with the object ID values; that can wait for more comprehensive map object constants, like pokecrystal has, since they're useful for events in general and not just trainer headers.