### PR TITLE
Add docker build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:jammy AS tools
+
+ENV BUILD_DIR /build
+
+ENV RGBDS_DIR ${BUILD_DIR}/rgbds
+ENV RGBDS_VER v0.5.2
+
+ENV POKE_DIR ${BUILD_DIR}/pokered
+ENV ROM_FILENAME=pokered.gbc
+
+# get required build tools
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        git \
+        libpng-tools \
+        libpng-dev \
+        # rgbds tools
+        bison \
+        libbison-dev \
+        cmake
+
+# build & install rgbds from src
+RUN mkdir -p ${RGBDS_DIR} && \
+    cd ${RGBDS_DIR} && \
+    git clone https://github.com/gbdev/rgbds . && \
+    git checkout ${RGBDS_VER} && \
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build && \
+    cmake --install build
+RUN rm -rf ${RGBDS_DIR}
+
+# build the gb rom from current src
+FROM tools AS build
+
+RUN mkdir -p ${POKE_DIR}
+COPY . ${POKE_DIR}
+
+RUN cd ${POKE_DIR} && make
+
+# copy the gb rom (so buildx can output it)
+#   example command: docker build --target output --output . .
+FROM build AS output
+
+COPY --from=build ${POKE_DIR}/${ROM_FILENAME} ${BUILD_DIR}

--- a/build-docker.bat
+++ b/build-docker.bat
@@ -1,0 +1,19 @@
+set srcDir=%~dp0
+set imgName=pokered-builder
+set romFilename=pokered/pokered.gbc
+
+@REM build rom inside docker
+docker build ^
+    --target build ^
+    -t %imgName% ^
+    %srcDir%
+
+@REM copy rom from docker image to source directory
+docker run ^
+    --name %imgName%-instance ^
+    %imgName% ^
+    true
+
+docker cp %imgName%-instance:/build/%romFilename% %srcDir%
+
+docker rm %imgName%-instance

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -ex
+
+srcDir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+imgName="pokered-builder"
+
+# build rom inside docker
+docker build \
+    --target build \
+    -t "${imgName}" \
+    "${srcDir}"
+
+# copy rom from docker image to source directory
+docker build \
+    --target output \
+    -t "${imgName}" \
+    --output \
+    "${srcDir}" \
+    "${srcDir}"


### PR DESCRIPTION
I have created a `Dockerfile` which will build a Pokered ROM inside a Ubuntu environment. I've found it very useful for building on any OS with minimal setup. Also added scripts for *nix and windows for building and copying out the ROM from Docker.

Build process:

- Install build tools for Pokered and RGBDS
- Build & install RGBDS
- Copy current Pokered source into image
- Build Pokered ROM
- Copy ROM out from final image