### PR TITLE
Identify `wcf91` as `wCurPartySpecies`, `wCurItem`, and `wCurListMenuItem`

### DIFF
--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -683,7 +683,7 @@ DoSpecialEffectByAnimationId:
 INCLUDE "data/battle_anims/special_effects.asm"
 
 DoBallTossSpecialEffects:
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp ULTRA_BALL + 1 ; is it a Master Ball or Ultra Ball?
 	jr nc, .skipFlashingEffect
 .flashingEffect ; do a flashing effect if it's Master Ball or Ultra Ball
@@ -2031,7 +2031,7 @@ ChangeMonPic:
 	and a
 	jr z, .playerTurn
 	ld a, [wChangeMonPicEnemyTurnSpecies]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd0b5], a
 	xor a
 	ld [wSpriteFlipped], a
@@ -2599,7 +2599,7 @@ TossBallAnimation:
 
 	ld hl, .PokeBallAnimations
 	; choose which toss animation to use
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp POKE_BALL
 	ld b, TOSS_ANIM
 	jr z, .done

--- a/engine/battle/common_text.asm
+++ b/engine/battle/common_text.asm
@@ -32,7 +32,7 @@ PrintBeginningBattleText:
 	ld b, SILPH_SCOPE
 	call IsItemInBag
 	ld a, [wEnemyMonSpecies2]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	cp RESTLESS_SOUL
 	jr z, .isMarowak
 	ld a, b

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -229,7 +229,7 @@ StartBattle:
 	ld b, 0
 	add hl, bc
 	ld a, [hl] ; species
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wBattleMonSpecies2], a
 	call LoadScreenTilesFromBuffer1
 	hlcoord 1, 5
@@ -1353,7 +1353,7 @@ EnemySendOutFirstMon:
 	add hl, bc
 	ld a, [hl]
 	ld [wEnemyMonSpecies2], a
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	call LoadEnemyMonData
 	ld hl, wEnemyMonHP
 	ld a, [hli]
@@ -1420,7 +1420,7 @@ EnemySendOutFirstMon:
 	ld hl, TrainerSentOutText
 	call PrintText
 	ld a, [wEnemyMonSpecies2]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd0b5], a
 	call GetMonHeader
 	ld de, vFrontPic
@@ -1759,7 +1759,7 @@ SendOutMon:
 	call PlayMoveAnimation
 	hlcoord 4, 11
 	predef AnimateSendingOutMon
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	call PlayCry
 	call PrintEmptyString
 	jp SaveScreenTilesToBuffer1
@@ -1841,7 +1841,7 @@ DrawPlayerHUDAndHPBar:
 	call PrintLevel
 .doNotPrintLevel
 	ld a, [wLoadedMonSpecies]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	hlcoord 10, 9
 	predef DrawHP
 	ld a, $1
@@ -2159,7 +2159,7 @@ DisplayBattleMenu::
 	jp LoadScreenTilesFromBuffer1 ; restore saved screen and return
 .throwSafariBallWasSelected
 	ld a, SAFARI_BALL
-	ld [wcf91], a
+	ld [wCurItem], a
 	jr UseBagItem
 
 .upperLeftMenuItemWasNotSelected ; a menu item other than the upper left item was selected
@@ -2184,7 +2184,7 @@ DisplayBattleMenu::
 
 ; bait was selected
 	ld a, SAFARI_BAIT
-	ld [wcf91], a
+	ld [wCurItem], a
 	jr UseBagItem
 
 BagWasSelected:
@@ -2236,7 +2236,7 @@ DisplayBagMenu:
 
 UseBagItem:
 	; either use an item from the bag or use a safari zone item
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	ld [wd11e], a
 	call GetItemName
 	call CopyToStringBuffer
@@ -2305,7 +2305,7 @@ PartyMenuOrRockOrRun:
 	jr nz, .partyMenuWasSelected
 ; safari battle
 	ld a, SAFARI_ROCK
-	ld [wcf91], a
+	ld [wCurItem], a
 	jp UseBagItem
 .partyMenuWasSelected
 	call LoadScreenTilesFromBuffer1
@@ -2379,7 +2379,7 @@ PartyMenuOrRockOrRun:
 	jr nz, .doEnemyMonAnimation
 ; enemy mon is not minimised
 	ld a, [wEnemyMonSpecies]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd0b5], a
 	call GetMonHeader
 	ld de, vFrontPic
@@ -6771,7 +6771,7 @@ InitBattle::
 
 InitOpponent:
 	ld a, [wCurOpponent]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wEnemyMonSpecies2], a
 	jr InitBattleCommon
 
@@ -6847,14 +6847,14 @@ InitWildBattle:
 	ld a, "T"
 	ld [hli], a
 	ld [hl], "@"
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	push af
 	ld a, MON_GHOST
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld de, vFrontPic
 	call LoadMonFrontSprite ; load ghost sprite
 	pop af
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	jr .spriteLoaded
 .isNoGhost
 	ld de, vFrontPic
@@ -7030,7 +7030,7 @@ LoadMonBackPic:
 ; Assumes the monster's attributes have
 ; been loaded with GetMonHeader.
 	ld a, [wBattleMonSpecies2]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	hlcoord 1, 5
 	ld b, 7
 	ld c, 8

--- a/engine/battle/misc.asm
+++ b/engine/battle/misc.asm
@@ -118,5 +118,5 @@ GetMonSpecies:
 	ld d, 0
 	add hl, de
 	ld a, [hl]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ret

--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -54,7 +54,7 @@ ReadTrainer:
 	ld a, [hli]
 	and a ; have we reached the end of the trainer data?
 	jr z, .FinishUp
-	ld [wcf91], a ; write species somewhere (XXX why?)
+	ld [wCurPartySpecies], a
 	ld a, ENEMY_PARTY_DATA
 	ld [wMonDataLocation], a
 	push hl
@@ -71,7 +71,7 @@ ReadTrainer:
 	jr z, .AddLoneMove
 	ld [wCurEnemyLevel], a
 	ld a, [hli]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld a, ENEMY_PARTY_DATA
 	ld [wMonDataLocation], a
 	push hl

--- a/engine/battle/wild_encounters.asm
+++ b/engine/battle/wild_encounters.asm
@@ -76,7 +76,7 @@ TryDoWildEncounter:
 	ld a, [hli]
 	ld [wCurEnemyLevel], a
 	ld a, [hl]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wEnemyMonSpecies2], a
 	ld a, [wRepelRemainingSteps]
 	and a

--- a/engine/debug/debug_menu.asm
+++ b/engine/debug/debug_menu.asm
@@ -98,7 +98,7 @@ TestBattle: ; unreferenced except in _DEBUG
 
 	; Give the player a level 20 Rhydon.
 	ld a, RHYDON
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld a, 20
 	ld [wCurEnemyLevel], a
 	xor a

--- a/engine/debug/debug_party.asm
+++ b/engine/debug/debug_party.asm
@@ -4,7 +4,7 @@ SetDebugNewGameParty: ; unreferenced except in _DEBUG
 	ld a, [de]
 	cp -1
 	ret z
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	inc de
 	ld a, [de]
 	ld [wCurEnemyLevel], a
@@ -97,7 +97,7 @@ IF DEF(_DEBUG)
 	ld a, [de]
 	cp -1
 	jr z, .items_end
-	ld [wcf91], a
+	ld [wCurItem], a
 	inc de
 	ld a, [de]
 	inc de

--- a/engine/events/give_pokemon.asm
+++ b/engine/events/give_pokemon.asm
@@ -13,7 +13,7 @@ _GivePokemon::
 ; add to box
 	xor a
 	ld [wEnemyBattleStatus3], a
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wEnemyMonSpecies2], a
 	callfar LoadEnemyMonData
 	call SetPokedexOwnedFlag
@@ -52,7 +52,7 @@ _GivePokemon::
 	ret
 
 SetPokedexOwnedFlag:
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	push af
 	ld [wd11e], a
 	predef IndexToPokedex

--- a/engine/events/hidden_objects/museum_fossils.asm
+++ b/engine/events/hidden_objects/museum_fossils.asm
@@ -1,6 +1,6 @@
 AerodactylFossil:
 	ld a, FOSSIL_AERODACTYL
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	call DisplayMonFrontSpriteInBox
 	call EnableAutoTextBoxDrawing
 	tx_pre AerodactylFossilText
@@ -12,7 +12,7 @@ AerodactylFossilText::
 
 KabutopsFossil:
 	ld a, FOSSIL_KABUTOPS
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	call DisplayMonFrontSpriteInBox
 	call EnableAutoTextBoxDrawing
 	tx_pre KabutopsFossilText
@@ -24,7 +24,6 @@ KabutopsFossilText::
 
 DisplayMonFrontSpriteInBox:
 ; Displays a pokemon's front sprite in a pop-up window.
-; [wcf91] = pokemon internal id number
 	ld a, 1
 	ldh [hAutoBGTransferEnabled], a
 	call Delay3
@@ -35,7 +34,7 @@ DisplayMonFrontSpriteInBox:
 	ld [wTextBoxID], a
 	call DisplayTextBoxID
 	call UpdateSprites
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd0b5], a
 	call GetMonHeader
 	ld de, vChars1 tile $31

--- a/engine/events/hidden_objects/route_15_binoculars.asm
+++ b/engine/events/hidden_objects/route_15_binoculars.asm
@@ -5,7 +5,7 @@ Route15GateLeftBinoculars:
 	call EnableAutoTextBoxDrawing
 	tx_pre Route15UpstairsBinocularsText
 	ld a, ARTICUNO
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	call PlayCry
 	jp DisplayMonFrontSpriteInBox
 

--- a/engine/events/in_game_trades.asm
+++ b/engine/events/in_game_trades.asm
@@ -99,7 +99,7 @@ InGameTrade_DoTrade:
 	jp c, .tradeFailed ; jump if the player didn't select a pokemon
 	ld a, [wInGameTradeGiveMonSpecies]
 	ld b, a
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	cp b
 	ld a, $2
 	jr nz, .tradeFailed ; jump if the selected mon's species is not the required one
@@ -128,7 +128,7 @@ InGameTrade_DoTrade:
 	pop af
 	ld [wWhichPokemon], a
 	ld a, [wInGameTradeReceiveMonSpecies]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	xor a
 	ld [wMonDataLocation], a ; not used
 	ld [wRemoveMonFromBox], a

--- a/engine/events/pokemart.asm
+++ b/engine/events/pokemart.asm
@@ -72,7 +72,7 @@ DisplayPokemartDialogue_::
 	ld a, [wIsKeyItem]
 	and a
 	jr nz, .unsellableItem
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	call IsItemHM
 	jr c, .unsellableItem
 	ld a, PRICEDITEMLISTMENU
@@ -156,7 +156,7 @@ DisplayPokemartDialogue_::
 	call DisplayChooseQuantityMenu
 	inc a
 	jr z, .buyMenuLoop ; if the player closed the choose quantity menu with the B button
-	ld a, [wcf91] ; item ID
+	ld a, [wCurItem]
 	ld [wd11e], a ; store item ID for GetItemName
 	call GetItemName
 	call CopyToStringBuffer

--- a/engine/events/prize_menu.asm
+++ b/engine/events/prize_menu.asm
@@ -222,7 +222,7 @@ HandlePrizeChoice:
 	jr .subtractCoins
 .giveMon
 	ld a, [wd11e]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	push af
 	call GetPrizeMonLevel
 	ld c, a
@@ -287,7 +287,7 @@ OhFineThenTextPtr:
 	text_end
 
 GetPrizeMonLevel:
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld b, a
 	ld hl, PrizeMonLevelDictionary
 .loop

--- a/engine/gfx/mon_icons.asm
+++ b/engine/gfx/mon_icons.asm
@@ -196,9 +196,9 @@ WriteMonPartySpriteOAMBySpecies:
 UnusedPartyMonSpriteFunction:
 ; This function is unused and doesn't appear to do anything useful. It looks
 ; like it may have been intended to load the tile patterns and OAM data for
-; the mon party sprite associated with the species in [wcf91].
+; the mon party sprite associated with the species in [wCurPartySpecies].
 ; However, its calculations are off and it loads garbage data.
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	call GetPartyMonSpriteID
 	push af
 	ld hl, vSprites tile $00

--- a/engine/gfx/palettes.asm
+++ b/engine/gfx/palettes.asm
@@ -69,7 +69,7 @@ SetPal_StatusScreen:
 	ld de, wPalPacket
 	ld bc, $10
 	call CopyData
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	cp NUM_POKEMON_INDEXES + 1
 	jr c, .pokemon
 	ld a, $1 ; not pokemon
@@ -97,7 +97,7 @@ SetPal_Pokedex:
 	ld de, wPalPacket
 	ld bc, $10
 	call CopyData
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	call DeterminePaletteIDOutOfBattle
 	ld hl, wPalPacket + 3
 	ld [hl], a

--- a/engine/items/inventory.asm
+++ b/engine/items/inventory.asm
@@ -1,7 +1,7 @@
 ; function to add an item (in varying quantities) to the player's bag or PC box
 ; INPUT:
 ; hl = address of inventory (either wNumBagItems or wNumBoxItems)
-; [wcf91] = item ID
+; [wCurItem] = item ID
 ; [wItemQuantity] = item quantity
 ; sets carry flag if successful, unsets carry flag if unsuccessful
 AddItemToInventory_::
@@ -30,7 +30,7 @@ AddItemToInventory_::
 .notAtEndOfInventory
 	ld a, [hli]
 	ld b, a ; b = ID of current item in table
-	ld a, [wcf91] ; a = ID of item being added
+	ld a, [wCurItem] ; a = ID of item being added
 	cp b ; does the current item in the table match the item being added?
 	jp z, .increaseItemQuantity ; if so, increase the item's quantity
 	inc hl
@@ -50,7 +50,7 @@ AddItemToInventory_::
 	ld c, a
 	ld b, 0
 	add hl, bc ; hl = address to store the item
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	ld [hli], a ; store item ID
 	ld a, [wItemQuantity]
 	ld [hli], a ; store item quantity

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -1,7 +1,7 @@
 UseItem_::
 	ld a, 1
 	ld [wActionResultOrTookBattleTurn], a ; initialise to success value
-	ld a, [wcf91] ;contains item_ID
+	ld a, [wCurItem]
 	cp HM01
 	jp nc, ItemUseTMHM
 	ld hl, ItemUsePtrTable
@@ -187,7 +187,7 @@ ItemUseBall:
 	ld b, a
 
 ; Get the item ID.
-	ld hl, wcf91
+	ld hl, wCurItem
 	ld a, [hl]
 
 ; The Master Ball always succeeds.
@@ -251,7 +251,7 @@ ItemUseBall:
 	call Multiply
 
 ; Determine BallFactor. It's 8 for Great Balls and 12 for the others.
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp GREAT_BALL
 	ld a, 12
 	jr nz, .skip1
@@ -336,7 +336,7 @@ ItemUseBall:
 ; Poké Ball:         BallFactor2 = 255
 ; Great Ball:        BallFactor2 = 200
 ; Ultra/Safari Ball: BallFactor2 = 150
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	ld b, 255
 	cp POKE_BALL
 	jr z, .skip4
@@ -428,11 +428,11 @@ ItemUseBall:
 	ld [wDamageMultipliers], a
 	ld a, [wWhichPokemon]
 	push af
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	push af
 	predef MoveAnimation
 	pop af
-	ld [wcf91], a
+	ld [wCurItem], a
 	pop af
 	ld [wWhichPokemon], a
 
@@ -490,15 +490,15 @@ ItemUseBall:
 	ld [hl], a
 
 .skip6
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	push af
 	ld a, [wEnemyMonSpecies2]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld a, [wEnemyMonLevel]
 	ld [wCurEnemyLevel], a
 	callfar LoadEnemyMonData
 	pop af
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	pop hl
 	pop af
 	ld [hld], a
@@ -509,7 +509,7 @@ ItemUseBall:
 	ld [hl], a
 	ld a, [wEnemyMonSpecies]
 	ld [wCapturedMonSpecies], a
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd11e], a
 	ld a, [wBattleType]
 	dec a ; is this the old man battle?
@@ -762,7 +762,7 @@ ItemUseEvoStone:
 	jp nz, ItemUseNotTime
 	ld a, [wWhichPokemon]
 	push af
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	ld [wEvoStoneItemID], a
 	push af
 	ld a, EVO_STONE_PARTY_MENU
@@ -773,7 +773,7 @@ ItemUseEvoStone:
 	pop bc
 	jr c, .canceledItemUse
 	ld a, b
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld a, $01
 	ld [wForceEvolution], a
 	ld a, SFX_HEAL_AILMENT
@@ -808,7 +808,7 @@ ItemUseMedicine:
 	jp z, .emptyParty
 	ld a, [wWhichPokemon]
 	push af
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	push af
 	ld a, USE_ITEM_PARTY_MENU
 	ld [wPartyMenuTypeOrMessageID], a
@@ -840,11 +840,11 @@ ItemUseMedicine:
 	ld a, [wWhichPokemon]
 	ld [wUsedItemOnWhichPokemon], a
 	ld d, a
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld e, a
 	ld [wd0b5], a
 	pop af
-	ld [wcf91], a
+	ld [wCurItem], a
 	pop af
 	ld [wWhichPokemon], a
 	ld a, [wPseudoItemID]
@@ -855,7 +855,7 @@ ItemUseMedicine:
 	cp d ; is the pokemon trying to use softboiled on itself?
 	jr z, ItemUseMedicine ; if so, force another choice
 .checkItemType
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp REVIVE
 	jr nc, .healHP ; if it's a Revive or Max Revive
 	cp FULL_HEAL
@@ -868,7 +868,7 @@ ItemUseMedicine:
 .cureStatusAilment
 	ld bc, wPartyMon1Status - wPartyMon1
 	add hl, bc ; hl now points to status
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	lb bc, ANTIDOTE_MSG, 1 << PSN
 	cp ANTIDOTE
 	jr z, .checkMonStatus
@@ -922,7 +922,7 @@ ItemUseMedicine:
 	or b
 	jr nz, .notFainted
 .fainted
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp REVIVE
 	jr z, .updateInBattleFaintedData
 	cp MAX_REVIVE
@@ -954,7 +954,7 @@ ItemUseMedicine:
 	pop hl
 	jr .compareCurrentHPToMaxHP
 .notFainted
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp REVIVE
 	jp z, .healingItemNoEffect
 	cp MAX_REVIVE
@@ -974,7 +974,7 @@ ItemUseMedicine:
 	pop hl
 	jr nz, .notFullHP
 .fullHP ; if the pokemon's current HP equals its max HP
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp FULL_RESTORE
 	jp nz, .healingItemNoEffect
 	inc hl
@@ -983,7 +983,7 @@ ItemUseMedicine:
 	and a ; does the pokemon have a status ailment?
 	jp z, .healingItemNoEffect
 	ld a, FULL_HEAL
-	ld [wcf91], a
+	ld [wCurItem], a
 	dec hl
 	dec hl
 	dec hl
@@ -1073,7 +1073,7 @@ ItemUseMedicine:
 	ld [hl], a
 	jr .addHealAmount
 .notUsingSoftboiled2
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp SODA_POP
 	ld b, 60 ; Soda Pop heal amount
 	jr z, .addHealAmount
@@ -1108,7 +1108,7 @@ ItemUseMedicine:
 	ld e, l ; de now points to current HP
 	ld hl, (wPartyMon1MaxHP + 1) - (wPartyMon1HP + 1)
 	add hl, de ; hl now points to max HP
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp REVIVE
 	jr z, .setCurrentHPToHalfMaxHP
 	ld a, [hld]
@@ -1120,7 +1120,7 @@ ItemUseMedicine:
 	ld a, [de]
 	sbc b
 	jr nc, .setCurrentHPToMaxHp ; if current HP exceeds max HP after healing
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp HYPER_POTION
 	jr c, .setCurrentHPToMaxHp ; if using a Full Restore or Max Potion
 	cp MAX_REVIVE
@@ -1150,7 +1150,7 @@ ItemUseMedicine:
 	ld [wHPBarNewHP], a
 	dec de
 .doneHealingPartyHP ; done updating the pokemon's current HP in the party data structure
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp FULL_RESTORE
 	jr nz, .updateInBattleData
 	ld bc, wPartyMon1Status - (wPartyMon1MaxHP + 1)
@@ -1169,7 +1169,7 @@ ItemUseMedicine:
 	ld [wBattleMonHP], a
 	ld a, [hld]
 	ld [wBattleMonHP + 1], a
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp FULL_RESTORE
 	jr nz, .calculateHPBarCoords
 	xor a
@@ -1194,7 +1194,7 @@ ItemUseMedicine:
 	call RemoveUsedItem
 	pop hl
 .skipRemovingItem
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp FULL_RESTORE
 	jr c, .playStatusAilmentCuringSound
 	cp FULL_HEAL
@@ -1212,7 +1212,7 @@ ItemUseMedicine:
 	ldh [hUILayoutFlags], a
 	ld a, REVIVE_MSG
 	ld [wPartyMenuTypeOrMessageID], a
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp REVIVE
 	jr z, .showHealingItemMessage
 	cp MAX_REVIVE
@@ -1267,7 +1267,7 @@ ItemUseMedicine:
 	call GetPartyMonName
 	pop de
 	pop hl
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp RARE_CANDY
 	jp z, .useRareCandy
 	push hl
@@ -1293,7 +1293,7 @@ ItemUseMedicine:
 	pop hl
 	call .recalculateStats
 	ld hl, VitaminStats
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	sub HP_UP - 1
 	ld c, a
 .statNameLoop ; loop to get the address of the name of the stat the vitamin increases
@@ -1357,7 +1357,7 @@ ItemUseMedicine:
 	pop hl
 	ld a, [wWhichPokemon]
 	push af
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	push af
 	push de
 	push hl
@@ -1412,7 +1412,7 @@ ItemUseMedicine:
 	ld a, $01
 	ld [wUpdateSpritesEnabled], a
 	pop af
-	ld [wcf91], a
+	ld [wCurItem], a
 	pop af
 	ld [wWhichPokemon], a
 	jp RemoveUsedItem
@@ -1650,7 +1650,7 @@ ItemUseXStat:
 	ld a, [hl]
 	push af ; save [wPlayerMoveEffect]
 	push hl
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	sub X_ATTACK - ATTACK_UP1_EFFECT
 	ld [hl], a ; store player move effect
 	call PrintItemUseTextAndRemoveItem
@@ -1954,7 +1954,7 @@ ItemUsePPUp:
 ItemUsePPRestore:
 	ld a, [wWhichPokemon]
 	push af
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	ld [wPPRestoreItem], a
 .chooseMon
 	xor a
@@ -2155,7 +2155,7 @@ ItemUseTMHM:
 	ld a, [wIsInBattle]
 	and a
 	jp nz, ItemUseNotTime
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	sub TM01 ; underflows below 0 for HM items (before TM items)
 	push af
 	jr nc, .skipAdding
@@ -2190,7 +2190,7 @@ ItemUseTMHM:
 .useMachine
 	ld a, [wWhichPokemon]
 	push af
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	push af
 .chooseMon
 	ld hl, wStringBuffer
@@ -2237,13 +2237,13 @@ ItemUseTMHM:
 	jr c, .chooseMon
 	predef LearnMove ; teach move
 	pop af
-	ld [wcf91], a
+	ld [wCurItem], a
 	pop af
 	ld [wWhichPokemon], a
 	ld a, b
 	and a
 	ret z
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	call IsItemHM
 	ret c
 	jp RemoveUsedItem
@@ -2538,14 +2538,14 @@ GetSelectedMoveOffset2:
 ; confirms the item toss and then tosses the item
 ; INPUT:
 ; hl = address of inventory (either wNumBagItems or wNumBoxItems)
-; [wcf91] = item ID
+; [wCurItem] = item ID
 ; [wWhichPokemon] = index of item within inventory
 ; [wItemQuantity] = quantity to toss
 ; OUTPUT:
 ; clears carry flag if the item is tossed, sets carry flag if not
 TossItem_::
 	push hl
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	call IsItemHM
 	pop hl
 	jr c, .tooImportantToToss
@@ -2556,7 +2556,7 @@ TossItem_::
 	and a
 	jr nz, .tooImportantToToss
 	push hl
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	ld [wd11e], a
 	call GetItemName
 	call CopyToStringBuffer
@@ -2576,7 +2576,7 @@ TossItem_::
 	push hl
 	ld a, [wWhichPokemon]
 	call RemoveItemFromInventory
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	ld [wd11e], a
 	call GetItemName
 	call CopyToStringBuffer
@@ -2607,7 +2607,7 @@ TooImportantToTossText:
 
 ; checks if an item is a key item
 ; INPUT:
-; [wcf91] = item ID
+; [wCurItem] = item ID
 ; OUTPUT:
 ; [wIsKeyItem] = result
 ; 00: item is not key item
@@ -2615,7 +2615,7 @@ TooImportantToTossText:
 IsKeyItem_::
 	ld a, $01
 	ld [wIsKeyItem], a
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp HM01 ; is the item an HM or TM?
 	jr nc, .checkIfItemIsHM
 ; if the item is not an HM or TM
@@ -2635,7 +2635,7 @@ IsKeyItem_::
 	and a
 	ret nz
 .checkIfItemIsHM
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	call IsItemHM
 	ret c
 	xor a
@@ -2649,7 +2649,7 @@ SendNewMonToBox:
 	ld a, [de]
 	inc a
 	ld [de], a
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd0b5], a
 	ld c, a
 .loop

--- a/engine/items/tm_prices.asm
+++ b/engine/items/tm_prices.asm
@@ -1,7 +1,7 @@
 GetMachinePrice::
-; Input:  [wcf91] = Item Id of a TM
+; Input:  [wCurItem] = Item ID of a TM
 ; Output: Stores the TM price at hItemPrice
-	ld a, [wcf91] ; a contains TM item id
+	ld a, [wCurItem]
 	sub TM01 ; underflows below 0 for HM items (before TM items)
 	ret c ; HMs are priceless
 	ld d, a

--- a/engine/items/tms.asm
+++ b/engine/items/tms.asm
@@ -1,6 +1,6 @@
-; tests if mon [wcf91] can learn move [wMoveNum]
+; tests if mon [wCurPartySpecies] can learn move [wMoveNum]
 CanLearnTM:
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd0b5], a
 	call GetMonHeader
 	ld hl, wMonHLearnset

--- a/engine/link/cable_club.asm
+++ b/engine/link/cable_club.asm
@@ -806,7 +806,7 @@ TradeCenter_Trade:
 	ld e, a
 	add hl, de
 	ld a, [hl]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld hl, wEnemyMons
 	ld a, c
 	ld bc, wEnemyMon2 - wEnemyMon1

--- a/engine/menus/league_pc.asm
+++ b/engine/menus/league_pc.asm
@@ -83,7 +83,7 @@ LeaguePCShowMon:
 	ld hl, wHallOfFame
 	ld a, [hli]
 	ld [wHoFMonSpecies], a
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd0b5], a
 	ld [wBattleMonSpecies2], a
 	ld [wWholeScreenPaletteMonSpecies], a

--- a/engine/menus/naming_screen.asm
+++ b/engine/menus/naming_screen.asm
@@ -8,7 +8,7 @@ AskName:
 	ld b, 4
 	ld c, 11
 	call z, ClearScreenArea ; only if in wild battle
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd11e], a
 	call GetMonName
 	ld hl, DoYouWantToNicknameText
@@ -457,7 +457,7 @@ PrintNamingText:
 	ld de, RivalsTextString
 	dec a
 	jr z, .notNickname
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wMonPartySpriteSpecies], a
 	push af
 	farcall WriteMonPartySpriteOAMBySpecies

--- a/engine/menus/players_pc.asm
+++ b/engine/menus/players_pc.asm
@@ -225,7 +225,7 @@ PlayerPCToss:
 	ld a, [wIsKeyItem]
 	and a
 	jr nz, .next
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	call IsItemHM
 	jr c, .next
 ; if it's not a key item, there can be more than one of the item

--- a/engine/menus/pokedex.asm
+++ b/engine/menus/pokedex.asm
@@ -404,7 +404,7 @@ ShowPokedexDataInternal:
 	call GBPalWhiteOut ; zero all palettes
 	call ClearScreen
 	ld a, [wd11e] ; pokemon ID
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	push af
 	ld b, SET_PAL_POKEDEX
 	call RunPaletteCommand
@@ -488,7 +488,7 @@ ShowPokedexDataInternal:
 	call IsPokemonBitSet
 	pop af
 	ld [wd11e], a
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd0b5], a
 	pop de
 
@@ -502,8 +502,8 @@ ShowPokedexDataInternal:
 	call GetMonHeader ; load pokemon picture location
 	hlcoord 1, 1
 	call LoadFlippedFrontSpriteByMonIndex ; draw pokemon picture
-	ld a, [wcf91]
-	call PlayCry ; play pokemon cry
+	ld a, [wCurPartySpecies]
+	call PlayCry
 
 	pop hl
 	pop de

--- a/engine/menus/start_sub_menus.asm
+++ b/engine/menus/start_sub_menus.asm
@@ -166,7 +166,7 @@ StartMenu_Pokemon::
 	res BIT_SURF_ALLOWED, [hl]
 	jp z, .loop
 	ld a, SURFBOARD
-	ld [wcf91], a
+	ld [wCurItem], a
 	ld [wPseudoItemID], a
 	call UseItem
 	ld a, [wActionResultOrTookBattleTurn]
@@ -194,7 +194,7 @@ StartMenu_Pokemon::
 	text_end
 .dig
 	ld a, ESCAPE_ROPE
-	ld [wcf91], a
+	ld [wCurItem], a
 	ld [wPseudoItemID], a
 	call UseItem
 	ld a, [wActionResultOrTookBattleTurn]
@@ -259,7 +259,7 @@ StartMenu_Pokemon::
 	ld a, [wPartyAndBillsPCSavedMenuItem]
 	push af
 	ld a, POTION
-	ld [wcf91], a
+	ld [wCurItem], a
 	ld [wPseudoItemID], a
 	call UseItem
 	pop af
@@ -337,7 +337,7 @@ StartMenu_Item::
 	call PlaceUnfilledArrowMenuCursor
 	xor a
 	ld [wMenuItemToSwap], a
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp BICYCLE
 	jp z, .useOrTossItem
 .notBicycle1
@@ -364,11 +364,11 @@ StartMenu_Item::
 	jr z, .useOrTossItem
 	jp ItemMenuLoop
 .useOrTossItem ; if the player made the choice to use or toss the item
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	ld [wd11e], a
 	call GetItemName
 	call CopyToStringBuffer
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp BICYCLE
 	jr nz, .notBicycle2
 	ld a, [wStatusFlags6]
@@ -383,14 +383,14 @@ StartMenu_Item::
 	jr nz, .tossItem
 ; use item
 	ld [wPseudoItemID], a ; a must be 0 due to above conditional jump
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	cp HM01
 	jr nc, .useItem_partyMenu
 	ld hl, UsableItems_CloseMenu
 	ld de, 1
 	call IsInArray
 	jr c, .useItem_closeMenu
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	ld hl, UsableItems_PartyMenu
 	ld de, 1
 	call IsInArray
@@ -426,7 +426,7 @@ StartMenu_Item::
 	ld a, [wIsKeyItem]
 	and a
 	jr nz, .skipAskingQuantity
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	call IsItemHM
 	jr c, .skipAskingQuantity
 	call DisplayChooseQuantityMenu

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -59,7 +59,7 @@ DisplayCreditsMon:
 	ld hl, CreditsMons
 	add hl, bc ; go that far in the list of monsters and get the next one
 	ld a, [hl]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd0b5], a
 	hlcoord 8, 6
 	call GetMonHeader

--- a/engine/movie/evolution.asm
+++ b/engine/movie/evolution.asm
@@ -2,7 +2,7 @@ EvolveMon:
 	push hl
 	push de
 	push bc
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	push af
 	ld a, [wd0b5]
 	push af
@@ -25,7 +25,7 @@ EvolveMon:
 	ld c, 0
 	call EvolutionSetWholeScreenPalette
 	ld a, [wEvoNewSpecies]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd0b5], a
 	call Evolution_LoadPic
 	ld de, vFrontPic
@@ -33,7 +33,7 @@ EvolveMon:
 	ld bc, 7 * 7
 	call CopyVideoData
 	ld a, [wEvoOldSpecies]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd0b5], a
 	call Evolution_LoadPic
 	ld a, $1
@@ -77,7 +77,7 @@ EvolveMon:
 	pop af
 	ld [wd0b5], a
 	pop af
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	pop bc
 	pop de
 	pop hl

--- a/engine/movie/hall_of_fame.asm
+++ b/engine/movie/hall_of_fame.asm
@@ -101,7 +101,7 @@ HoFShowMonOrPlayer:
 	ld a, $c0
 	ldh [hSCX], a
 	ld a, [wHoFMonSpecies]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd0b5], a
 	ld [wBattleMonSpecies2], a
 	ld [wWholeScreenPaletteMonSpecies], a

--- a/engine/movie/oak_speech/oak_speech.asm
+++ b/engine/movie/oak_speech/oak_speech.asm
@@ -52,7 +52,7 @@ OakSpeech:
 	predef InitPlayerData2
 	ld hl, wNumBoxItems
 	ld a, POTION
-	ld [wcf91], a
+	ld [wCurItem], a
 	ld a, 1
 	ld [wItemQuantity], a
 	call AddItemToInventory
@@ -74,7 +74,7 @@ OakSpeech:
 	call ClearScreen
 	ld a, NIDORINO
 	ld [wd0b5], a
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	call GetMonHeader
 	hlcoord 6, 4
 	call LoadFlippedFrontSpriteByMonIndex

--- a/engine/movie/title.asm
+++ b/engine/movie/title.asm
@@ -361,7 +361,7 @@ ClearBothBGMaps:
 	jp FillMemory
 
 LoadTitleMonSprite:
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd0b5], a
 	hlcoord 5, 10
 	call GetMonHeader

--- a/engine/movie/trade.asm
+++ b/engine/movie/trade.asm
@@ -727,7 +727,7 @@ Trade_CircleOAM3:
 
 ; a = species
 Trade_LoadMonSprite:
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd0b5], a
 	ld [wWholeScreenPaletteMonSpecies], a
 	ld b, SET_PAL_POKEMON_WHOLE_SCREEN

--- a/engine/overworld/field_move_messages.asm
+++ b/engine/overworld/field_move_messages.asm
@@ -9,7 +9,7 @@ PrintStrengthText:
 UsedStrengthText:
 	text_far _UsedStrengthText
 	text_asm
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	call PlayCry
 	call Delay3
 	jp TextScriptEnd

--- a/engine/pokemon/add_mon.asm
+++ b/engine/pokemon/add_mon.asm
@@ -21,7 +21,7 @@ _AddPartyMon::
 	jr nc, .noCarry
 	inc d
 .noCarry
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [de], a ; write species of new mon in party list
 	inc de
 	ld a, $ff ; terminator
@@ -64,7 +64,7 @@ _AddPartyMon::
 	ld e, l
 	ld d, h
 	push hl
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd0b5], a
 	call GetMonHeader
 	ld hl, wMonHeader
@@ -80,7 +80,7 @@ _AddPartyMon::
 	jr nz, .next4
 
 ; If the mon is being added to the player's party, update the pokedex.
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd11e], a
 	push de
 	predef IndexToPokedex
@@ -275,7 +275,7 @@ AddPartyMon_WriteMovePP:
 	jr nz, .pploop ; there are still moves to read
 	ret
 
-; adds enemy mon [wcf91] (at position [wWhichPokemon] in enemy list) to own party
+; adds enemy mon [wCurPartySpecies] (at position [wWhichPokemon] in enemy list) to own party
 ; used in the cable club trade center
 _AddEnemyMonToPlayerParty::
 	ld hl, wPartyCount
@@ -288,7 +288,7 @@ _AddEnemyMonToPlayerParty::
 	ld c, a
 	ld b, $0
 	add hl, bc
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [hli], a      ; add mon as last list entry
 	ld [hl], $ff     ; write new sentinel
 	ld hl, wPartyMons
@@ -322,7 +322,7 @@ _AddEnemyMonToPlayerParty::
 	call SkipFixedLengthTextEntries
 	ld bc, NAME_LENGTH
 	call CopyData    ; write new mon's nickname (from an enemy mon)
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd11e], a
 	predef IndexToPokedex
 	ld a, [wd11e]
@@ -371,7 +371,7 @@ _MoveMon::
 	cp DAYCARE_TO_PARTY
 	ld a, [wDayCareMon]
 	jr z, .copySpecies
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 .copySpecies
 	ld [hli], a          ; write new mon ID
 	ld [hl], $ff         ; write new sentinel

--- a/engine/pokemon/bills_pc.asm
+++ b/engine/pokemon/bills_pc.asm
@@ -224,7 +224,7 @@ BillsPCDeposit:
 	jp c, BillsPCMenu
 	call DisplayDepositWithdrawMenu
 	jp nc, BillsPCMenu
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	call GetCryData
 	call PlaySoundWaitForCurrent
 	ld a, PARTY_TO_BOX
@@ -276,7 +276,7 @@ BillsPCWithdraw:
 	ld a, [wWhichPokemon]
 	ld hl, wBoxMonNicks
 	call GetPartyMonName
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	call GetCryData
 	call PlaySoundWaitForCurrent
 	xor a ; BOX_TO_PARTY
@@ -311,7 +311,7 @@ BillsPCRelease:
 	ld [wRemoveMonFromBox], a
 	call RemovePokemon
 	call WaitForSoundToFinish
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	call PlayCry
 	ld hl, MonWasReleasedText
 	call PrintText

--- a/engine/pokemon/evos_moves.asm
+++ b/engine/pokemon/evos_moves.asm
@@ -53,13 +53,13 @@ Evolution_PartyMonLoop: ; loop over party mons
 	ld h, [hl]
 	ld l, a
 	push hl
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	push af
 	xor a ; PLAYER_PARTY_DATA
 	ld [wMonDataLocation], a
 	call LoadMonData
 	pop af
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	pop hl
 
 .evoEntryLoop ; loop over evolution entries
@@ -95,7 +95,7 @@ Evolution_PartyMonLoop: ; loop over party mons
 .checkItemEvo
 	ld a, [hli]
 	ld b, a ; evolution item
-	ld a, [wcf91] ; this is supposed to be the last item used, but it is also used to hold species numbers
+	ld a, [wCurItem]
 	cp b ; was the evolution item in this entry used?
 	jp nz, .nextEvoEntry1 ; if not, go to the next evolution entry
 .checkLevel
@@ -320,7 +320,7 @@ Evolution_ReloadTilesetTilePatterns:
 LearnMoveFromLevelUp:
 	ld hl, EvosMovesPointerTable
 	ld a, [wd11e] ; species
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	dec a
 	ld bc, 0
 	ld hl, EvosMovesPointerTable
@@ -371,7 +371,7 @@ LearnMoveFromLevelUp:
 	call CopyToStringBuffer
 	predef LearnMove
 .done
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd11e], a
 	ret
 
@@ -384,7 +384,7 @@ WriteMonMoves:
 	push bc
 	ld hl, EvosMovesPointerTable
 	ld b, 0
-	ld a, [wcf91]  ; cur mon ID
+	ld a, [wCurPartySpecies]
 	dec a
 	add a
 	rl b

--- a/engine/pokemon/load_mon_data.asm
+++ b/engine/pokemon/load_mon_data.asm
@@ -4,11 +4,11 @@ LoadMonData_::
 ;  1: enemymon
 ;  2: boxmon
 ;  3: daycaremon
-; Return monster id at wcf91 and its data at wLoadedMon.
+; Return monster id at wCurPartySpecies and its data at wLoadedMon.
 ; Also load base stats at wMonHeader for convenience.
 
 	ld a, [wDayCareMonSpecies]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld a, [wMonDataLocation]
 	cp DAYCARE_DATA
 	jr z, .GetMonHeader
@@ -18,7 +18,7 @@ LoadMonData_::
 	callfar GetMonSpecies
 
 .GetMonHeader
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd0b5], a ; input for GetMonHeader
 	call GetMonHeader
 

--- a/engine/pokemon/status_screen.asm
+++ b/engine/pokemon/status_screen.asm
@@ -170,9 +170,9 @@ StatusScreen:
 	call GBPalNormal
 	hlcoord 1, 0
 	call LoadFlippedFrontSpriteByMonIndex ; draw Pokémon picture
-	ld a, [wcf91]
-	call PlayCry ; play Pokémon cry
-	call WaitForTextScrollButtonPress ; wait for button
+	ld a, [wCurPartySpecies]
+	call PlayCry
+	call WaitForTextScrollButtonPress
 	pop af
 	ldh [hTileAnimations], a
 	ret

--- a/home/give.asm
+++ b/home/give.asm
@@ -4,7 +4,7 @@ GiveItem::
 ; Return carry on success.
 	ld a, b
 	ld [wd11e], a
-	ld [wcf91], a
+	ld [wCurItem], a
 	ld a, c
 	ld [wItemQuantity], a
 	ld hl, wNumBagItems
@@ -18,7 +18,7 @@ GiveItem::
 GivePokemon::
 ; Give the player monster b at level c.
 	ld a, b
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld a, c
 	ld [wCurEnemyLevel], a
 	xor a ; PLAYER_PARTY_DATA

--- a/home/inventory.asm
+++ b/home/inventory.asm
@@ -28,7 +28,7 @@ RemoveItemFromInventory::
 ; function to add an item (in varying quantities) to the player's bag or PC box
 ; INPUT:
 ; HL = address of inventory (either wNumBagItems or wNumBoxItems)
-; [wcf91] = item ID
+; [wCurItem] = item ID
 ; [wItemQuantity] = item quantity
 ; sets carry flag if successful, unsets carry flag if unsuccessful
 AddItemToInventory::

--- a/home/item.asm
+++ b/home/item.asm
@@ -1,7 +1,7 @@
 ; uses an item
 ; UseItem is used with dummy items to perform certain other functions as well
 ; INPUT:
-; [wcf91] = item ID
+; [wCurItem] = item ID
 ; OUTPUT:
 ; [wActionResultOrTookBattleTurn] = success
 ; 00: unsuccessful
@@ -13,7 +13,7 @@ UseItem::
 ; confirms the item toss and then tosses the item
 ; INPUT:
 ; hl = address of inventory (either wNumBagItems or wNumBoxItems)
-; [wcf91] = item ID
+; [wCurItem] = item ID
 ; [wWhichPokemon] = index of item within inventory
 ; [wItemQuantity] = quantity to toss
 ; OUTPUT:
@@ -33,7 +33,7 @@ TossItem::
 
 ; checks if an item is a key item
 ; INPUT:
-; [wcf91] = item ID
+; [wCurItem] = item ID
 ; OUTPUT:
 ; [wIsKeyItem] = result
 ; 00: item is not key item

--- a/home/item_price.asm
+++ b/home/item_price.asm
@@ -1,6 +1,6 @@
 GetItemPrice::
 ; Stores item's price as BCD at hItemPrice (3 bytes)
-; Input: [wcf91] = item id
+; Input: [wCurItem] = item id
 	ldh a, [hLoadedROMBank]
 	push af
 	ld a, [wListMenuID]
@@ -15,7 +15,7 @@ GetItemPrice::
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [wcf91] ; a contains item id
+	ld a, [wCurItem]
 	cp HM01
 	jr nc, .getTMPrice
 	ld bc, $3

--- a/home/list_menu.asm
+++ b/home/list_menu.asm
@@ -124,28 +124,30 @@ DisplayListMenuIDLoop::
 	ld b, 0
 	add hl, bc
 	ld a, [hl]
-	ld [wcf91], a
+	ld [wCurListMenuItem], a
 	ld a, [wListMenuID]
 	and a ; PCPOKEMONLISTMENU?
 	jr z, .pokemonList
+; if it's an item menu
+	assert wCurListMenuItem == wCurItem
 	push hl
 	call GetItemPrice
 	pop hl
 	ld a, [wListMenuID]
 	cp ITEMLISTMENU
 	jr nz, .skipGettingQuantity
-; if it's an item menu
 	inc hl
 	ld a, [hl] ; a = item quantity
 	ld [wMaxItemQuantity], a
 .skipGettingQuantity
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	ld [wd0b5], a
 	ld a, BANK(ItemNames)
 	ld [wPredefBank], a
 	call GetName
 	jr .storeChosenEntry
 .pokemonList
+	assert wCurListMenuItem == wCurPartySpecies
 	ld hl, wPartyCount
 	ld a, [wListPointer]
 	cp l ; is it a list of party pokemon or box pokemon?
@@ -413,8 +415,8 @@ PrintListMenuEntries::
 	push hl
 	ld a, [de]
 	ld de, ItemPrices
-	ld [wcf91], a
-	call GetItemPrice ; get price
+	ld [wCurItem], a
+	call GetItemPrice
 	pop hl
 	ld bc, SCREEN_WIDTH + 5 ; 1 row down and 5 columns right
 	add hl, bc
@@ -468,7 +470,7 @@ PrintListMenuEntries::
 	jr nz, .nextListEntry
 .printItemQuantity
 	ld a, [wd11e]
-	ld [wcf91], a
+	ld [wCurItem], a
 	call IsKeyItem ; check if item is unsellable
 	ld a, [wIsKeyItem]
 	and a ; is the item unsellable?

--- a/home/pics.asm
+++ b/home/pics.asm
@@ -16,7 +16,7 @@ UncompressMonSprite::
 ; $4A ≤ index < $74:       bank $B ("Pics 3")
 ; $74 ≤ index < $99:       bank $C ("Pics 4")
 ; $99 ≤ index:             bank $D ("Pics 5")
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld b, a
 	cp MEW
 	ld a, BANK(MewPicFront)

--- a/home/pokemon.asm
+++ b/home/pokemon.asm
@@ -77,7 +77,7 @@ DrawHPBar::
 ; 02: current box
 ; 03: daycare
 ; OUTPUT:
-; [wcf91] = pokemon ID
+; [wCurPartySpecies] = pokemon ID
 ; wLoadedMon = base address of pokemon data
 ; wMonHeader = base address of base stats
 LoadMonData::
@@ -101,7 +101,7 @@ LoadFrontSpriteByMonIndex::
 	push hl
 	ld a, [wd11e]
 	push af
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd11e], a
 	predef IndexToPokedex
 	ld hl, wd11e
@@ -115,7 +115,7 @@ LoadFrontSpriteByMonIndex::
 	jr c, .validDexNumber   ; dex >#151 invalid
 .invalidDexNumber
 	ld a, RHYDON ; $1
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ret
 .validDexNumber
 	push hl
@@ -264,7 +264,7 @@ HandlePartyMenuInput::
 	ld c, a
 	add hl, bc
 	ld a, [hl]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wBattleMonSpecies2], a
 	call BankswitchBack
 	and a

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1073,7 +1073,10 @@ wUnusedNamePointer:: dw
 
 wItemPrices:: dw
 
-wcf91:: db ; used with a lot of things (too much to list here)
+wCurPartySpecies::
+wCurItem::
+wCurListMenuItem::
+	db
 
 ; which pokemon you selected
 wWhichPokemon:: db

--- a/scripts/CeruleanBadgeHouse.asm
+++ b/scripts/CeruleanBadgeHouse.asm
@@ -34,7 +34,7 @@ CeruleanBadgeHouseMiddleAgedManText:
 	call DisplayListMenuID
 	jr c, .done
 	ld hl, CeruleanBadgeHouseBadgeTextPointers
-	ld a, [wcf91]
+	ld a, [wCurItem]
 	sub BOULDERBADGE
 	add a
 	ld d, $0

--- a/scripts/Daycare.asm
+++ b/scripts/Daycare.asm
@@ -54,7 +54,7 @@ DaycareGentlemanText:
 	xor a
 	ld [wRemoveMonFromBox], a
 	call RemovePokemon
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	call PlayCry
 	ld hl, .ComeSeeMeInAWhileText
 	jp .done
@@ -169,7 +169,7 @@ DaycareGentlemanText:
 	ld [wMoveMonType], a
 	call MoveMon
 	ld a, [wDayCareMonSpecies]
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld a, [wPartyCount]
 	dec a
 	push af
@@ -198,7 +198,7 @@ DaycareGentlemanText:
 	ld a, [hl]
 	ld [de], a
 
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	call PlayCry
 	ld hl, .GotMonBackText
 	jr .done

--- a/scripts/FightingDojo.asm
+++ b/scripts/FightingDojo.asm
@@ -239,7 +239,7 @@ FightingDojoHitmonleePokeBallText:
 	ld a, [wCurrentMenuItem]
 	and a
 	jr nz, .done
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld b, a
 	ld c, 30
 	call GivePokemon
@@ -273,7 +273,7 @@ FightingDojoHitmonchanPokeBallText:
 	ld a, [wCurrentMenuItem]
 	and a
 	jr nz, .done
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld b, a
 	ld c, 30
 	call GivePokemon

--- a/scripts/OaksLab.asm
+++ b/scripts/OaksLab.asm
@@ -321,7 +321,7 @@ OaksLabRivalChoosesStarterScript:
 	call Delay3
 	ld a, [wRivalStarterTemp]
 	ld [wRivalStarter], a
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd11e], a
 	call GetMonName
 	ld a, OAKSLAB_RIVAL
@@ -824,7 +824,7 @@ OaksLabBulbasaurPokeBallText:
 	ld b, OAKSLAB_BULBASAUR_POKE_BALL
 
 OaksLabSelectedPokeBallScript:
-	ld [wcf91], a
+	ld [wCurPartySpecies], a
 	ld [wd11e], a
 	ld a, b
 	ld [wSpriteIndex], a
@@ -897,7 +897,7 @@ OaksLabMonChoiceMenu:
 	ld a, [wCurrentMenuItem]
 	and a
 	jr nz, OaksLabMonChoiceEnd
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wPlayerStarter], a
 	ld [wd11e], a
 	call GetMonName
@@ -926,7 +926,7 @@ OaksLabMonChoiceMenu:
 	ld [wMonDataLocation], a
 	ld a, 5
 	ld [wCurEnemyLevel], a
-	ld a, [wcf91]
+	ld a, [wCurPartySpecies]
 	ld [wd11e], a
 	call AddPartyMon
 	ld hl, wStatusFlags4


### PR DESCRIPTION
`wcf91` corresponds to these bytes in pokegold:

```asm
wCurItem:: db
wCurItemQuantity::
wMartItemID::
	db

wCurPartySpecies:: db
```

(Note the labels after it, e.g. pokered `wWhichPokemon` corresponds to pokegold `wCurPartyMon`, `wHPBarType` to `wWhichHPBar`, `wRemoveMonFromBox` to `wPokemonWithdrawDepositParameter`, etc.)

Unlike in pokegold, the species ID and item ID share a byte. This is important for `DisplayListMenuID` and probably elsewhere.