### PR TITLE
Remove Stadium data patch from tools/make_patch.c

### DIFF
--- a/tools/make_patch.c
+++ b/tools/make_patch.c
@@ -340,10 +340,6 @@ struct Buffer *process_template(const char *template_filename, const char *patch
 
 	// The ROM checksum will always differ
 	buffer_append(patches, &(struct Patch){0x14e, 2});
-	// The Stadium data (see stadium.c) will always differ
-	unsigned int rom_size = (unsigned int)xfsize("", orig_rom);
-	unsigned int stadium_size = 24 + 6 + 2 + (rom_size / 0x2000) * 2;
-	buffer_append(patches, &(struct Patch){rom_size - stadium_size, stadium_size});
 
 	// Fill in the template
 	const struct Symbol *current_hook = NULL;


### PR DESCRIPTION
Reference #353. 

The Stadium Data patch is not needed in pokered.