### PR TITLE
Fix wPlayerHPBarColor type

### DIFF
--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1018,14 +1018,14 @@ wOnSGB:: db
 wDefaultPaletteCommand:: db
 
 UNION
-wPlayerHPBarColor:: dw
+wPlayerHPBarColor:: db
 
 NEXTU
 ; species of the mon whose palette is used for the whole screen
 wWholeScreenPaletteMonSpecies:: db
+ENDU
 
 wEnemyHPBarColor:: db
-ENDU
 
 ; 0: green
 ; 1: yellow


### PR DESCRIPTION
`wPlayerHPBarColor` is only ever accessed as a single byte, not a word.

This still builds the exact same ROM.