### PR TITLE
Update install instructions for Arch Linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -101,10 +101,8 @@ Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building
 To install the software required for **pokered**:
 
 ```bash
-sudo pacman -S make gcc git
+sudo pacman -S make gcc git rgbds
 ```
-
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#pre-built) for Arch Linux to install **rgbds 0.6.1**.
 
 If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
 


### PR DESCRIPTION
RGBDS is now available in the official repos as community/rgbds