### PR TITLE
CI copy `.map` files to symbols branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,11 +66,12 @@ jobs:
         if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
         run: |
           cp -v *.sym symbols/
+          cp -v *.map symbols/
 
       - name: Update symbols
         if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
         uses: EndBug/add-and-commit@v9
         with:
           cwd: "./symbols"
-          add: "*.sym"
+          add: "*.sym *.map"
           message: ${{ github.event.commits[0].message }}


### PR DESCRIPTION
related to https://github.com/pret/pokecrystal/pull/1077

This PR simply modifies the CI to copy the `.map` files to the `symbols` branch as well. This has been done on pokecrystal and pokegold.