### PR TITLE
Make wCurrentBoxNum a byte instead of word

### DIFF
--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1896,7 +1896,9 @@ wBoxItems:: ds PC_ITEM_CAPACITY * 2 + 1
 
 ; bits 0-6: box number
 ; bit 7: whether the player has changed boxes before
-wCurrentBoxNum:: dw
+wCurrentBoxNum:: db
+
+	ds 1
 
 ; number of HOF teams
 wNumHoFTeams:: db


### PR DESCRIPTION
ref: https://github.com/pret/pokeyellow/pull/108