### PR TITLE
Remove old tile animation comments

### DIFF
--- a/home/vcopy.asm
+++ b/home/vcopy.asm
@@ -377,7 +377,7 @@ UpdateMovingBgTiles::
 
 	ldh a, [hTileAnimations]
 	and a
-	ret z ; no animations if indoors (or if a menu set this to 0)
+	ret z
 
 	ldh a, [hMovingBGTilesCounter1]
 	inc a
@@ -416,7 +416,7 @@ UpdateMovingBgTiles::
 	ldh a, [hTileAnimations]
 	rrca
 	ret nc
-; if in a cave, no flower animations
+
 	xor a
 	ldh [hMovingBGTilesCounter1], a
 	ret


### PR DESCRIPTION
They stopped being accurate after #304 and aren't really necessary.