### PR TITLE
Update core.asm: usage of EFFECTIVE for damage calculation

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3070,7 +3070,7 @@ ExecutePlayerMove:
 	ld [wMoveMissed], a
 	ld [wMonIsDisobedient], a
 	ld [wMoveDidntMiss], a
-	ld a, $a
+	ld a, EFFECTIVE
 	ld [wDamageMultipliers], a
 	ld a, [wActionResultOrTookBattleTurn]
 	and a ; has the player already used the turn (e.g. by using an item, trying to run or switching pokemon)
@@ -5596,7 +5596,7 @@ ExecuteEnemyMove:
 	xor a
 	ld [wMoveMissed], a
 	ld [wMoveDidntMiss], a
-	ld a, $a
+	ld a, EFFECTIVE
 	ld [wDamageMultipliers], a
 	call CheckEnemyStatusConditions
 	jr nz, .enemyHasNoSpecialConditions


### PR DESCRIPTION
Modified `ld a, $a` into `ld a, EFFECTIVE` so that if the type effectivnesses are modified, this is automatically reflected in the damage calculator.