### PR TITLE
Use constant in wram for hidden item flags

### DIFF
--- a/constants/item_constants.asm
+++ b/constants/item_constants.asm
@@ -215,3 +215,6 @@ DEF NUM_TM_HM EQU NUM_TMS + NUM_HMS
 ; These fit in 7 bytes, with one unused bit left over.
 DEF __tmhm_value__ = NUM_TM_HM + 1
 DEF UNUSED_TMNUM EQU __tmhm_value__
+
+DEF MAX_HIDDEN_ITEMS EQU 112
+DEF MAX_HIDDEN_COINS EQU 16

--- a/data/events/hidden_coins.asm
+++ b/data/events/hidden_coins.asm
@@ -3,6 +3,7 @@ MACRO hidden_coin
 ENDM
 
 HiddenCoinCoords:
+	table_width 3, HiddenCoinCoords
 	; map id, x, y
 	hidden_coin GAME_CORNER,  0,  8
 	hidden_coin GAME_CORNER,  1, 16
@@ -16,4 +17,5 @@ HiddenCoinCoords:
 	hidden_coin GAME_CORNER, 11,  7
 	hidden_coin GAME_CORNER, 15,  8
 	hidden_coin GAME_CORNER, 12, 15
+	assert_max_table_length MAX_HIDDEN_COINS
 	db -1 ; end

--- a/data/events/hidden_item_coords.asm
+++ b/data/events/hidden_item_coords.asm
@@ -3,6 +3,7 @@ MACRO hidden_item
 ENDM
 
 HiddenItemCoords:
+	table_width 3, HiddenItemCoords
 	; map id, x, y
 	hidden_item VIRIDIAN_FOREST,                1,  18
 	hidden_item VIRIDIAN_FOREST,               16,  42
@@ -58,4 +59,5 @@ HiddenItemCoords:
 	hidden_item VERMILION_CITY,                14,  11
 	hidden_item CERULEAN_CITY,                 15,   8
 	hidden_item ROUTE_4,                       40,   3
+	assert_max_table_length MAX_HIDDEN_ITEMS
 	db -1 ; end

--- a/macros/asserts.asm
+++ b/macros/asserts.asm
@@ -16,6 +16,12 @@ MACRO assert_table_length
 		"{CURRENT_TABLE_START}: expected {d:x} entries, each {d:CURRENT_TABLE_WIDTH} bytes"
 ENDM
 
+MACRO assert_max_table_length
+	DEF x = \1
+	ASSERT x * CURRENT_TABLE_WIDTH >= @ - {CURRENT_TABLE_START}, \
+		"{CURRENT_TABLE_START}: expected a maximum of {d:x} entries, each {d:CURRENT_TABLE_WIDTH} bytes"
+ENDM
+
 MACRO list_start
 	DEF list_index = 0
 	IF _NARG == 1

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -2042,9 +2042,9 @@ wGameProgressFlagsEnd::
 
 	ds 56
 
-wObtainedHiddenItemsFlags:: flag_array 112
+wObtainedHiddenItemsFlags:: flag_array MAX_HIDDEN_ITEMS
 
-wObtainedHiddenCoinsFlags:: flag_array 16
+wObtainedHiddenCoinsFlags:: flag_array MAX_HIDDEN_COINS
 
 ; $00 = walking
 ; $01 = biking


### PR DESCRIPTION
Prevents defining more hidden items than the wram flags have space for

Can define less than the maximum without complaints from the assert