### PR TITLE
Update comments related to Swift and Substitute checks

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -5368,10 +5368,10 @@ MoveHitTest:
 .swiftCheck
 	ld a, [de]
 	cp SWIFT_EFFECT
-	ret z ; Swift never misses (interestingly, Azure Heights lists this is a myth, but it appears to be true)
+	ret z ; Swift never misses due to code refactor that fixes accuracy bug from the Japanese versions
 	call CheckTargetSubstitute ; substitute check (note that this overwrites a)
 	jr z, .checkForDigOrFlyStatus
-; This code is buggy. It's supposed to prevent HP draining moves from working on substitutes.
+; The refactor made this code buggy. It's supposed to prevent HP draining moves from working on substitutes.
 ; Since CheckTargetSubstitute overwrites a with either $00 or $01, it never works.
 	cp DRAIN_HP_EFFECT
 	jp z, .moveMissed

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -5368,10 +5368,10 @@ MoveHitTest:
 .swiftCheck
 	ld a, [de]
 	cp SWIFT_EFFECT
-	ret z ; Swift never misses due to code refactor that fixes accuracy bug from the Japanese versions
+	ret z ; Swift never misses (this was fixed from the Japanese versions)
 	call CheckTargetSubstitute ; substitute check (note that this overwrites a)
 	jr z, .checkForDigOrFlyStatus
-; The refactor made this code buggy. It's supposed to prevent HP draining moves from working on substitutes.
+; The fix for Swift broke this code. It's supposed to prevent HP draining moves from working on Substitutes.
 ; Since CheckTargetSubstitute overwrites a with either $00 or $01, it never works.
 	cp DRAIN_HP_EFFECT
 	jp z, .moveMissed


### PR DESCRIPTION
In commit https://github.com/pret/pokered/commit/3eda472a22bc0ca68e56884d7a63020b68b7bcad (followed by a minor correction in https://github.com/pret/pokered/commit/187642e9051b000e5ad3d6de84697410c7022869), YamaArashi commented, among other things, that Azure Heights listed Swift's perfect accuracy as a myth. I can confirm that they updated [their list of myths](https://www.math.miami.edu/~jam/azure/compendium/myths.htm) and [page about Swift](https://www.math.miami.edu/~jam/azure/attacks/s/swift.htm) between April and June 2001 to explain that Swift is nonetheless affected by the general ~99.6% accuracy bug:
https://web.archive.org/web/20010414034401/http://www.math.miami.edu/~jam/azure/compendium/myths.htm
https://web.archive.org/web/20010603095011/https://www.math.miami.edu/~jam/azure/compendium/myths.htm
https://web.archive.org/web/20010420235927/https://www.math.miami.edu/~jam/azure/attacks/s/swift.htm
https://web.archive.org/web/20010622194211/http://www.math.miami.edu/~jam/azure/attacks/s/swift.htm

At the time of either the Azure Heights documentation or Yama's comments, the change to Swift's accuracy from the Japanese versions and its relation to Substitute and draining moves were likely unknown to most Western players and fans. It would take until 2016 for these to be thoroughly investigated and documented:
https://www.youtube.com/watch?v=Rrn4rtQXYQ0
https://web.archive.org/web/20200802034320/https://forums.glitchcity.info/index.php?topic=7522.0
https://pastebin.com/nJzRK337
https://www.youtube.com/watch?v=C6Hkos4vdsU

Thanks to these developments, Yama's comments on the Swift and Substitute checks can now be adjusted.