### PR TITLE
Document a small oversight

### DIFF
--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -1328,7 +1328,7 @@ CheckForTilePairCollisions::
 	jr .retry
 .currentTileMatchesFirstInPair
 	inc hl
-	ld a, [hl]
+	ld a, [hl] ; should be ld a, [hli]
 	cp c
 	jr z, .foundMatch
 	jr .tilePairCollisionLoop


### PR DESCRIPTION
This oversight causes strange issues if adding to the TilePairCollisionsLand or TilePairCollisionsWater arrays

Fixing it causes these arrays to perform as expected when adding new collisions to them - but it also improves game performance (removes 80-115 extra iterations of this tile collision loop) on each step on a tile in these arrays when in the cave or forest tilesets, or surfing on water tiles