### PR TITLE
fixed a typo ("geting", with only one t) in pokedex_ratings.asm

### DIFF
--- a/text/pokedex_ratings.asm
+++ b/text/pokedex_ratings.asm
@@ -56,8 +56,9 @@ _DexRatingText_Own50To59::
 	done
 
 _DexRatingText_Own60To69::
-	text "Ho! This is geting"
-	line "even better!"
+	text "Ho! This is"
+	line "getting even" 
+	cont "better!"
 	done
 
 _DexRatingText_Own70To79::


### PR DESCRIPTION
Also re-ordered the text a bit, because simply adding the missing "t" would overflow the line.