### PR TITLE
Fix incorrect comment about money received after battle

### DIFF
--- a/data/trainers/pic_pointers_money.asm
+++ b/data/trainers/pic_pointers_money.asm
@@ -6,7 +6,7 @@ ENDM
 TrainerPicAndMoneyPointers::
 	table_width 5, TrainerPicAndMoneyPointers
 	; pic pointer, base reward money
-	; money received after battle = base money × level of highest-level enemy mon
+	; money received after battle = base money × level of last enemy mon
 	pic_money YoungsterPic,    1500
 	pic_money BugCatcherPic,   1000
 	pic_money LassPic,         1500

--- a/wram.asm
+++ b/wram.asm
@@ -1199,7 +1199,7 @@ ENDU
 
 	ds 2
 
-; money received after battle = base money × level of highest-level enemy mon
+; money received after battle = base money × level of last enemy mon
 wTrainerBaseMoney:: dw ; BCD
 
 wMissableObjectCounter:: db


### PR DESCRIPTION
The calculation uses the last pokemon in the opponent's team.

Example where this matters: 
According to the comment, the Route 22's rival fight should give $630 and use the L18 pidgeotto it leads with for the calculation, but it actually gives $595 since it uses the L17 starter.