### PR TITLE
Identify the connections between Routes 22 and 23 as unused

### DIFF
--- a/data/maps/headers/Route22.asm
+++ b/data/maps/headers/Route22.asm
@@ -1,5 +1,5 @@
 
 	map_header Route22, ROUTE_22, OVERWORLD, NORTH | EAST
-	connection north, Route23, ROUTE_23, 0
+	connection north, Route23, ROUTE_23, 0 ; unused
 	connection east, ViridianCity, VIRIDIAN_CITY, -4
 	end_map_header

--- a/data/maps/headers/Route22.asm
+++ b/data/maps/headers/Route22.asm
@@ -1,5 +1,5 @@
 
 	map_header Route22, ROUTE_22, OVERWORLD, NORTH | EAST
-	connection north, Route23, ROUTE_23, 0 ; unused
+	connection north, Route23, ROUTE_23, 0 ; unnecessary
 	connection east, ViridianCity, VIRIDIAN_CITY, -4
 	end_map_header

--- a/data/maps/headers/Route23.asm
+++ b/data/maps/headers/Route23.asm
@@ -1,5 +1,5 @@
 
 	map_header Route23, ROUTE_23, PLATEAU, NORTH | SOUTH
 	connection north, IndigoPlateau, INDIGO_PLATEAU, 0
-	connection south, Route22, ROUTE_22, 0 ; unused
+	connection south, Route22, ROUTE_22, 0 ; unnecessary
 	end_map_header

--- a/data/maps/headers/Route23.asm
+++ b/data/maps/headers/Route23.asm
@@ -1,5 +1,5 @@
 
 	map_header Route23, ROUTE_23, PLATEAU, NORTH | SOUTH
 	connection north, IndigoPlateau, INDIGO_PLATEAU, 0
-	connection south, Route22, ROUTE_22, 0
+	connection south, Route22, ROUTE_22, 0 ; unused
 	end_map_header


### PR DESCRIPTION
These connections can only be seen in-game while noclipping and their removal has no impact on regular gameplay.