### PR TITLE
Fix comment about auto text box drawing

### DIFF
--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -976,7 +976,7 @@ wBoughtOrSoldItemInMart:: db
 ; $02 - draw
 wBattleResult:: db
 
-; bit 0: if set, DisplayTextID automatically draws a text box
+; bit 0: if set, prevents DisplayTextID from automatically drawing a text box
 wAutoTextBoxDrawingControl:: db
 
 ; used in some overworld scripts to vary scripted movement


### PR DESCRIPTION
Actually, setting bit 0 of this byte disables auto text box drawing on calling DisplayTextID. See https://github.com/pret/pokered/blob/6e3ab0a9e97ff14123ac65f56cb4b4ddab45b695/engine/menus/display_text_id_init.asm#L7