### PR TITLE
Remove incorrect wTilePlayerStandingOn "unused?" comment

### DIFF
--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -104,7 +104,7 @@ OverworldLoopLessDelay::
 	bit 0, a
 	jr nz, .checkForOpponent
 	lda_coord 8, 9
-	ld [wTilePlayerStandingOn], a
+	ld [wTilePlayerStandingOn], a ; checked when using Surf for forbidden tile pairs
 	call DisplayTextID ; display either the start menu or the NPC/sign text
 	ld a, [wEnteringCableClub]
 	and a

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -104,7 +104,7 @@ OverworldLoopLessDelay::
 	bit 0, a
 	jr nz, .checkForOpponent
 	lda_coord 8, 9
-	ld [wTilePlayerStandingOn], a ; unused?
+	ld [wTilePlayerStandingOn]
 	call DisplayTextID ; display either the start menu or the NPC/sign text
 	ld a, [wEnteringCableClub]
 	and a

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -104,7 +104,7 @@ OverworldLoopLessDelay::
 	bit 0, a
 	jr nz, .checkForOpponent
 	lda_coord 8, 9
-	ld [wTilePlayerStandingOn]
+	ld [wTilePlayerStandingOn], a
 	call DisplayTextID ; display either the start menu or the NPC/sign text
 	ld a, [wEnteringCableClub]
 	and a


### PR DESCRIPTION
Without this line, you are told you can't surf here when trying to surf in caves from stairs, unless you have bumped into the water first.

`TilePairCollisionsWater` contains the entry `db CAVERN, $14, $05` which prevents surfing from raised cave ground tiles. If `wTilePlayerStandingOn` is not updated when the start menu is opened, it will be left at the previous tile, which will be the raised ground tile if you have just walked onto the stairs from one.