### PR TITLE
Identify some unused WRAM variables

### DIFF
--- a/audio/engine_1.asm
+++ b/audio/engine_1.asm
@@ -1342,7 +1342,7 @@ Audio1_PlaySound::
 
 .playMusic
 	xor a
-	ld [wUnusedC000], a
+	ld [wUnusedMusicByte], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMusicTempo + 1], a
 	ld [wMusicWaveInstrument], a
@@ -1583,7 +1583,7 @@ Audio1_PlaySound::
 	ld a, $77
 	ldh [rNR50], a ; full volume
 	xor a
-	ld [wUnusedC000], a
+	ld [wUnusedMusicByte], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMuteAudioAndPauseMusic], a
 	ld [wMusicTempo + 1], a

--- a/audio/engine_2.asm
+++ b/audio/engine_2.asm
@@ -1405,7 +1405,7 @@ Audio2_PlaySound::
 
 .playMusic
 	xor a
-	ld [wUnusedC000], a
+	ld [wUnusedMusicByte], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMusicTempo + 1], a
 	ld [wMusicWaveInstrument], a
@@ -1646,7 +1646,7 @@ Audio2_PlaySound::
 	ld a, $77
 	ldh [rNR50], a ; full volume
 	xor a
-	ld [wUnusedC000], a
+	ld [wUnusedMusicByte], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMuteAudioAndPauseMusic], a
 	ld [wMusicTempo + 1], a

--- a/audio/engine_3.asm
+++ b/audio/engine_3.asm
@@ -1342,7 +1342,7 @@ Audio3_PlaySound::
 
 .playMusic
 	xor a
-	ld [wUnusedC000], a
+	ld [wUnusedMusicByte], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMusicTempo + 1], a
 	ld [wMusicWaveInstrument], a
@@ -1583,7 +1583,7 @@ Audio3_PlaySound::
 	ld a, $77
 	ldh [rNR50], a ; full volume
 	xor a
-	ld [wUnusedC000], a
+	ld [wUnusedMusicByte], a
 	ld [wDisableChannelOutputWhenSfxEnds], a
 	ld [wMuteAudioAndPauseMusic], a
 	ld [wMusicTempo + 1], a

--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -439,7 +439,7 @@ MoveAnimation:
 	call WaitForSoundToFinish
 	xor a
 	ld [wSubAnimSubEntryAddr], a
-	ld [wUnusedD09B], a
+	ld [wUnusedMoveAnimByte], a
 	ld [wSubAnimTransform], a
 	dec a ; NO_MOVE - 1
 	ld [wAnimSoundID], a
@@ -1125,12 +1125,12 @@ AnimationWaterDropletsEverywhere:
 	ld a, 16
 	ld [wBaseCoordY], a
 	ld a, 0
-	ld [wUnusedD08A], a
+	ld [wUnusedWaterDropletsByte], a
 	call _AnimationWaterDroplets
 	ld a, 24
 	ld [wBaseCoordY], a
 	ld a, 32
-	ld [wUnusedD08A], a
+	ld [wUnusedWaterDropletsByte], a
 	call _AnimationWaterDroplets
 	dec d
 	jr nz, .loop

--- a/engine/battle/misc.asm
+++ b/engine/battle/misc.asm
@@ -92,9 +92,9 @@ InitList:
 	ld a, h
 	ld [wListPointer + 1], a
 	ld a, e
-	ld [wUnusedCF8D], a
+	ld [wUnusedNamePointer], a
 	ld a, d
-	ld [wUnusedCF8D + 1], a
+	ld [wUnusedNamePointer + 1], a
 	ld bc, ItemPrices
 	ld a, c
 	ld [wItemPrices], a

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -740,7 +740,7 @@ ItemUseSurfboard:
 	ld a, b
 	ld [wSimulatedJoypadStatesEnd], a
 	xor a
-	ld [wUnusedCD39], a
+	ld [wUnusedSimulatedJoypadStatesMask], a
 	inc a
 	ld [wSimulatedJoypadStatesIndex], a
 	ret
@@ -1553,7 +1553,7 @@ ItemUseXAccuracy:
 ; The Card Key is handled in a different way.
 ItemUseCardKey:
 	xor a
-	ld [wUnusedD71F], a
+	ld [wUnusedCardKeyGateID], a
 	call GetTileAndCoordsInFrontOfPlayer
 	ld a, [GetTileAndCoordsInFrontOfPlayer]
 	cp $18
@@ -1585,7 +1585,7 @@ ItemUseCardKey:
 	cp e
 	jr nz, .nextEntry3
 	ld a, [hl]
-	ld [wUnusedD71F], a
+	ld [wUnusedCardKeyGateID], a
 	jr .done
 .nextEntry1
 	inc hl

--- a/engine/link/cable_club.asm
+++ b/engine/link/cable_club.asm
@@ -259,9 +259,9 @@ CableClub_DoBattleOrTradeAgain:
 	dec c
 	jr nz, .unpatchEnemyMonsLoop
 	ld a, LOW(wEnemyMonOT)
-	ld [wUnusedCF8D], a
+	ld [wUnusedNamePointer], a
 	ld a, HIGH(wEnemyMonOT)
-	ld [wUnusedCF8D + 1], a
+	ld [wUnusedNamePointer + 1], a
 	xor a
 	ld [wTradeCenterPointerTableIndex], a
 	ld a, SFX_STOP_ALL_MUSIC

--- a/engine/menus/main_menu.asm
+++ b/engine/menus/main_menu.asm
@@ -150,7 +150,7 @@ LinkMenu:
 	ld de, CableClubOptionsText
 	call PlaceString
 	xor a
-	ld [wUnusedCD37], a
+	ld [wUnusedLinkMenuByte], a
 	ld [wd72d], a
 	ld hl, wTopMenuItemY
 	ld a, $7

--- a/engine/menus/pokedex.asm
+++ b/engine/menus/pokedex.asm
@@ -36,7 +36,7 @@ ShowPokedexMenu:
 	ld [wCurrentMenuItem], a
 	ld [wLastMenuItem], a
 	ldh [hJoy7], a
-	ld [wUnusedCD3A], a
+	ld [wUnusedOverrideSimulatedJoypadStatesIndex], a
 	ld [wOverrideSimulatedJoypadStatesMask], a
 	pop af
 	ld [wListScrollOffset], a

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -29,7 +29,7 @@ HallOfFamePC:
 	ld c, 128
 	call DelayFrames
 	xor a
-	ld [wUnusedCD3D], a ; not read
+	ld [wUnusedCreditsByte], a ; not read
 	ld [wNumCreditsMonsDisplayed], a
 	jp Credits
 

--- a/engine/movie/oak_speech/init_player_data.asm
+++ b/engine/movie/oak_speech/init_player_data.asm
@@ -10,7 +10,7 @@ InitPlayerData2:
 	ld [wPlayerID + 1], a
 
 	ld a, $ff
-	ld [wUnusedD71B], a
+	ld [wUnusedPlayerDataByte], a
 
 	ld hl, wPartyCount
 	call InitializeEmptyList

--- a/engine/overworld/auto_movement.asm
+++ b/engine/overworld/auto_movement.asm
@@ -17,7 +17,7 @@ PlayerStepOutFromDoor::
 	ret
 .notStandingOnDoor
 	xor a
-	ld [wUnusedCD3A], a
+	ld [wUnusedOverrideSimulatedJoypadStatesIndex], a
 	ld [wSimulatedJoypadStatesIndex], a
 	ld [wSimulatedJoypadStatesEnd], a
 	ld hl, wd736
@@ -39,7 +39,7 @@ _EndNPCMovementScript::
 	ld [wNPCMovementScriptSpriteOffset], a
 	ld [wNPCMovementScriptPointerTableNum], a
 	ld [wNPCMovementScriptFunctionNum], a
-	ld [wUnusedCD3A], a
+	ld [wUnusedOverrideSimulatedJoypadStatesIndex], a
 	ld [wSimulatedJoypadStatesIndex], a
 	ld [wSimulatedJoypadStatesEnd], a
 	ret

--- a/engine/overworld/clear_variables.asm
+++ b/engine/overworld/clear_variables.asm
@@ -10,7 +10,7 @@ ClearVariablesOnEnterMap::
 	ldh [hJoyReleased], a
 	ldh [hJoyHeld], a
 	ld [wActionResultOrTookBattleTurn], a
-	ld [wUnusedD5A3], a
+	ld [wUnusedMapVariable], a
 	ld hl, wCardKeyDoorY
 	ld [hli], a
 	ld [hl], a

--- a/engine/overworld/movement.asm
+++ b/engine/overworld/movement.asm
@@ -179,7 +179,7 @@ UpdateNPCSprite:
 	res 0, [hl]
 	xor a
 	ld [wSimulatedJoypadStatesIndex], a
-	ld [wUnusedCD3A], a
+	ld [wUnusedOverrideSimulatedJoypadStatesIndex], a
 	ret
 .next
 	cp WALK

--- a/engine/pokemon/add_mon.asm
+++ b/engine/pokemon/add_mon.asm
@@ -92,7 +92,7 @@ _AddPartyMon::
 	ld hl, wPokedexOwned
 	call FlagAction
 	ld a, c ; whether the mon was already flagged as owned
-	ld [wUnusedD153], a ; not read
+	ld [wUnusedAlreadyOwnedFlag], a
 	ld a, [wd11e]
 	dec a
 	ld c, a

--- a/home/names2.asm
+++ b/home/names2.asm
@@ -88,9 +88,9 @@ GetName::
 	call CopyData
 .gotPtr
 	ld a, e
-	ld [wUnusedCF8D], a
+	ld [wUnusedNamePointer], a
 	ld a, d
-	ld [wUnusedCF8D + 1], a
+	ld [wUnusedNamePointer + 1], a
 	pop de
 	pop bc
 	pop hl

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -491,7 +491,7 @@ WarpFound2::
 	ld a, [wCurMap]
 	ld [wLastMap], a
 	ld a, [wCurMapWidth]
-	ld [wUnusedD366], a ; not read
+	ld [wUnusedLastMapWidth], a
 	ldh a, [hWarpDestinationMap]
 	ld [wCurMap], a
 	cp ROCK_TUNNEL_1F
@@ -1869,7 +1869,7 @@ JoypadOverworld::
 ; if done simulating button presses
 .doneSimulating
 	xor a
-	ld [wUnusedCD3A], a
+	ld [wUnusedOverrideSimulatedJoypadStatesIndex], a
 	ld [wSimulatedJoypadStatesIndex], a
 	ld [wSimulatedJoypadStatesEnd], a
 	ld [wJoyIgnore], a
@@ -2011,7 +2011,7 @@ LoadPlayerSpriteGraphicsCommon::
 LoadMapHeader::
 	farcall MarkTownVisitedAndLoadMissableObjects
 	ld a, [wCurMapTileset]
-	ld [wUnusedD119], a
+	ld [wUnusedCurMapTilesetCopy], a
 	ld a, [wCurMap]
 	call SwitchToMapRomBank
 	ld a, [wCurMapTileset]
@@ -2308,7 +2308,7 @@ LoadMapData::
 	ldh [hSCY], a
 	ldh [hSCX], a
 	ld [wWalkCounter], a
-	ld [wUnusedD119], a
+	ld [wUnusedCurMapTilesetCopy], a
 	ld [wWalkBikeSurfStateCopy], a
 	ld [wSpriteSetID], a
 	call LoadTextBoxTilePatterns

--- a/home/pathfinding.asm
+++ b/home/pathfinding.asm
@@ -40,7 +40,7 @@ MoveSprite_::
 	ld [wSimulatedJoypadStatesEnd], a
 	dec a
 	ld [wJoyIgnore], a
-	ld [wUnusedCD3A], a
+	ld [wUnusedOverrideSimulatedJoypadStatesIndex], a
 	ret
 
 ; divides [hDividend2] by [hDivisor2] and stores the quotient in [hQuotient2]

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1,6 +1,6 @@
 SECTION "Audio RAM", WRAM0
 
-wUnusedC000:: db
+wUnusedMusicByte:: db
 
 wSoundID:: db
 
@@ -567,20 +567,17 @@ ENDU
 	ds 1
 
 wNPCMovementDirections2Index::
-wUnusedCD37::
+wUnusedLinkMenuByte::
 ; number of items in wFilteredBagItems list
 wFilteredBagItemsCount:: db
 
 ; the next simulated joypad state is at wSimulatedJoypadStatesEnd plus this value minus 1
 ; 0 if the joypad state is not being simulated
 wSimulatedJoypadStatesIndex:: db
-
 ; written to but nothing ever reads it
-wUnusedCD39:: db
-
+wUnusedSimulatedJoypadStatesMask:: db
 ; written to but nothing ever reads it
-wUnusedCD3A:: db
-
+wUnusedOverrideSimulatedJoypadStatesIndex:: db
 ; mask indicating which real button presses can override simulated ones
 ; XXX is it ever not 0?
 wOverrideSimulatedJoypadStatesMask:: db
@@ -786,7 +783,7 @@ wBadgeOrFaceTiles:: ds NUM_BADGES + 1
 wTempObtainedBadgesBooleans:: ds NUM_BADGES
 
 NEXTU
-wUnusedCD3D:: db
+wUnusedCreditsByte:: db
 ; the number of credits mons that have been displayed so far
 wNumCreditsMonsDisplayed:: db
 
@@ -1065,7 +1062,7 @@ wItemList:: ds 16
 wListPointer:: dw
 
 ; used to store pointers, but never read
-wUnusedCF8D:: dw
+wUnusedNamePointer:: dw
 
 wItemPrices:: dw
 
@@ -1397,7 +1394,7 @@ wOptionsInitialized::
 wNewSlotMachineBallTile::
 ; how much to add to the X/Y coord
 wCoordAdjustmentAmount::
-wUnusedD08A::
+wUnusedWaterDropletsByte::
 	db
 
 wSlideMonDelay::
@@ -1442,7 +1439,7 @@ wPartyMenuAnimMonEnabled::
 ; non-zero when enabled. causes nest locations to blink on and off.
 ; the town selection cursor will blink regardless of what this value is
 wTownMapSpriteBlinkingEnabled::
-wUnusedD09B:: db
+wUnusedMoveAnimByte:: db
 
 ; current destination address in OAM for frame blocks (big endian)
 wFBDestAddr:: dw
@@ -1553,7 +1550,7 @@ wMoveNum:: db
 
 wMovesString:: ds 56
 
-wUnusedD119:: db
+wUnusedCurMapTilesetCopy:: db
 
 ; wWalkBikeSurfState is sometimes copied here, but it doesn't seem to be used for anything
 wWalkBikeSurfStateCopy:: db
@@ -1688,7 +1685,7 @@ wSerialPlayerDataBlock:: ; ds $1a8
 ; that case, this would be ESCAPE_ROPE.
 wPseudoItemID:: db
 
-wUnusedD153:: db
+wUnusedAlreadyOwnedFlag:: db
 
 	ds 2
 
@@ -1791,8 +1788,7 @@ wYBlockCoord:: db
 wXBlockCoord:: db
 
 wLastMap:: db
-
-wUnusedD366:: db
+wUnusedLastMapWidth:: db
 
 wCurMapHeader::
 wCurMapTileset:: db
@@ -1902,7 +1898,7 @@ wCurrentBoxNum:: db
 ; number of HOF teams
 wNumHoFTeams:: db
 
-wUnusedD5A3:: db
+wUnusedMapVariable:: db
 
 wPlayerCoins:: dw ; BCD
 
@@ -2084,7 +2080,8 @@ wLastBlackoutMap:: db
 ; destination map (for certain types of special warps, not ordinary walking)
 wDestinationMap:: db
 
-wUnusedD71B:: db
+; initialized to $ff, but nothing ever reads it
+wUnusedPlayerDataByte:: db
 
 ; used to store the tile in front of the boulder when trying to push a boulder
 ; also used to store the result of the collision check ($ff for a collision and $00 for no collision)
@@ -2096,7 +2093,7 @@ wDungeonWarpDestinationMap:: db
 ; which dungeon warp within the source map was used
 wWhichDungeonWarp:: db
 
-wUnusedD71F:: db
+wUnusedCardKeyGateID:: db
 
 	ds 8
 
@@ -2254,8 +2251,7 @@ wTrainerHeaderPtr:: dw
 
 ; the trainer the player must face after getting a wrong answer in the Cinnabar
 ; gym quiz
-wOpponentAfterWrongAnswer::
-wUnusedDA38:: db
+wOpponentAfterWrongAnswer:: db
 
 ; index of current map script, mostly used as index for function pointer array
 ; mostly copied from map-specific map script pointer and written back later

--- a/scripts/PokemonTower7F.asm
+++ b/scripts/PokemonTower7F.asm
@@ -58,7 +58,7 @@ PokemonTower7FHideNPCScript:
 	ld [wJoyIgnore], a
 	ld [wSpriteIndex], a
 	ld [wTrainerHeaderFlagBit], a
-	ld [wUnusedDA38], a
+	ld [wOpponentAfterWrongAnswer], a ; not used here; likely a mistake copied from maps/CinnabarGym.asm
 	ld a, SCRIPT_POKEMONTOWER7F_DEFAULT
 	ld [wPokemonTower7FCurScript], a
 	ld [wCurMapScript], a


### PR DESCRIPTION
These are mostly things that only get read/written in one or two places and can't really have meaningful names beyond "in what context do they appear". I'm trying to follow pokegold's precedents for 100% label completion even with unused/unidentifiable variables.