### PR TITLE
party_struct constants and ExchangeBytes Size

### DIFF
--- a/constants/pokemon_data_constants.asm
+++ b/constants/pokemon_data_constants.asm
@@ -23,6 +23,37 @@ DEF BASE_TMHM        rb (NUM_TM_HM + 7) / 8
                      rb_skip
 DEF BASE_DATA_SIZE EQU _RS
 
+; party_struct members (see macros/wram.asm)
+rsreset
+DEF MON_SPECIES    rb
+DEF MON_HP         rw
+DEF MON_BOX_LEVEL  rb
+DEF MON_STATUS     rb
+DEF MON_TYPE       rw
+rsset MON_TYPE
+DEF MON_TYPE1      rb
+DEF MON_TYPE2      rb
+DEF MON_CATCH_RATE rb
+DEF MON_MOVES      rb NUM_MOVES
+DEF MON_OTID       rw
+DEF MON_EXP        rb 3
+DEF MON_HP_EXP     rw
+DEF MON_ATK_EXP    rw
+DEF MON_DEF_EXP    rw
+DEF MON_SPD_EXP    rw
+DEF MON_SPC_EXP    rw
+DEF MON_DVS        rw
+DEF MON_PP         rb NUM_MOVES
+DEF BOXMON_STRUCT_LENGTH EQU _RS
+DEF MON_LEVEL      rb
+DEF MON_STATS      rw NUM_STATS
+rsset MON_STATS
+DEF MON_MAXHP      rw
+DEF MON_ATK        rw
+DEF MON_DEF        rw
+DEF MON_SPD        rw
+DEF MON_SPC        rw
+DEF PARTYMON_STRUCT_LENGTH EQU _RS
 
 DEF PARTY_LENGTH EQU 6
 

--- a/constants/serial_constants.asm
+++ b/constants/serial_constants.asm
@@ -14,6 +14,10 @@ DEF SERIAL_NO_DATA_BYTE  EQU $FE
 ; signals the end of one part of a patch list (there are two parts) for player/enemy party data
 DEF SERIAL_PATCH_LIST_PART_TERMINATOR EQU $FF
 
+DEF SERIAL_PREAMBLE_LENGTH    EQU 6
+DEF SERIAL_RN_PREAMBLE_LENGTH EQU 7
+DEF SERIAL_RNS_LENGTH         EQU 10
+
 DEF LINK_STATE_NONE          EQU $00 ; not using link
 DEF LINK_STATE_IN_CABLE_CLUB EQU $01 ; in a cable club room (Colosseum or Trade Centre)
 DEF LINK_STATE_START_TRADE   EQU $02 ; pre-trade selection screen initialisation

--- a/engine/link/cable_club.asm
+++ b/engine/link/cable_club.asm
@@ -123,21 +123,21 @@ CableClub_DoBattleOrTradeAgain:
 	ldh [rIE], a
 	ld hl, wSerialRandomNumberListBlock
 	ld de, wSerialOtherGameboyRandomNumberListBlock
-	ld bc, $11
+	ld bc, SERIAL_RN_PREAMBLE_LENGTH + SERIAL_RNS_LENGTH
 	vc_hook Wireless_ExchangeBytes_RNG_state_unknown_Type5
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
 	ld hl, wSerialPlayerDataBlock
 	ld de, wSerialEnemyDataBlock
-	ld bc, $1a8
+	ld bc, SERIAL_PREAMBLE_LENGTH + NAME_LENGTH + 1 + PARTY_LENGTH + 1 + (PARTYMON_STRUCT_LENGTH + NAME_LENGTH * 2) * PARTY_LENGTH + 3
 	vc_hook Wireless_ExchangeBytes_party_structs
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
 	ld hl, wSerialPartyMonsPatchList
 	ld de, wSerialEnemyMonsPatchList
-	ld bc, $c8
+	ld bc, 200
 	vc_hook Wireless_ExchangeBytes_patch_lists
 	call Serial_ExchangeBytes
 	ld a, (1 << SERIAL) | (1 << TIMER) | (1 << VBLANK)


### PR DESCRIPTION
I noticed the sizes for the `Serial_ExchangeBytes` was not defined yet. So I pulled the definitions from pokecrystal's Gen2toGen1 code. I also added party\_struct constants to facilitate this. The party\_struct constants should be able to be used elsewhere as well.

Pokeyellow PR: https://github.com/pret/pokeyellow/pull/91