### PR TITLE
Improved Virtual Console patch identifiers

### DIFF
--- a/data/text/text_4.asm
+++ b/data/text/text_4.asm
@@ -211,7 +211,7 @@ _CableClubNPCPleaseWaitText::
 	text_end
 
 _CableClubNPCLinkClosedBecauseOfInactivityText::
-	vc_patch Change_MSG
+	vc_patch Change_link_closed_inactivity_message
 IF DEF(_RED_VC) || DEF(_BLUE_VC)
 	text "Please come again!"
 	done

--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -176,12 +176,12 @@ PlayAnimation:
 	ld h, [hl]
 	ld l, a
 .animationLoop
-	vc_hook FPA_Thunderbolt_End
+	vc_hook Stop_reducing_move_anim_flashing_Thunderbolt
 	ld a, [hli]
-	vc_hook_red FPA_007_End
-	vc_hook_blue FPA_009_End
+	vc_hook_red Stop_reducing_move_anim_flashing_Reflect
+	vc_hook_blue Stop_reducing_move_anim_flashing_Self_Destruct
 	cp -1
-	vc_hook_blue FPA_008_End
+	vc_hook_blue Stop_reducing_move_anim_flashing_Reflect
 	jr z, .AnimationOver
 	cp FIRST_SE_ID ; is this subanimation or a special effect?
 	jr c, .playSubanimation
@@ -250,55 +250,57 @@ PlayAnimation:
 	ld a, [wAnimPalette]
 	ldh [rOBP0], a
 	call LoadAnimationTileset
-	vc_hook FPA_001_Begin
+	vc_hook Reduce_move_anim_flashing_Mega_Punch_Self_Destruct_Explosion
 	call LoadSubanimation
 	call PlaySubanimation
-	vc_hook FPA_001_End
+	vc_hook_red Stop_reducing_move_anim_flashing_Mega_Punch
+	vc_hook_blue Stop_reducing_move_anim_flashing_Mega_Punch_Explosion
 	pop af
-	vc_hook_red FPA_008_End
+	vc_hook_red Stop_reducing_move_anim_flashing_Dream_Eater
 	ldh [rOBP0], a
 .nextAnimationCommand
-	vc_hook FPA_005_End
+	vc_hook_red Stop_reducing_move_anim_flashing_Hyper_Beam
+	vc_hook_blue Stop_reducing_move_anim_flashing_Bubblebeam_Hyper_Beam_Blizzard
 	pop hl
-	vc_hook FPA_002_End
+	vc_hook Stop_reducing_move_anim_flashing_Guillotine
 	jr .animationLoop
 .AnimationOver
 	ret
 
 LoadSubanimation:
-	vc_hook FPA_002_Begin
+	vc_hook Reduce_move_anim_flashing_Guillotine
 	ld a, [wSubAnimAddrPtr + 1]
-	vc_hook FPA_003_Begin
+	vc_hook Reduce_move_anim_flashing_Mega_Kick
 	ld h, a
-	vc_hook_red FPA_131_Begin
+	vc_hook_red Reduce_move_anim_flashing_Blizzard
 	ld a, [wSubAnimAddrPtr]
-	vc_hook_red FPA_56_Begin
+	vc_hook_red Reduce_move_anim_flashing_Self_Destruct
 	ld l, a
 	ld a, [hli]
 	ld e, a
-	vc_hook FPA_76_Begin
+	vc_hook Reduce_move_anim_flashing_Explosion
 	ld a, [hl]
-	vc_hook FPA_Thunderbolt_Begin
+	vc_hook Reduce_move_anim_flashing_Thunderbolt
 	ld d, a ; de = address of subanimation
 	ld a, [de]
-	vc_hook_blue FPA_012_Begin
+	vc_hook_blue Reduce_move_anim_flashing_Rock_Slide
 	ld b, a
-	vc_hook FPA_Spore_Begin
+	vc_hook Reduce_move_anim_flashing_Spore
 	and %00011111
-	vc_hook FPA_Bubblebeam_Begin
+	vc_hook Reduce_move_anim_flashing_Bubblebeam
 	ld [wSubAnimCounter], a ; number of frame blocks
-	vc_hook_red FPA_010_Begin
-	vc_hook_blue FPA_009_Begin
+	vc_hook_red Reduce_move_anim_flashing_Rock_Slide
+	vc_hook_blue Reduce_move_anim_flashing_Self_Destruct
 	ld a, b
 	and %11100000
 	cp SUBANIMTYPE_ENEMY << 5
-	vc_hook_blue FPA_004_Begin
+	vc_hook_blue Reduce_move_anim_flashing_Blizzard
 	jr nz, .isNotType5
 .isType5
 	call GetSubanimationTransform2
 	jr .saveTransformation
 .isNotType5
-	vc_hook FPA_Hyper_Beam_Begin
+	vc_hook Reduce_move_anim_flashing_Hyper_Beam
 	call GetSubanimationTransform1
 .saveTransformation
 ; place the upper 3 bits of a into bits 0-2 of a before storing
@@ -329,7 +331,7 @@ LoadSubanimation:
 ; sets the transform to SUBANIMTYPE_NORMAL if it's the player's turn
 ; sets the transform to the subanimation type if it's the enemy's turn
 GetSubanimationTransform1:
-	vc_hook FPA_Reflect_Begin
+	vc_hook Reduce_move_anim_flashing_Reflect
 	ld b, a
 	ldh a, [hWhoseTurn]
 	and a
@@ -422,15 +424,15 @@ MoveAnimation:
 	jr nz, .animationsDisabled
 	call ShareMoveAnimations
 	call PlayAnimation
-	vc_hook_red FPA_004_End
-	vc_hook_blue FPA_011_End
+	vc_hook_red Stop_reducing_move_anim_flashing_Bubblebeam_Mega_Kick
+	vc_hook_blue Stop_reducing_move_anim_flashing_Spore
 	jr .next4
 .animationsDisabled
 	ld c, 30
 	call DelayFrames
 .next4
-	vc_hook_red FPA_010_End
-	vc_hook_blue FPA_012_End
+	vc_hook_red Stop_reducing_move_anim_flashing
+	vc_hook_blue Stop_reducing_move_anim_flashing_Rock_Slide_Dream_Eater
 	call PlayApplyingAttackAnimation ; shake the screen or flash the pic in and out (to show damage)
 .animationFinished
 	call WaitForSoundToFinish
@@ -568,7 +570,7 @@ SetAnimationPalette:
 .notSGB
 	ld a, $e4
 	ld [wAnimPalette], a
-	vc_hook FPA_Dream_Eater_Begin
+	vc_hook Reduce_move_anim_flashing_Dream_Eater
 	ldh [rOBP0], a
 	ld a, $6c
 	ldh [rOBP1], a
@@ -984,7 +986,7 @@ AnimationFlashScreenLong:
 	ld [wFlashScreenLongCounter], a
 	pop hl
 	jr nz, .loop
-	vc_hook_red FPA_phy_End
+	vc_hook_red Stop_reducing_move_anim_flashing_Psychic
 	ret
 
 ; BG palettes

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3023,7 +3023,7 @@ LinkBattleExchangeData:
 	ld a, b
 .doExchange
 	ld [wSerialExchangeNybbleSendData], a
-	vc_hook send_byt2
+	vc_hook Wireless_start_exchange
 	callfar PrintWaitingText
 .syncLoop1
 	call Serial_ExchangeNybble
@@ -3031,8 +3031,8 @@ LinkBattleExchangeData:
 	ld a, [wSerialExchangeNybbleReceiveData]
 	inc a
 	jr z, .syncLoop1
-	vc_hook send_byt2_ret
-	vc_patch FIGHT
+	vc_hook Wireless_end_exchange
+	vc_patch Wireless_net_delay_1
 IF DEF(_RED_VC) || DEF(_BLUE_VC)
 	ld b, 26
 ELSE
@@ -3044,8 +3044,8 @@ ENDC
 	call Serial_ExchangeNybble
 	dec b
 	jr nz, .syncLoop2
-	vc_hook send_dummy
-	vc_patch FIGHT2
+	vc_hook Wireless_start_send_zero_bytes
+	vc_patch Wireless_net_delay_2
 IF DEF(_RED_VC) || DEF(_BLUE_VC)
 	ld b, 26
 ELSE
@@ -3057,7 +3057,7 @@ ENDC
 	call Serial_SendZeroByte
 	dec b
 	jr nz, .syncLoop3
-	vc_hook send_dummy_end
+	vc_hook Wireless_end_send_zero_bytes
 	ret
 
 ExecutePlayerMove:
@@ -6677,8 +6677,8 @@ BattleRandom:
 	ld a, [hl]
 	pop bc
 	pop hl
-	vc_hook fight_ret_c
-	vc_patch fight_ret
+	vc_hook Unknown_BattleRandom_ret_c
+	vc_patch BattleRandom_ret
 IF DEF(_RED_VC) || DEF(_BLUE_VC)
 	ret
 ELSE
@@ -6749,9 +6749,9 @@ HandleExplodingAnimation:
 
 PlayMoveAnimation:
 	ld [wAnimationID], a
-	vc_hook_red FPA_conf_Begin
+	vc_hook_red Reduce_move_anim_flashing_Confusion
 	call Delay3
-	vc_hook_red FPA_phy_Begin
+	vc_hook_red Reduce_move_anim_flashing_Psychic
 	predef_jump MoveAnimation
 
 InitBattle::

--- a/engine/gfx/palettes.asm
+++ b/engine/gfx/palettes.asm
@@ -484,7 +484,7 @@ CheckSGB:
 	ldh a, [rJOYP]
 	ldh a, [rJOYP]
 	call Wait7000
-	vc_hook Network_RESET
+	vc_hook Unknown_network_reset
 	call Wait7000
 	ld a, $30
 	ldh [rJOYP], a

--- a/engine/link/cable_club.asm
+++ b/engine/link/cable_club.asm
@@ -124,21 +124,21 @@ CableClub_DoBattleOrTradeAgain:
 	ld hl, wSerialRandomNumberListBlock
 	ld de, wSerialOtherGameboyRandomNumberListBlock
 	ld bc, $11
-	vc_hook Network17
+	vc_hook Wireless_ExchangeBytes_1_unknown_Type5
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
 	ld hl, wSerialPlayerDataBlock
 	ld de, wSerialEnemyDataBlock
 	ld bc, $1a8
-	vc_hook Network424
+	vc_hook Wireless_ExchangeBytes_2
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
 	ld hl, wSerialPartyMonsPatchList
 	ld de, wSerialEnemyMonsPatchList
 	ld bc, $c8
-	vc_hook Network200
+	vc_hook Wireless_ExchangeBytes_3
 	call Serial_ExchangeBytes
 	ld a, (1 << SERIAL) | (1 << TIMER) | (1 << VBLANK)
 	ldh [rIE], a
@@ -862,7 +862,7 @@ TradeCenter_Trade:
 	ld de, TradeCompleted
 	call PlaceString
 	predef SaveSAVtoSRAM2
-	vc_hook save_game_end
+	vc_hook Trade_save_game_end
 	ld c, 50
 	call DelayFrames
 	xor a

--- a/engine/link/cable_club_npc.asm
+++ b/engine/link/cable_club_npc.asm
@@ -31,7 +31,7 @@ CableClubNPC::
 ; USING_INTERNAL_CLOCK, which allows the player to proceed past the link
 ; receptionist's "Please wait." It assumes that hSerialConnectionStatus is at
 ; its original address.
-	vc_hook linkCable_fake_begin
+	vc_hook Link_fake_connection_status
 	vc_assert hSerialConnectionStatus == $ffaa, \
 		"hSerialConnectionStatus is no longer located at 00:ffaa"
 	vc_assert USING_INTERNAL_CLOCK == $02, \
@@ -63,7 +63,7 @@ CableClubNPC::
 	ld a, [wCurrentMenuItem]
 	and a
 	jr nz, .choseNo
-	vc_hook linkCable_block_input
+	vc_hook Wireless_TryQuickSave_block_input
 	callfar SaveSAVtoSRAM
 	call WaitForSoundToFinish
 	ld a, SFX_SAVE
@@ -76,10 +76,10 @@ CableClubNPC::
 	xor a
 	ld [hl], a
 	ldh [hSerialReceivedNewData], a
-	vc_hook linkCable_fake_end
+	vc_hook Wireless_prompt
 	ld [wSerialExchangeNybbleSendData], a
 	call Serial_SyncAndExchangeNybble
-	vc_hook Network_RECHECK
+	vc_hook Wireless_net_recheck
 	ld hl, wUnknownSerialCounter
 	ld a, [hli]
 	inc a

--- a/engine/menus/main_menu.asm
+++ b/engine/menus/main_menu.asm
@@ -284,11 +284,11 @@ LinkMenu:
 .choseCancel
 	xor a
 	ld [wMenuJoypadPollCount], a
-	vc_hook Network_STOP
+	vc_hook Wireless_net_stop
 	call Delay3
 	call CloseLinkConnection
 	ld hl, LinkCanceledText
-	vc_hook Network_END
+	vc_hook Wireless_net_end
 	call PrintText
 	ld hl, wd72e
 	res 6, [hl]

--- a/engine/menus/save.asm
+++ b/engine/menus/save.asm
@@ -39,7 +39,7 @@ LoadSAV0:
 	ld [MBC1SRamBank], a
 ; This vc_hook does not have to be in any particular location.
 ; It is defined here because it refers to the same labels as the two lines below.
-	vc_hook SaveLimit
+	vc_hook Unknown_save_limit
 	ld hl, sGameData
 	ld bc, sGameDataEnd - sGameData
 	call SAVCheckSum

--- a/home/serial.asm
+++ b/home/serial.asm
@@ -230,7 +230,7 @@ Serial_PrintWaitingTextAndSyncAndExchangeNybble::
 	jp LoadScreenTilesFromBuffer1
 
 Serial_SyncAndExchangeNybble::
-	vc_hook send_send_buf2
+	vc_hook Wireless_WaitLinkTransfer
 	ld a, $ff
 	ld [wSerialExchangeNybbleReceiveData], a
 .loop1
@@ -254,7 +254,7 @@ Serial_SyncAndExchangeNybble::
 	ld a, [wSerialExchangeNybbleReceiveData]
 	inc a
 	jr z, .loop1
-	vc_patch Network10
+	vc_patch Wireless_net_delay_3
 IF DEF(_RED_VC) || DEF(_BLUE_VC)
 	ld b, 26
 ELSE
@@ -266,7 +266,7 @@ ENDC
 	call Serial_ExchangeNybble
 	dec b
 	jr nz, .loop2
-	vc_patch Network11
+	vc_patch Wireless_net_delay_4
 IF DEF(_RED_VC) || DEF(_BLUE_VC)
 	ld b, 26
 ELSE
@@ -280,7 +280,7 @@ ENDC
 	jr nz, .loop3
 	ld a, [wSerialExchangeNybbleReceiveData]
 	ld [wSerialSyncAndExchangeNybbleReceiveData], a
-	vc_hook send_send_buf2_ret
+	vc_hook Wireless_WaitLinkTransfer_ret
 	ret
 
 Serial_ExchangeNybble::

--- a/vc/pokeblue.patch.template
+++ b/vc/pokeblue.patch.template
@@ -25,108 +25,108 @@
 ;ReduceColorB1 = 0	;0~31 (for Green Mode)
 ;MotionBlur1 = 31	;0~31 (for Green Mode)
 ;PaletteX = c31,31,31	;X:0~15, cR,G,B (0~31)
-[SaveLimit]
+[SaveLimit@Unknown_save_limit]
 Mode = 12
 Type = 1
 Index = {hex sGameData}
 Address = {hex sGameDataEnd}
 
-[send_send_buf2]
+[send_send_buf2@Wireless_WaitLinkTransfer]
 Mode = 2
 Address = {HEX @}
 Type = 29
 
-[send_send_buf2_ret]
+[send_send_buf2_ret@Wireless_WaitLinkTransfer_ret]
 Mode = 2
 Address = {HEX @}
 Type = 30
 
-[send_byt2]
+[send_byt2@Wireless_start_exchange]
 Mode = 2
 Address = {HEX @+5}
 Type = 31
 
-[send_byt2_ret]
+[send_byt2_ret@Wireless_end_exchange]
 Mode = 2
 Address = {HEX @}
 Type = 32
 
-[send_dummy]
+[send_dummy@Wireless_start_send_zero_bytes]
 Mode = 2
 Address = {HEX @}
 Type = 33
 
-[send_dummy_end]
+[send_dummy_end@Wireless_end_send_zero_bytes]
 Mode = 2
 Address = {HEX @}
 Type = 34
 
-[FIGHT]
+[FIGHT@Wireless_net_delay_1]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[FIGHT2]
+[FIGHT2@Wireless_net_delay_2]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network10]
+[Network10@Wireless_net_delay_3]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network11]
+[Network11@Wireless_net_delay_4]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network17]
+[Network17@Wireless_ExchangeBytes_1_unknown_Type5]
 Mode = 2
 Address = {HEX @}
 Type = 5
 
-[Network424]
+[Network424@Wireless_ExchangeBytes_2]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network200]
+[Network200@Wireless_ExchangeBytes_3]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network_RECHECK]
+[Network_RECHECK@Wireless_net_recheck]
 Mode = 2
 Address = {HEX @}
 Type = 7
 
-[Network_STOP]
+[Network_STOP@Wireless_net_stop]
 Mode = 2
 Address = {HEX @}
 Type = 8
 
-[Network_END]
+[Network_END@Wireless_net_end]
 Mode = 2
 Address = {HEX @}
 Type = 9
 
-[Network_RESET]
+[Network_RESET@Unknown_network_reset]
 Mode = 2
 Address = {HEX @}
 Type = 10
 
-[linkCable fake begin]
+[linkCable fake begin@Link_fake_connection_status]
 Mode = 2
 Address = {HEX @}
 Type = 16
 
-[linkCable fake end]
+[linkCable fake end@Wireless_prompt]
 Mode = 2
 Address = {HEX @}
 Type = 17
 
-[linkCable block input]
+[linkCable block input@Wireless_TryQuickSave_block_input]
 Mode = 2
 Address = {HEX @+5}
 Type = 18
@@ -136,29 +136,29 @@ Type = 18
 ;Address = 0x59E6
 ;Type = 19
 
-[save game end]
+[save game end@Trade_save_game_end]
 Mode = 2
 Address = {HEX @}
 Type = 20
 
-[Change_MSG]
+[Change_MSG@Change_link_closed_inactivity_message]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH_ +1 20}
 
-[fight_ret]
+[fight_ret@BattleRandom_ret]
 Mode = 1
 Address = {HEX @}
 Fixcode = {PATCH}
 
-[fight_ret_c]
+[fight_ret_c@Unknown_BattleRandom_ret_c]
 Mode = 2
 Address = {HEX @}
 Type = 98
 
 ;rsm003758
 ;No151
-[FPA 001 Begin]               
+[FPA 001 Begin@Reduce_move_anim_flashing_Mega_Punch_Self_Destruct_Explosion]               
 Mode = 3                      
 Type = 0                      
 Address = {HEX @}            
@@ -169,7 +169,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==              ==            ||  ==            ==              ==              ==              ==            ||  ==            ==              ==              ==              ==          }     
 ConditionValueC = {dws_ "M"           "E"             "G"             "A"             "P"             MEGA_PUNCH    00  "S"           "E"             "L"             "F"             MEGA_PUNCH    00  "E"           "X"             "P"             "L"             MEGA_PUNCH  }     
 
-[FPA 001 End]               
+[FPA 001 End@Stop_reducing_move_anim_flashing_Mega_Punch_Explosion]               
 Mode = 3                    
 Type = 1                    
 Address = {HEX @}           
@@ -182,7 +182,7 @@ ConditionValueC = {dws_ "M"           "E"             "G"             "A"       
                                     
 ;rsm141151   
 ;No117              
-[FPA 002 Begin]                     
+[FPA 002 Begin@Reduce_move_anim_flashing_Guillotine]                     
 Mode = 3                            
 Type = 0                            
 Address = {HEX @}                   
@@ -195,7 +195,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }          
 ConditionValueC = {dws_ "G"           "U"             "I"             "L"             GUILLOTINE  }          
 
-[FPA 002 End]                                          
+[FPA 002 End@Stop_reducing_move_anim_flashing_Guillotine]                                          
 Mode = 3                                                                             
 Type = 1                                                 
 Address = {HEX @}                                        
@@ -208,7 +208,7 @@ ConditionValueC = {dws_ "G"           "U"             "I"             "L"       
 
 ;rsm143918
 ;No150
-[FPA 003 Begin]               
+[FPA 003 Begin@Reduce_move_anim_flashing_Mega_Kick]               
 Mode = 3                      
 Type = 0                      
 Address = {HEX @}            
@@ -223,7 +223,7 @@ ConditionValueC = {dws_ "M"           "E"             "G"             "A"       
 
 ;rsm152422
 ;No131
-[FPA 004 Begin]                           
+[FPA 004 Begin@Reduce_move_anim_flashing_Blizzard]                           
 Mode = 3                                   
 Type = 0                                   
 Address = {HEX @}                         
@@ -237,7 +237,7 @@ ConditionValueC = {dws_ "B"           "L"             "I"             "Z"       
 
 ;rsm160334
 ;No123
-[FPA 005 Begin@FPA_Bubblebeam_Begin]                           
+[FPA 005 Begin@Reduce_move_anim_flashing_Bubblebeam]                           
 Mode = 3                                   
 Type = 0                                   
 Address = {hex @}                         
@@ -248,7 +248,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }   
 ConditionValueC = {dws_ "B"           "U"             "B"             "B"             BUBBLEBEAM  }   
 
-[FPA 005 End]                                        
+[FPA 005 End@Stop_reducing_move_anim_flashing_Bubblebeam_Hyper_Beam_Blizzard]                                        
 Mode = 3                                             
 Type = 1                                             
 Address = {HEX @}                                    
@@ -260,7 +260,7 @@ ConditionValueC = {dws_ "B"           "U"             "B"             "B"       
 
 ;rsm163356
 ;No116
-[FPA 006 Begin@FPA_Hyper_Beam_Begin]                                                 
+[FPA 006 Begin@Reduce_move_anim_flashing_Hyper_Beam]                                                 
 Mode = 3               
 Type = 0               
 Address = {HEX @}         
@@ -277,7 +277,7 @@ ConditionValueC = {dws_ "H"           "Y"             "P"             "E"       
 
 ;rsm174631
 ;No57
-[FPA 007 Begin@FPA_Thunderbolt_Begin]                                                 
+[FPA 007 Begin@Reduce_move_anim_flashing_Thunderbolt]                                                 
 Mode = 3               
 Type = 0               
 Address = {HEX @}       
@@ -289,7 +289,7 @@ ConditionValueB = {dws_ ==            ==              ==              ==        
 ConditionValueC = {dws_ "T"           "H"             "U"             "N"             THUNDERBOLT }  
    
                          
-[FPA 007 End@FPA_Thunderbolt_End]       
+[FPA 007 End@Stop_reducing_move_anim_flashing_Thunderbolt]       
 Mode = 3                 
 Type = 1                 
 Address = {HEX @}
@@ -301,7 +301,7 @@ ConditionValueC = {dws_ "T"           "H"             "U"             "N"       
 
 ;rsm134518  
 ;No159                                 
-[FPA 008 Begin@FPA_Reflect_Begin]                                                   
+[FPA 008 Begin@Reduce_move_anim_flashing_Reflect]                                                   
 Mode = 3                 
 Type = 0                 
 Address = {hex @}        
@@ -314,7 +314,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }    
 ConditionValueC = {dws_ "R"           "E"             "F"             "L"             REFLECT     }             
                          
-[FPA 008 End]       
+[FPA 008 End@Stop_reducing_move_anim_flashing_Reflect]       
 Mode = 3                 
 Type = 1                 
 Address = {HEX @}
@@ -328,7 +328,7 @@ ConditionValueC = {dws_ "R"           "E"             "F"             "L"       
 
 ;rsm140510 
 ;No56                                 
-[FPA 009 Begin]                                                   
+[FPA 009 Begin@Reduce_move_anim_flashing_Self_Destruct]                                                   
 Mode = 3                 
 Type = 0                 
 Address = {HEX @}        
@@ -339,7 +339,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          } 
 ConditionValueC = {dws_ "S"           "E"             "L"             "F"             SELFDESTRUCT}          
                          
-[FPA 009 End]       
+[FPA 009 End@Stop_reducing_move_anim_flashing_Self_Destruct]       
 Mode = 3                 
 Type = 1                 
 Address = {HEX @}
@@ -350,7 +350,7 @@ ConditionValueC = {dws_ "S"           "E"             "L"             "F"       
 
 ;rsm150211 
 ;No156                              
-[FPA 010 Begin@FPA_Dream_Eater_Begin]                                                   
+[FPA 010 Begin@Reduce_move_anim_flashing_Dream_Eater]                                                   
 Mode = 3                 
 Type = 0                 
 Address = {hex @} 
@@ -374,7 +374,7 @@ ConditionValueC = {dws_ "D"           "R"             "E"             "A"       
 
 ;rsm163334     
 ;No36                     
-[FPA 011 Begin@FPA_Spore_Begin]                       
+[FPA 011 Begin@Reduce_move_anim_flashing_Spore]                       
 Mode = 3                              
 Type = 0                              
 Address = {HEX @}                     
@@ -387,7 +387,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }             
 ConditionValueC = {dws_ "S"           "P"             "O"             "R"             SPORE       }             
                                       
-[FPA 011 End]                         
+[FPA 011 End@Stop_reducing_move_anim_flashing_Spore]                         
 Mode = 3                              
 Type = 1                              
 Address = {hex @}                     
@@ -398,7 +398,7 @@ ConditionValueC = {dws_ "S"           "P"             "O"             "R"       
 
 ;rsm012224 
 ;No12                        
-[FPA 012 Begin]                       
+[FPA 012 Begin@Reduce_move_anim_flashing_Rock_Slide]                       
 Mode = 3                              
 Type = 0                              
 Address = {HEX @}                     
@@ -409,7 +409,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }         
 ConditionValueC = {dws_ "R"           "O"             "C"             "K"             ROCK_SLIDE  }         
                                       
-[FPA 012 End]                         
+[FPA 012 End@Stop_reducing_move_anim_flashing_Rock_Slide_Dream_Eater]                         
 Mode = 3                              
 Type = 1                              
 Address = {hex @}                     
@@ -424,7 +424,7 @@ ConditionValueC = {dws_ "R"           "O"             "C"             "K"       
 
 ;explosion  
 ;No76                                             
-[FPA 76 Begin]                                                  
+[FPA 76 Begin@Reduce_move_anim_flashing_Explosion]                                                  
 Mode = 3                                                         
 Type = 0                                                         
 Address = 0x78186                                              

--- a/vc/pokered.patch.template
+++ b/vc/pokered.patch.template
@@ -25,7 +25,7 @@
 ;ReduceColorB1 = 0	;0~31 (for Green Mode)
 ;MotionBlur1 = 31	;0~31 (for Green Mode)
 ;PaletteX = c31,31,31	;X:0~15, cR,G,B (0~31)
-[SaveLimit]
+[SaveLimit@Unknown_save_limit]
 Mode = 12
 Type = 1
 Index = {hex sGameData}
@@ -36,102 +36,102 @@ Address = {hex sGameDataEnd}
 ;Address = 0x1551
 ;Type = 3
 
-[send_send_buf2]
+[send_send_buf2@Wireless_WaitLinkTransfer]
 Mode = 2
 Address = {HEX @}
 Type = 29
 
-[send_send_buf2_ret]
+[send_send_buf2_ret@Wireless_WaitLinkTransfer_ret]
 Mode = 2
 Address = {HEX @}
 Type = 30
 
-[send_byt2]
+[send_byt2@Wireless_start_exchange]
 Mode = 2
 Address = {HEX @+5}
 Type = 31
 
-[send_byt2_ret]
+[send_byt2_ret@Wireless_end_exchange]
 Mode = 2
 Address = {HEX @}
 Type = 32
 
-[send_dummy]
+[send_dummy@Wireless_start_send_zero_bytes]
 Mode = 2
 Address = {HEX @}
 Type = 33
 
-[send_dummy_end]
+[send_dummy_end@Wireless_end_send_zero_bytes]
 Mode = 2
 Address = {HEX @}
 Type = 34
 
-[FIGHT]
+[FIGHT@Wireless_net_delay_1]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[FIGHT2]
+[FIGHT2@Wireless_net_delay_2]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network10]
+[Network10@Wireless_net_delay_3]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network11]
+[Network11@Wireless_net_delay_4]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network17]
+[Network17@Wireless_ExchangeBytes_1_unknown_Type5]
 Mode = 2
 Address = {HEX @}
 Type = 5
 
-[Network424]
+[Network424@Wireless_ExchangeBytes_2]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network200]
+[Network200@Wireless_ExchangeBytes_3]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network_RECHECK]
+[Network_RECHECK@Wireless_net_recheck]
 Mode = 2
 Address = {HEX @}
 Type = 7
 
-[Network_STOP]
+[Network_STOP@Wireless_net_stop]
 Mode = 2
 Address = {HEX @}
 Type = 8
 
-[Network_END]
+[Network_END@Wireless_net_end]
 Mode = 2
 Address = {HEX @}
 Type = 9
 
-[Network_RESET]
+[Network_RESET@Unknown_network_reset]
 Mode = 2
 Address = {HEX @}
 Type = 10
 
-[linkCable fake begin]
+[linkCable fake begin@Link_fake_connection_status]
 Mode = 2
 Address = {HEX @}
 Type = 16
 
-[linkCable fake end]
+[linkCable fake end@Wireless_prompt]
 Mode = 2
 Address = {HEX @}
 Type = 17
 
-[linkCable block input]
+[linkCable block input@Wireless_TryQuickSave_block_input]
 Mode = 2
 Address = {HEX @+5}
 Type = 18
@@ -141,24 +141,24 @@ Type = 18
 ;Address = 0x59E6
 ;Type = 19
 
-[save game end]
+[save game end@Trade_save_game_end]
 Mode = 2
 Address = {HEX @}
 Type = 20
 
 ;93 A7 A4 7F AB A8 AD AA 7F A7
 ;at 93
-[Change_MSG]
+[Change_MSG@Change_link_closed_inactivity_message]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH_ +1 20}
 
-[fight_ret]
+[fight_ret@BattleRandom_ret]
 Mode = 1
 Address = {HEX @}
 Fixcode = {PATCH}
 
-[fight_ret_c]
+[fight_ret_c@Unknown_BattleRandom_ret_c]
 Mode = 2
 Address = {HEX @}
 Type = 98
@@ -183,7 +183,7 @@ Type = 98
 
 ;rsm033659 
 ;no151 mega punch
-[FPA 001 Begin]               
+[FPA 001 Begin@Reduce_move_anim_flashing_Mega_Punch_Self_Destruct_Explosion]               
 Mode = 3                      
 Type = 0                      
 Address = {HEX @}            
@@ -197,7 +197,7 @@ ConditionValueB = {dws_ ==            ==              ==              ==        
 ConditionValueC = {dws_ "M"           "E"             "G"             "A"             "P"             MEGA_PUNCH    00  "S"           "E"             "L"             "F"             "D"             MEGA_PUNCH    00  "E"           "X"             "P"             "L"             MEGA_PUNCH  }  
 
 
-[FPA 001 End]                                               
+[FPA 001 End@Stop_reducing_move_anim_flashing_Mega_Punch]                                               
 Mode = 3                                                    
 Type = 1                                                    
 Address = {HEX @}                                           
@@ -209,7 +209,7 @@ ConditionValueC = {dws_ "M"           "E"             "G"             "A"       
                                     
 ;rsm032916    
 ;no117 guillotine                
-[FPA 002 Begin]                     
+[FPA 002 Begin@Reduce_move_anim_flashing_Guillotine]                     
 Mode = 3                            
 Type = 0                            
 Address = {HEX @}                   
@@ -222,7 +222,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }         
 ConditionValueC = {dws_ "G"           "U"             "I"             "L"             GUILLOTINE  } 
 
-[FPA 002 End]                 
+[FPA 002 End@Stop_reducing_move_anim_flashing_Guillotine]                 
 Mode = 3                      
 Type = 1                      
 Address = {HEX @}           
@@ -234,7 +234,7 @@ ConditionValueC = {dws_ "G"           "U"             "I"             "L"       
 
 ;rsm041307 
 ;no150 mega kick
-[FPA 003 Begin]               
+[FPA 003 Begin@Reduce_move_anim_flashing_Mega_Kick]               
 Mode = 3                      
 Type = 0                      
 Address = {HEX @}            
@@ -250,7 +250,7 @@ ConditionValueC = {dws_ "M"           "E"             "G"             "A"       
 
 ;rsm001929 
 ;no123 bubble beam
-[FPA 004 Begin@FPA_Bubblebeam_Begin]                           
+[FPA 004 Begin@Reduce_move_anim_flashing_Bubblebeam]                           
 Mode = 3                                   
 Type = 0                                   
 Address = {hex @}                         
@@ -261,7 +261,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }  
 ConditionValueC = {dws_ "B"           "U"             "B"             "B"             BUBBLEBEAM  } 
 
-[FPA 004 End]                         
+[FPA 004 End@Stop_reducing_move_anim_flashing_Bubblebeam_Mega_Kick]                         
 Mode = 3                              
 Type = 1                              
 Address = {hex @}                     
@@ -273,7 +273,7 @@ ConditionValueC = {dws_ "B"           "U"             "B"             "B"       
 
 ;rsm103658 
 ;no116 hyper beam
-[FPA 005 Begin@FPA_Hyper_Beam_Begin]                                                 
+[FPA 005 Begin@Reduce_move_anim_flashing_Hyper_Beam]                                                 
 Mode = 3               
 Type = 0               
 Address = {HEX @}         
@@ -286,7 +286,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }    
 ConditionValueC = {dws_ "H"           "Y"             "P"             "E"             HYPER_BEAM  }    
 
-[FPA 005 End]                      
+[FPA 005 End@Stop_reducing_move_anim_flashing_Hyper_Beam]                      
 Mode = 3                           
 Type = 1                           
 Address = {HEX @}                 
@@ -298,7 +298,7 @@ ConditionValueC = {dws_ "H"           "Y"             "P"             "E"       
 
 ;rsm133358
 ;no57 thunderbolt
-[FPA 006 Begin@FPA_Thunderbolt_Begin]                                                 
+[FPA 006 Begin@Reduce_move_anim_flashing_Thunderbolt]                                                 
 Mode = 3               
 Type = 0               
 Address = {HEX @}       
@@ -310,7 +310,7 @@ ConditionValueB = {dws_ ==            ==              ==              ==        
 ConditionValueC = {dws_ "T"           "H"             "U"             "N"             THUNDERBOLT }  
    
                          
-[FPA 006 End@FPA_Thunderbolt_End]       
+[FPA 006 End@Stop_reducing_move_anim_flashing_Thunderbolt]       
 Mode = 3                 
 Type = 1                 
 Address = {HEX @}
@@ -321,7 +321,7 @@ ConditionValueC = {dws_ "T"           "H"             "U"             "N"       
 
 ;rsm152340  
 ;no159 reflect                                  
-[FPA 007 Begin@FPA_Reflect_Begin]                                                   
+[FPA 007 Begin@Reduce_move_anim_flashing_Reflect]                                                   
 Mode = 3                 
 Type = 0                 
 Address = {hex @}        
@@ -334,7 +334,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }       
 ConditionValueC = {dws_ "R"           "E"             "F"             "L"             REFLECT     }                
                          
-[FPA 007 End]       
+[FPA 007 End@Stop_reducing_move_anim_flashing_Reflect]       
 Mode = 3                 
 Type = 1                 
 Address = {HEX @}
@@ -345,7 +345,7 @@ ConditionValueC = {dws_ "R"           "E"             "F"             "L"       
 
 ;rsm171812  
 ;no156 dream eater                               
-[FPA 008 Begin@FPA_Dream_Eater_Begin]                                                   
+[FPA 008 Begin@Reduce_move_anim_flashing_Dream_Eater]                                                   
 Mode = 3                 
 Type = 0                 
 Address = {hex @} 
@@ -358,7 +358,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          } 
 ConditionValueC = {dws_ "D"           "R"             "E"             "A"             DREAM_EATER }          
                          
-[FPA 008 End]       
+[FPA 008 End@Stop_reducing_move_anim_flashing_Dream_Eater]       
 Mode = 3                 
 Type = 1                 
 Address = {HEX @}
@@ -369,7 +369,7 @@ ConditionValueC = {dws_ "B"           "L"             "I"             "Z"       
 
 ;rsm174650   
 ;no36 spore                       
-[FPA 009 Begin@FPA_Spore_Begin]                       
+[FPA 009 Begin@Reduce_move_anim_flashing_Spore]                       
 Mode = 3                              
 Type = 0                              
 Address = {HEX @}                     
@@ -385,7 +385,7 @@ ConditionValueC = {dws_ "S"           "P"             "O"             "R"       
 
 ;rsm152115
 ;no12 rock slide                      
-[FPA 010 Begin]                       
+[FPA 010 Begin@Reduce_move_anim_flashing_Rock_Slide]                       
 Mode = 3                              
 Type = 0                              
 Address = {HEX @}                     
@@ -396,7 +396,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }      
 ConditionValueC = {dws_ "R"           "O"             "C"             "K"             ROCK_SLIDE  }      
                                       
-[FPA 010 End]                         
+[FPA 010 End@Stop_reducing_move_anim_flashing]                         
 Mode = 3                              
 Type = 1                              
 Address = {HEX @}                    
@@ -408,7 +408,7 @@ ConditionValueC = {dws_ "D"           "R"             "E"             "A"       
 
 ;explosion  
 ;No76 explosion                                             
-[FPA 76 Begin]                                                  
+[FPA 76 Begin@Reduce_move_anim_flashing_Explosion]                                                  
 Mode = 3                                                         
 Type = 0                                                         
 Address = {HEX @}                                              
@@ -421,7 +421,7 @@ ConditionValueC = {dws_ "E"           "X"             "P"             "L"       
 
 
 ;No56 self-destruct                                                 
-[FPA 56 Begin]                                                 
+[FPA 56 Begin@Reduce_move_anim_flashing_Self_Destruct]                                                 
 Mode = 3                                                        
 Type = 0                                                        
 Address = {HEX @}                                               
@@ -434,7 +434,7 @@ ConditionValueC = {dws_ "S"           "E"             "L"             "F"       
 
 
 ;No131 blizzard                                                                                                           
-[FPA 131 Begin]                                                                                                                                 
+[FPA 131 Begin@Reduce_move_anim_flashing_Blizzard]                                                                                                                                 
 Mode = 3                                                              
 Type = 0                                                              
 Address = {HEX @}                                                     
@@ -447,7 +447,7 @@ ConditionValueC = {dws_ "B"           "L"             "I"             "Z"       
 
 
 ;confusion                                                     
-[FPA conf Begin]                                                      
+[FPA conf Begin@Reduce_move_anim_flashing_Confusion]                                                      
 Mode = 3                                                                                     
 Type = 0                                                             
 Address = {hex @}                                                  
@@ -459,7 +459,7 @@ ConditionValueB = {dws_ ==            ==              ==              ==        
 ConditionValueC = {dws_ "C"           "O"             "N"             "F"             "S"             CONFUSION   }  
 
 ;phychic                                                   
-[FPA phy Begin]                                                                                                                
+[FPA phy Begin@Reduce_move_anim_flashing_Psychic]                                                                                                                
 Mode = 3                                                   
 Type = 0                                                   
 Address = {hex @}                                          
@@ -470,7 +470,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==              ==          } 
 ConditionValueC = {dws_ "P"           "S"             "Y"             "C"             "I"             PSYCHIC_M   }    
 
-[FPA phy End]                                                                                    
+[FPA phy End@Stop_reducing_move_anim_flashing_Psychic]                                                                                    
 Mode = 3                                                                                         
 Type = 1                                                                                         
 Address = {hex @}                                                                                


### PR DESCRIPTION
Please reference: [pret/pokecrystal#886](https://github.com/pret/pokecrystal/issues/886) [pret/pokecrystal#907](https://github.com/pret/pokecrystal/pull/907)

Notable differences from [pret/pokecrystal#907](https://github.com/pret/pokecrystal/pull/907):

*   `Change_MSG` => `Change_link_closed_inactivity_message`
*   Lots of renaming of the FPA's to reference their moves.
*   `FIGHT` => `Wireless_net_delay_1`
*   `FIGHT2` => `Wireless_net_delay_2`
*   `fight_ret_c` => `Unknown_BattleRandom_ret_c` (Unknown what this hook is actually doing.. Maybe changes the patched `ret` back to `ret c` under the right conditions.)
*   `fight_ret` => `BattleRandom_ret` (patches `ret c` to `ret` )
*   `Network17` => `Wireless_ExchangeBytes_1_unknown_Type5` (This is a different mode than used with the normal ExchangeBytes routines.. Not sure what it's doing different)
*   `Network_STOP` => `Wireless_net_stop`
*   `Network_END` => `Wireless_net_end`
*   `SaveLimit` => `Unknown_save_limit`