### PR TITLE
Update to RGBDS 0.7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@master
         with:
           path: rgbds
-          ref: v0.6.1
+          ref: v0.7.0
           repository: gbdev/rgbds
 
       - name: Install rgbds

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,9 +42,9 @@ Run setup and leave the default settings. At the "**Select Packages**" step, cho
 
 Double click on the text that says "**Skip**" next to each package to select the most recent version to install.
 
-Then follow the [**rgbds** install instructions](https://rgbds.gbdev.io/install#pre-built) for Windows with Cygwin to install **rgbds 0.6.1**.
+Then follow the [**rgbds** install instructions](https://rgbds.gbdev.io/install#pre-built) for Windows with Cygwin to install **rgbds 0.7.0**.
 
-**Note:** If you already have an installed rgbds older than 0.6.0, you will need to update to 0.6.0 or 0.6.1. Ignore this if you have never installed rgbds before. If a version newer than 0.6.1 does not work, try downloading 0.6.1.
+**Note:** If you already have an installed rgbds older than 0.7.0, you will need to update to 0.7.0. Ignore this if you have never installed rgbds before. If a version newer than 0.7.0 does not work, try downloading 0.7.0.
 
 Now open the **Cygwin terminal** and enter the following commands.
 
@@ -67,7 +67,7 @@ Install [**Homebrew**](https://brew.sh/). Follow the official instructions.
 
 Open **Terminal** and prepare to enter commands.
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#pre-built) for macOS to install **rgbds 0.6.1**.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#pre-built) for macOS to install **rgbds 0.7.0**.
 
 Now you're ready to [build **pokered**](#build-pokered).
 
@@ -84,7 +84,7 @@ To install the software required for **pokered**:
 sudo apt-get install make gcc git
 ```
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.7.0** from source.
 
 ### OpenSUSE
 
@@ -94,7 +94,7 @@ To install the software required for **pokered**:
 sudo zypper install make gcc git
 ```
 
-Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
+Then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.7.0** from source.
 
 ### Arch Linux
 
@@ -104,7 +104,7 @@ To install the software required for **pokered**:
 sudo pacman -S make gcc git rgbds
 ```
 
-If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
+If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.7.0** from source.
 
 ### Termux
 
@@ -120,7 +120,7 @@ To install **rgbds**:
 sudo apt install rgbds
 ```
 
-If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
+If you want to compile and install **rgbds** yourself instead, then follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.7.0** from source.
 
 ### Other distros
 
@@ -131,7 +131,7 @@ If your distro is not listed here, try to find the required software in its repo
 - `git`
 - `rgbds`
 
-If `rgbds` is not available, you'll need to follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.6.1** from source.
+If `rgbds` is not available, you'll need to follow the [**rgbds** instructions](https://rgbds.gbdev.io/install#building-from-source) to build **rgbds 0.7.0** from source.
 
 Now you're ready to [build **pokered**](#build-pokered).
 
@@ -153,8 +153,8 @@ make
 
 ### Build with a local rgbds version
 
-If you have different projects that require different versions of `rgbds`, it might not be convenient to install rgbds 0.6.1 globally. Instead, you can put its files in a directory within pokered, such as `pokered/rgbds-0.6.1/`. Then specify it when you run `make`:
+If you have different projects that require different versions of `rgbds`, it might not be convenient to install rgbds 0.7.0 globally. Instead, you can put its files in a directory within pokered, such as `pokered/rgbds-0.7.0/`. Then specify it when you run `make`:
 
 ```bash
-make RGBDS=rgbds-0.6.1/
+make RGBDS=rgbds-0.7.0/
 ```

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ tools:
 	$(MAKE) -C tools/
 
 
-RGBASMFLAGS = -hL -Q8 -P includes.asm -Weverything -Wnumeric-string=2 -Wtruncation=1
+RGBASMFLAGS = -Q8 -P includes.asm -Weverything -Wnumeric-string=2 -Wtruncation=1
 # Create a sym/map for debug purposes if `make` run with `DEBUG=1`
 ifeq ($(DEBUG),1)
 RGBASMFLAGS += -E

--- a/constants/hardware_constants.asm
+++ b/constants/hardware_constants.asm
@@ -2,19 +2,6 @@
 
 DEF GBC EQU $11
 
-; memory map
-DEF VRAM_Begin  EQU $8000
-DEF VRAM_End    EQU $a000
-DEF SRAM_Begin  EQU $a000
-DEF SRAM_End    EQU $c000
-DEF WRAM0_Begin EQU $c000
-DEF WRAM0_End   EQU $d000
-DEF WRAM1_Begin EQU $d000
-DEF WRAM1_End   EQU $e000
-; hardware registers $ff00-$ff80 (see below)
-DEF HRAM_Begin  EQU $ff80
-DEF HRAM_End    EQU $ffff
-
 ; MBC1
 DEF MBC1SRamEnable      EQU $0000
 DEF MBC1RomBank         EQU $2000

--- a/engine/gfx/oam_dma.asm
+++ b/engine/gfx/oam_dma.asm
@@ -2,7 +2,7 @@ WriteDMACodeToHRAM::
 ; Since no other memory is available during OAM DMA,
 ; DMARoutine is copied to HRAM and executed there.
 	ld c, LOW(hDMARoutine)
-	ld b, DMARoutineEnd - DMARoutine
+	ld b, DMARoutine.End - DMARoutine
 	ld hl, DMARoutine
 .copy
 	ld a, [hli]
@@ -25,4 +25,4 @@ hDMARoutine::
 	jr nz, .wait
 	ret
 ENDL
-DMARoutineEnd:
+.End:

--- a/engine/menus/save.asm
+++ b/engine/menus/save.asm
@@ -705,7 +705,7 @@ ClearSAV:
 
 PadSRAM_FF:
 	ld [MBC1SRamBank], a
-	ld hl, SRAM_Begin
-	ld bc, SRAM_End - SRAM_Begin
+	ld hl, STARTOF(SRAM)
+	ld bc, SIZEOF(SRAM)
 	ld a, $ff
 	jp FillMemory

--- a/home/header.asm
+++ b/home/header.asm
@@ -79,3 +79,5 @@ Start::
 ; This makes sure it doesn't get used for anything else.
 
 	ds $0150 - @
+
+ENDSECTION

--- a/home/init.asm
+++ b/home/init.asm
@@ -41,8 +41,8 @@ DEF rLCDC_DEFAULT EQU %11100011
 
 	ld sp, wStack
 
-	ld hl, WRAM0_Begin
-	ld bc, WRAM1_End - WRAM0_Begin
+	ld hl, STARTOF(WRAM0)
+	ld bc, SIZEOF(WRAM0)
 .loop
 	ld [hl], 0
 	inc hl
@@ -53,8 +53,8 @@ DEF rLCDC_DEFAULT EQU %11100011
 
 	call ClearVram
 
-	ld hl, HRAM_Begin
-	ld bc, HRAM_End - HRAM_Begin
+	ld hl, STARTOF(HRAM)
+	ld bc, SIZEOF(HRAM)
 	call FillMemory
 
 	call ClearSprites
@@ -119,8 +119,8 @@ DEF rLCDC_DEFAULT EQU %11100011
 	jp PrepareTitleScreen
 
 ClearVram::
-	ld hl, VRAM_Begin
-	ld bc, VRAM_End - VRAM_Begin
+	ld hl, STARTOF(VRAM)
+	ld bc, SIZEOF(VRAM)
 	xor a
 	jp FillMemory
 

--- a/ram/hram.asm
+++ b/ram/hram.asm
@@ -397,3 +397,5 @@ hJoyInput:: db
 hDisableJoypadPolling:: db
 
 	ds 5
+
+ENDSECTION

--- a/ram/sram.asm
+++ b/ram/sram.asm
@@ -51,3 +51,5 @@ sBank3IndividualBoxChecksums:: ds 6
 ; All 12 boxes fit within 2 SRAM banks
 	ASSERT box_n == NUM_BOXES, \
 		"boxes: Expected {d:NUM_BOXES} total boxes, got {d:box_n}"
+
+ENDSECTION

--- a/ram/vram.asm
+++ b/ram/vram.asm
@@ -29,3 +29,5 @@ vTitleLogo::  ds $80 tiles
 vTitleLogo2:: ds 30 tiles
 
 ENDU
+
+ENDSECTION

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -2320,3 +2320,5 @@ SECTION "Stack", WRAM0
 ; the stack grows downward
 	ds $100 - 1
 wStack:: db
+
+ENDSECTION

--- a/rgbdscheck.asm
+++ b/rgbdscheck.asm
@@ -1,16 +1,6 @@
-MAJOR EQU 0
-MINOR EQU 6
-PATCH EQU 0
-
-WRONG_RGBDS EQUS "fail \"pokered requires rgbds v0.6.0 or newer.\""
-
 IF !DEF(__RGBDS_MAJOR__) || !DEF(__RGBDS_MINOR__) || !DEF(__RGBDS_PATCH__)
-	WRONG_RGBDS
-ELSE
-IF (__RGBDS_MAJOR__ < MAJOR) || \
-	(__RGBDS_MAJOR__ == MAJOR && __RGBDS_MINOR__ < MINOR) || \
-	(__RGBDS_MAJOR__ == MAJOR && __RGBDS_MINOR__ == MINOR && __RGBDS_PATCH__ < PATCH) || \
-	(__RGBDS_MAJOR__ == MAJOR && __RGBDS_MINOR__ == MINOR && __RGBDS_PATCH__ == PATCH && DEF(__RGBDS_RC__))
-	WRONG_RGBDS
+	fail "pokered requires rgbds v0.7.0 or newer."
 ENDC
+IF __RGBDS_MAJOR__ == 0 && __RGBDS_MINOR__ <  7
+	fail "pokered requires rgbds v0.7.0 or newer."
 ENDC


### PR DESCRIPTION
These new features are used from RGBDS 0.7.0:

- Use `SIZEOF` and `STARTOF` for section types, instead of `*RAM_Begin/End` constants
- Use `ENDSECTION` at the end of `INCLUDE`d files which start their own `SECTION`s
  - These can be found via:  
    ``for f in `git grep -Elw '^SECTION'`; do git grep -ho "INCLUDE \"$f\""; done``
- `DMARoutineEnd` can be `.End` since `ENDL` restores scope

Also rgbdscheck.asm is rewritten to be more robust with older versions of RGBDS. (We can't define constants since `DEF` is required in 0.7.0 but not yet defined in old enough versions; likewise for backslash line continuations, `ELIF`, etc.)

Note that the object file revision is still 9, so tools/unnamed.py did not need updating.