### PR TITLE
Document route 8 gate player facing bug

### DIFF
--- a/scripts/Route8Gate.asm
+++ b/scripts/Route8Gate.asm
@@ -27,6 +27,7 @@ Route8GateScript0:
 	ld hl, CoordsData_1e22c
 	call ArePlayerCoordsInArray
 	ret nc
+	; bug, player would already be facing left and should face up towards the guard.
 	ld a, PLAYER_DIR_LEFT
 	ld [wPlayerMovingDirection], a
 	xor a


### PR DESCRIPTION
Adds comment that the player faces left (which they should be facing already) when the Route 8 Gate guard stops the player, instead of facing towards the guard like in the other gates