### PR TITLE
Correct StarterDex function comment

### DIFF
--- a/engine/events/starter_dex.asm
+++ b/engine/events/starter_dex.asm
@@ -1,4 +1,4 @@
-; this function temporarily makes the starters (and Ivysaur) seen
+; this function temporarily makes the starters (and Ivysaur) owned
 ; so that the full Pokedex information gets displayed in Oak's lab
 StarterDex:
 	ld a, 1 << (DEX_BULBASAUR - 1) | 1 << (DEX_IVYSAUR - 1) | 1 << (DEX_CHARMANDER - 1) | 1 << (DEX_SQUIRTLE - 1)


### PR DESCRIPTION
Corrects a comment to clarify that Pokémon need to be owned for the full Pokédex information to appear, rather than just seen.