### PR TITLE
Improve comment about the "ED" tile bug

### DIFF
--- a/engine/menus/naming_screen.asm
+++ b/engine/menus/naming_screen.asm
@@ -326,7 +326,8 @@ DisplayNamingScreen:
 LoadEDTile:
 	ld de, ED_Tile
 	ld hl, vFont tile $70
-	ld bc, (ED_TileEnd - ED_Tile) / $8
+	; BUG: BANK("Home") should be BANK(ED_Tile), although it coincidentally works as-is
+	lb bc, BANK("Home"), (ED_TileEnd - ED_Tile) / $8
 	jp CopyVideoDataDouble
 
 ED_Tile:

--- a/engine/menus/naming_screen.asm
+++ b/engine/menus/naming_screen.asm
@@ -327,8 +327,6 @@ LoadEDTile:
 	ld de, ED_Tile
 	ld hl, vFont tile $70
 	ld bc, (ED_TileEnd - ED_Tile) / $8
-	; to fix the graphical bug on poor emulators
-	;lb bc, BANK(ED_Tile), (ED_TileEnd - ED_Tile) / $8
 	jp CopyVideoDataDouble
 
 ED_Tile:


### PR DESCRIPTION
This workaround was added as a comment in commit https://github.com/pret/pokered/commit/8a6d46f3d9ba4fb6939eb9ea9949f47aa8608d4a.