### PR TITLE
Identify remaining uses of `wd0b5` and `wd11e`

### DIFF
--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -2032,7 +2032,7 @@ ChangeMonPic:
 	jr z, .playerTurn
 	ld a, [wChangeMonPicEnemyTurnSpecies]
 	ld [wCurPartySpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	xor a
 	ld [wSpriteFlipped], a
 	call GetMonHeader
@@ -2044,7 +2044,7 @@ ChangeMonPic:
 	push af
 	ld a, [wChangeMonPicPlayerTurnSpecies]
 	ld [wBattleMonSpecies2], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	predef LoadMonBackPic
 	xor a ; TILEMAP_MON_PIC

--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -701,7 +701,7 @@ DoBallTossSpecialEffects:
 	ld a, [wIsInBattle]
 	cp 2 ; is it a trainer battle?
 	jr z, .isTrainerBattle
-	ld a, [wd11e]
+	ld a, [wPokeBallAnimData]
 	cp $10 ; is the enemy pokemon the Ghost Marowak?
 	ret nz
 ; if the enemy pokemon is the Ghost Marowak, make it dodge during the last 3 frames

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -2237,7 +2237,7 @@ DisplayBagMenu:
 UseBagItem:
 	; either use an item from the bag or use a safari zone item
 	ld a, [wCurItem]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	call CopyToStringBuffer
 	xor a
@@ -3564,7 +3564,7 @@ CheckPlayerStatusConditions:
 	bit USING_RAGE, a ; is mon using rage?
 	jp z, .checkPlayerStatusConditionsDone ; if we made it this far, mon can move normally this turn
 	ld a, RAGE
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMoveName
 	call CopyToStringBuffer
 	xor a
@@ -3654,7 +3654,7 @@ PrintMoveIsDisabledText:
 	res CHARGING_UP, a ; end the pokemon's
 	ld [de], a
 	ld a, [hl]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMoveName
 	ld hl, MoveIsDisabledText
 	jp PrintText
@@ -6067,7 +6067,7 @@ CheckEnemyStatusConditions:
 	bit USING_RAGE, a ; is mon using rage?
 	jp z, .checkEnemyStatusConditionsDone ; if we made it this far, mon can move normally this turn
 	ld a, RAGE
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMoveName
 	call CopyToStringBuffer
 	xor a
@@ -6245,7 +6245,7 @@ LoadEnemyMonData:
 	ld a, [hl]     ; base exp
 	ld [de], a
 	ld a, [wEnemyMonSpecies2]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld hl, wNameBuffer
 	ld de, wEnemyMonNick

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6252,9 +6252,9 @@ LoadEnemyMonData:
 	ld bc, NAME_LENGTH
 	call CopyData
 	ld a, [wEnemyMonSpecies2]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	predef IndexToPokedex
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld c, a
 	ld b, FLAG_SET

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -1421,7 +1421,7 @@ EnemySendOutFirstMon:
 	call PrintText
 	ld a, [wEnemyMonSpecies2]
 	ld [wCurPartySpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld de, vFrontPic
 	call LoadMonFrontSprite
@@ -1642,7 +1642,7 @@ LoadBattleMonFromParty:
 	ld bc, wBattleMonPP - wBattleMonLevel
 	call CopyData
 	ld a, [wBattleMonSpecies2]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld hl, wPartyMonNicks
 	ld a, [wPlayerMonNumber]
@@ -1686,7 +1686,7 @@ LoadEnemyMonFromParty:
 	ld bc, wEnemyMonPP - wEnemyMonLevel
 	call CopyData
 	ld a, [wEnemyMonSpecies]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld hl, wEnemyMonNicks
 	ld a, [wWhichPokemon]
@@ -2380,7 +2380,7 @@ PartyMenuOrRockOrRun:
 ; enemy mon is not minimised
 	ld a, [wEnemyMonSpecies]
 	ld [wCurPartySpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld de, vFrontPic
 	call LoadMonFrontSprite
@@ -4406,7 +4406,7 @@ GetEnemyMonStat:
 	ld a, [wEnemyMonLevel]
 	ld [wCurEnemyLevel], a
 	ld a, [wEnemyMonSpecies]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld hl, wEnemyMonDVs
 	ld de, wLoadedMonSpeedExp
@@ -4610,7 +4610,7 @@ CriticalHitTest:
 	jr nz, .handleEnemy
 	ld a, [wBattleMonSpecies]
 .handleEnemy
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld a, [wMonHBaseSpeed]
 	ld b, a
@@ -5625,7 +5625,7 @@ EnemyCanExecuteChargingMove:
 	res CHARGING_UP, [hl] ; no longer charging up for attack
 	res INVULNERABLE, [hl] ; no longer invulnerable to typical attacks
 	ld a, [wEnemyMoveNum]
-	ld [wd0b5], a
+	ld [wNameListIndex], a
 	ld a, BANK(MoveNames)
 	ld [wPredefBank], a
 	ld a, MOVE_NAME
@@ -6098,7 +6098,7 @@ GetCurrentMove:
 	jr nz, .selected
 	ld a, [wPlayerSelectedMove]
 .selected
-	ld [wd0b5], a
+	ld [wNameListIndex], a
 	dec a
 	ld hl, Moves
 	ld bc, MOVE_LENGTH
@@ -6120,7 +6120,7 @@ LoadEnemyMonData:
 	jp z, LoadEnemyMonFromParty
 	ld a, [wEnemyMonSpecies2]
 	ld [wEnemyMonSpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld a, [wEnemyBattleStatus3]
 	bit TRANSFORMED, a ; is enemy mon transformed?

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3728,13 +3728,13 @@ MonName1Text:
 	ld hl, wEnemyUsedMove
 .playerTurn
 	ld [hl], a
-	ld [wd11e], a
+	ld [wMoveGrammar], a
 	call DetermineExclamationPointTextNum
 	ld a, [wMonIsDisobedient]
 	and a
 	ld hl, Used2Text
 	ret nz
-	ld a, [wd11e]
+	ld a, [wMoveGrammar]
 	cp 3
 	ld hl, Used2Text
 	ret c
@@ -3771,7 +3771,7 @@ _PrintMoveName:
 	text_far _MoveNameText
 	text_asm
 	ld hl, ExclamationPointPointerTable
-	ld a, [wd11e] ; exclamation point num
+	ld a, [wMoveGrammar]
 	add a
 	push bc
 	ld b, $0
@@ -3819,7 +3819,7 @@ ExclamationPoint5Text:
 ; but the functionality didn't get removed
 DetermineExclamationPointTextNum:
 	push bc
-	ld a, [wd11e] ; move ID
+	ld a, [wMoveGrammar] ; move ID
 	ld c, a
 	ld b, $0
 	ld hl, ExclamationPointMoveSets
@@ -3835,7 +3835,7 @@ DetermineExclamationPointTextNum:
 	jr .loop
 .done
 	ld a, b
-	ld [wd11e], a ; exclamation point num
+	ld [wMoveGrammar], a
 	pop bc
 	ret
 
@@ -5120,7 +5120,7 @@ MirrorMoveFailedText:
 
 ; function used to reload move data for moves like Mirror Move and Metronome
 ReloadMoveData:
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	dec a
 	ld hl, Moves
 	ld bc, MOVE_LENGTH

--- a/engine/battle/effects.asm
+++ b/engine/battle/effects.asm
@@ -1262,7 +1262,7 @@ MimicEffect:
 	add hl, bc
 	ld a, d
 	ld [hl], a
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMoveName
 	call PlayCurrentMoveAnimation
 	ld hl, MimicLearnedMoveText
@@ -1309,7 +1309,7 @@ DisableEffect:
 	pop hl
 	and a
 	jr z, .pickMoveToDisable ; loop until a non-00 move slot is found
-	ld [wd11e], a ; store move number
+	ld [wNamedObjectIndex], a ; store move number
 	push hl
 	ldh a, [hWhoseTurn]
 	and a
@@ -1354,7 +1354,7 @@ DisableEffect:
 	jr nz, .printDisableText
 	inc hl ; wEnemyDisabledMoveNumber
 .printDisableText
-	ld a, [wd11e] ; move number
+	ld a, [wNamedObjectIndex] ; move number
 	ld [hl], a
 	call GetMoveName
 	ld hl, MoveWasDisabledText

--- a/engine/battle/experience.asm
+++ b/engine/battle/experience.asm
@@ -170,7 +170,7 @@ GainExperience:
 	add hl, bc
 	ld a, [hl] ; species
 	ld [wd0b5], a
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	call GetMonHeader
 	ld bc, (wPartyMon1MaxHP + 1) - wPartyMon1Species
 	add hl, bc
@@ -252,7 +252,7 @@ GainExperience:
 	xor a ; PLAYER_PARTY_DATA
 	ld [wMonDataLocation], a
 	ld a, [wd0b5]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	predef LearnMoveFromLevelUp
 	ld hl, wCanEvolveFlags
 	ld a, [wWhichPokemon]
@@ -306,7 +306,7 @@ DivideExpDataByNumMonsGainingExp:
 	jr nz, .countSetBitsLoop
 	cp $2
 	ret c ; return if only one mon is gaining exp
-	ld [wd11e], a ; store number of mons gaining exp
+	ld [wTempByteValue], a ; store number of mons gaining exp
 	ld hl, wEnemyMonBaseStats
 	ld c, wEnemyMonBaseExp + 1 - wEnemyMonBaseStats
 .divideLoop
@@ -314,7 +314,7 @@ DivideExpDataByNumMonsGainingExp:
 	ldh [hDividend], a
 	ld a, [hl]
 	ldh [hDividend + 1], a
-	ld a, [wd11e]
+	ld a, [wTempByteValue]
 	ldh [hDivisor], a
 	ld b, $2
 	call Divide ; divide value by number of mons gaining exp

--- a/engine/battle/experience.asm
+++ b/engine/battle/experience.asm
@@ -113,8 +113,8 @@ GainExperience:
 	ld b, 0
 	ld hl, wPartySpecies
 	add hl, bc
-	ld a, [hl] ; species
-	ld [wd0b5], a
+	ld a, [hl]
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld d, MAX_LEVEL
 	callfar CalcExperience ; get max exp
@@ -168,8 +168,8 @@ GainExperience:
 	ld [hl], a
 	ld bc, wPartyMon1Species - wPartyMon1Level
 	add hl, bc
-	ld a, [hl] ; species
-	ld [wd0b5], a
+	ld a, [hl]
+	ld [wCurSpecies], a
 	ld [wPokedexNum], a
 	call GetMonHeader
 	ld bc, (wPartyMon1MaxHP + 1) - wPartyMon1Species
@@ -251,7 +251,7 @@ GainExperience:
 	call LoadScreenTilesFromBuffer1
 	xor a ; PLAYER_PARTY_DATA
 	ld [wMonDataLocation], a
-	ld a, [wd0b5]
+	ld a, [wCurSpecies]
 	ld [wPokedexNum], a
 	predef LearnMoveFromLevelUp
 	ld hl, wCanEvolveFlags

--- a/engine/battle/get_trainer_name.asm
+++ b/engine/battle/get_trainer_name.asm
@@ -11,7 +11,7 @@ GetTrainerName_::
 	jr z, .foundName
 	cp RIVAL3
 	jr z, .foundName
-	ld [wd0b5], a
+	ld [wNameListIndex], a
 	ld a, TRAINER_NAME
 	ld [wNameListType], a
 	ld a, BANK(TrainerNames)

--- a/engine/battle/misc.asm
+++ b/engine/battle/misc.asm
@@ -8,7 +8,7 @@ FormatMovesString:
 	and a ; end of move list?
 	jr z, .printDashLoop ; print dashes when no moves are left
 	push hl
-	ld [wd0b5], a
+	ld [wNameListIndex], a
 	ld a, BANK(MoveNames)
 	ld [wPredefBank], a
 	ld a, MOVE_NAME

--- a/engine/battle/move_effects/transform.asm
+++ b/engine/battle/move_effects/transform.asm
@@ -116,7 +116,7 @@ TransformEffect_:
 ; original (unmodified) stats and stat mods
 	pop hl
 	ld a, [hl]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld hl, wEnemyMonUnmodifiedAttack
 	ld de, wPlayerMonUnmodifiedAttack

--- a/engine/battle/print_type.asm
+++ b/engine/battle/print_type.asm
@@ -1,4 +1,4 @@
-; [wd0b5] = pokemon ID
+; [wCurSpecies] = pokemon ID
 ; hl = dest addr
 PrintMonType:
 	call GetPredefRegisters

--- a/engine/battle/safari_zone.asm
+++ b/engine/battle/safari_zone.asm
@@ -16,7 +16,7 @@ PrintSafariZoneBattleText:
 	jr nz, .done
 	push hl
 	ld a, [wEnemyMonSpecies]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld a, [wMonHCatchRate]
 	ld [wEnemyMonActualCatchRate], a

--- a/engine/battle/trainer_ai.asm
+++ b/engine/battle/trainer_ai.asm
@@ -732,7 +732,7 @@ AIPrintItemUse:
 AIPrintItemUse_:
 ; print "x used [wAIItem] on z!"
 	ld a, [wAIItem]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	ld hl, AIBattleUseItemText
 	jp PrintText

--- a/engine/events/cinnabar_lab.asm
+++ b/engine/events/cinnabar_lab.asm
@@ -98,7 +98,7 @@ PrintFossilsInBag:
 	cp $ff
 	ret z
 	push hl
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	hlcoord 2, 2
 	ldh a, [hItemCounter]
@@ -114,10 +114,10 @@ PrintFossilsInBag:
 ; loads the names of the fossil item and the resulting mon
 LoadFossilItemAndMonName::
 	ld a, [wFossilMon]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	call CopyToStringBuffer
 	ld a, [wFossilItem]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	ret

--- a/engine/events/display_pokedex.asm
+++ b/engine/events/display_pokedex.asm
@@ -8,7 +8,7 @@ _DisplayPokedex::
 	ld c, 10
 	call DelayFrames
 	predef IndexToPokedex
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld c, a
 	ld b, FLAG_SET

--- a/engine/events/give_pokemon.asm
+++ b/engine/events/give_pokemon.asm
@@ -54,9 +54,9 @@ _GivePokemon::
 SetPokedexOwnedFlag:
 	ld a, [wCurPartySpecies]
 	push af
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	predef IndexToPokedex
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld c, a
 	ld hl, wPokedexOwned

--- a/engine/events/give_pokemon.asm
+++ b/engine/events/give_pokemon.asm
@@ -63,7 +63,7 @@ SetPokedexOwnedFlag:
 	ld b, FLAG_SET
 	predef FlagActionPredef
 	pop af
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld hl, GotMonText
 	jp PrintText

--- a/engine/events/heal_party.asm
+++ b/engine/events/heal_party.asm
@@ -84,7 +84,7 @@ HealParty:
 .done
 	xor a
 	ld [wWhichPokemon], a
-	ld [wd11e], a
+	ld [wUsingPPUp], a
 
 	ld a, [wPartyCount]
 	ld b, a

--- a/engine/events/hidden_items.asm
+++ b/engine/events/hidden_items.asm
@@ -14,7 +14,7 @@ HiddenItems:
 	ld a, 1
 	ld [wDoNotWaitForButtonPressAfterDisplayingText], a
 	ld a, [wHiddenObjectFunctionArgument] ; item ID
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	tx_pre_jump FoundHiddenItemText
 

--- a/engine/events/hidden_objects/museum_fossils.asm
+++ b/engine/events/hidden_objects/museum_fossils.asm
@@ -35,7 +35,7 @@ DisplayMonFrontSpriteInBox:
 	call DisplayTextBoxID
 	call UpdateSprites
 	ld a, [wCurPartySpecies]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld de, vChars1 tile $31
 	call LoadMonFrontSprite

--- a/engine/events/in_game_trades.asm
+++ b/engine/events/in_game_trades.asm
@@ -77,7 +77,7 @@ DoInGameTradeDialogue:
 ; copies name of species a to hl
 InGameTrade_GetMonName:
 	push de
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld hl, wNameBuffer
 	pop de

--- a/engine/events/poison.asm
+++ b/engine/events/poison.asm
@@ -44,7 +44,7 @@ ApplyOutOfBattlePoisonDamage:
 	inc hl
 	ld [hl], a
 	ld a, [de]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	push de
 	ld a, [wWhichPokemon]
 	ld hl, wPartyMonNicks

--- a/engine/events/pokemart.asm
+++ b/engine/events/pokemart.asm
@@ -157,7 +157,7 @@ DisplayPokemartDialogue_::
 	inc a
 	jr z, .buyMenuLoop ; if the player closed the choose quantity menu with the B button
 	ld a, [wCurItem]
-	ld [wd11e], a ; store item ID for GetItemName
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	call CopyToStringBuffer
 	ld hl, PokemartTellBuyPriceText

--- a/engine/events/prize_menu.asm
+++ b/engine/events/prize_menu.asm
@@ -88,34 +88,34 @@ GetPrizeMenuId:
 	cp 2 ; is TM_menu?
 	jr nz, .putMonName
 	ld a, [wPrize1]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	hlcoord 2, 4
 	call PlaceString
 	ld a, [wPrize2]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	hlcoord 2, 6
 	call PlaceString
 	ld a, [wPrize3]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	hlcoord 2, 8
 	call PlaceString
 	jr .putNoThanksText
 .putMonName
 	ld a, [wPrize1]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	hlcoord 2, 4
 	call PlaceString
 	ld a, [wPrize2]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	hlcoord 2, 6
 	call PlaceString
 	ld a, [wPrize3]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	hlcoord 2, 8
 	call PlaceString
@@ -189,7 +189,7 @@ HandlePrizeChoice:
 	ld hl, wPrize1
 	add hl, de
 	ld a, [hl]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	ld a, [wWhichPrizeWindow]
 	cp 2 ; is prize a TM?
 	jr nz, .getMonName
@@ -208,9 +208,9 @@ HandlePrizeChoice:
 	call HasEnoughCoins
 	jr c, .notEnoughCoins
 	ld a, [wWhichPrizeWindow]
-	cp $02
+	cp 2 ; is prize a TM?
 	jr nz, .giveMon
-	ld a, [wd11e]
+	ld a, [wNamedObjectIndex]
 	ld b, a
 	ld a, 1
 	ld c, a
@@ -218,7 +218,7 @@ HandlePrizeChoice:
 	jr nc, .bagFull
 	jr .subtractCoins
 .giveMon
-	ld a, [wd11e]
+	ld a, [wNamedObjectIndex]
 	ld [wCurPartySpecies], a
 	push af
 	call GetPrizeMonLevel

--- a/engine/gfx/mon_icons.asm
+++ b/engine/gfx/mon_icons.asm
@@ -258,9 +258,9 @@ WriteMonPartySpriteOAM:
 	jp CopyData
 
 GetPartyMonSpriteID:
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	predef IndexToPokedex
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	ld c, a
 	dec a
 	srl a

--- a/engine/gfx/palettes.asm
+++ b/engine/gfx/palettes.asm
@@ -275,13 +275,13 @@ DeterminePaletteID:
 	ret nz
 	ld a, [hl]
 DeterminePaletteIDOutOfBattle:
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	and a ; is the mon index 0?
 	jr z, .skipDexNumConversion
 	push bc
 	predef IndexToPokedex
 	pop bc
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 .skipDexNumConversion
 	ld e, a
 	ld d, 0

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -528,7 +528,7 @@ ItemUseBall:
 	predef FlagActionPredef
 	ld a, c
 	push af
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld c, a
 	ld b, FLAG_SET
@@ -542,7 +542,7 @@ ItemUseBall:
 	call PrintText
 	call ClearSprites
 	ld a, [wEnemyMonSpecies]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	predef ShowPokedexData
 
 .skipShowingPokedexData
@@ -1255,7 +1255,7 @@ ItemUseMedicine:
 	push hl
 	ld a, [hl]
 	ld [wd0b5], a
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ld bc, wPartyMon1Level - wPartyMon1
 	add hl, bc ; hl now points to level
 	ld a, [hl] ; a = level
@@ -1396,7 +1396,7 @@ ItemUseMedicine:
 	ld a, d
 	ld [wWhichPokemon], a
 	ld a, e
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	xor a ; PLAYER_PARTY_DATA
 	ld [wMonDataLocation], a
 	call LoadMonData
@@ -2009,7 +2009,7 @@ ItemUsePPRestore:
 	add 1 << 6 ; increase PP Up count by 1
 	ld [hl], a
 	ld a, 1 ; 1 PP Up used
-	ld [wd11e], a
+	ld [wUsingPPUp], a
 	call RestoreBonusPP ; add the bonus PP to current PP
 	ld hl, PPIncreasedText
 	call PrintText
@@ -2162,9 +2162,9 @@ ItemUseTMHM:
 	add NUM_TMS + NUM_HMS ; adjust HM IDs to come after TM IDs
 .skipAdding
 	inc a
-	ld [wd11e], a
+	ld [wTempTMHM], a
 	predef TMToMove ; get move ID from TM/HM ID
-	ld a, [wd11e]
+	ld a, [wTempTMHM]
 	ld [wMoveNum], a
 	call GetMoveName
 	call CopyToStringBuffer
@@ -2893,7 +2893,7 @@ ItemUseReloadOverworldData:
 	call LoadCurrentMapView
 	jp UpdateSprites
 
-; creates a list at wBuffer of maps where the mon in [wd11e] can be found.
+; creates a list at wBuffer of maps where the mon in [wPokedexNum] can be found.
 ; this is used by the pokedex to display locations the mon can be found on the map.
 FindWildLocationsOfMon:
 	ld hl, WildDataPointers
@@ -2928,7 +2928,7 @@ CheckMapForMon:
 	inc hl
 	ld b, NUM_WILDMONS
 .loop
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	cp [hl]
 	jr nz, .nextEntry
 	ld a, c

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -510,7 +510,7 @@ ItemUseBall:
 	ld a, [wEnemyMonSpecies]
 	ld [wCapturedMonSpecies], a
 	ld [wCurPartySpecies], a
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ld a, [wBattleType]
 	dec a ; is this the old man battle?
 	jr z, .oldManCaughtMon ; if so, don't give the player the caught Pokémon
@@ -520,7 +520,7 @@ ItemUseBall:
 
 ; Add the caught Pokémon to the Pokédex.
 	predef IndexToPokedex
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld c, a
 	ld b, FLAG_TEST

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -1988,7 +1988,7 @@ ItemUsePPRestore:
 	call GetSelectedMoveOffset
 	push hl
 	ld a, [hl]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMoveName
 	call CopyToStringBuffer
 	pop hl
@@ -2558,7 +2558,7 @@ TossItem_::
 	jr nz, .tooImportantToToss
 	push hl
 	ld a, [wCurItem]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	call CopyToStringBuffer
 	ld hl, IsItOKToTossItemText
@@ -2578,7 +2578,7 @@ TossItem_::
 	ld a, [wWhichPokemon]
 	call RemoveItemFromInventory
 	ld a, [wCurItem]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	call CopyToStringBuffer
 	ld hl, ThrewAwayItemText

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -842,7 +842,7 @@ ItemUseMedicine:
 	ld d, a
 	ld a, [wCurPartySpecies]
 	ld e, a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	pop af
 	ld [wCurItem], a
 	pop af
@@ -1254,7 +1254,7 @@ ItemUseMedicine:
 .useVitamin
 	push hl
 	ld a, [hl]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	ld [wPokedexNum], a
 	ld bc, wPartyMon1Level - wPartyMon1
 	add hl, bc ; hl now points to level
@@ -2651,7 +2651,7 @@ SendNewMonToBox:
 	inc a
 	ld [de], a
 	ld a, [wCurPartySpecies]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	ld c, a
 .loop
 	inc de

--- a/engine/items/tms.asm
+++ b/engine/items/tms.asm
@@ -20,17 +20,17 @@ CanLearnTM:
 	ld b, FLAG_TEST
 	predef_jump FlagActionPredef
 
-; converts TM/HM number in wd11e into move number
+; converts TM/HM number in [wTempTMHM] into move number
 ; HMs start at 51
 TMToMove:
-	ld a, [wd11e]
+	ld a, [wTempTMHM]
 	dec a
 	ld hl, TechnicalMachines
 	ld b, $0
 	ld c, a
 	add hl, bc
 	ld a, [hl]
-	ld [wd11e], a
+	ld [wTempTMHM], a
 	ret
 
 INCLUDE "data/moves/tmhm_moves.asm"

--- a/engine/items/tms.asm
+++ b/engine/items/tms.asm
@@ -1,7 +1,7 @@
 ; tests if mon [wCurPartySpecies] can learn move [wMoveNum]
 CanLearnTM:
 	ld a, [wCurPartySpecies]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld hl, wMonHLearnset
 	push hl

--- a/engine/link/cable_club.asm
+++ b/engine/link/cable_club.asm
@@ -660,7 +660,7 @@ TradeCenter_PrintPartyListNames:
 	ld a, [de]
 	cp $ff
 	ret z
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	push bc
 	push hl
 	push de
@@ -697,7 +697,7 @@ TradeCenter_Trade:
 	ld b, 0
 	add hl, bc
 	ld a, [hl]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld hl, wNameBuffer
 	ld de, wNameOfPlayerMonToBeTraded
@@ -709,7 +709,7 @@ TradeCenter_Trade:
 	ld b, 0
 	add hl, bc
 	ld a, [hl]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld hl, WillBeTradedText
 	bccoord 1, 14

--- a/engine/menus/league_pc.asm
+++ b/engine/menus/league_pc.asm
@@ -84,7 +84,7 @@ LeaguePCShowMon:
 	ld a, [hli]
 	ld [wHoFMonSpecies], a
 	ld [wCurPartySpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	ld [wBattleMonSpecies2], a
 	ld [wWholeScreenPaletteMonSpecies], a
 	ld a, [hli]

--- a/engine/menus/naming_screen.asm
+++ b/engine/menus/naming_screen.asm
@@ -9,7 +9,7 @@ AskName:
 	ld c, 11
 	call z, ClearScreenArea ; only if in wild battle
 	ld a, [wCurPartySpecies]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld hl, DoYouWantToNicknameText
 	call PrintText
@@ -462,7 +462,7 @@ PrintNamingText:
 	push af
 	farcall WriteMonPartySpriteOAMBySpecies
 	pop af
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	hlcoord 4, 1
 	call PlaceString

--- a/engine/menus/pokedex.asm
+++ b/engine/menus/pokedex.asm
@@ -471,7 +471,7 @@ ShowPokedexDataInternal:
 	ld h, b
 	ld l, c
 	push de
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	push af
 	call IndexToPokedex
 
@@ -480,7 +480,7 @@ ShowPokedexDataInternal:
 	ld [hli], a
 	ld a, "<DOT>"
 	ld [hli], a
-	ld de, wd11e
+	ld de, wPokedexNum
 	lb bc, LEADING_ZEROES | 1, 3
 	call PrintNumber ; print pokedex number
 
@@ -624,10 +624,10 @@ DrawTileLine:
 INCLUDE "data/pokemon/dex_entries.asm"
 
 PokedexToIndex:
-	; converts the Pokédex number at wd11e to an index
+	; converts the Pokédex number at [wPokedexNum] to an index
 	push bc
 	push hl
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	ld b, a
 	ld c, 0
 	ld hl, PokedexOrder
@@ -639,23 +639,23 @@ PokedexToIndex:
 	jr nz, .loop
 
 	ld a, c
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	pop hl
 	pop bc
 	ret
 
 IndexToPokedex:
-	; converts the index number at wd11e to a Pokédex number
+	; converts the index number at [wPokedexNum] to a Pokédex number
 	push bc
 	push hl
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld hl, PokedexOrder
 	ld b, 0
 	ld c, a
 	add hl, bc
 	ld a, [hl]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	pop hl
 	pop bc
 	ret

--- a/engine/menus/pokedex.asm
+++ b/engine/menus/pokedex.asm
@@ -9,7 +9,7 @@ ShowPokedexMenu:
 	ld [wListScrollOffset], a
 	ld [wLastMenuItem], a
 	inc a
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ldh [hJoy7], a
 .setUpGraphics
 	ld b, SET_PAL_GENERIC
@@ -68,8 +68,8 @@ HandlePokedexSideMenu:
 	push af
 	add b
 	inc a
-	ld [wd11e], a
-	ld a, [wd11e]
+	ld [wPokedexNum], a
+	ld a, [wPokedexNum]
 	push af
 	ld a, [wDexMaxSeenMon]
 	push af ; this doesn't need to be preserved
@@ -111,7 +111,7 @@ HandlePokedexSideMenu:
 	pop af
 	ld [wDexMaxSeenMon], a
 	pop af
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	pop af
 	ld [wListScrollOffset], a
 	pop af
@@ -142,7 +142,7 @@ HandlePokedexSideMenu:
 
 ; play pokemon cry
 .choseCry
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	call GetCryData
 	call PlaySound
 	jr .handleMenuInput
@@ -222,7 +222,7 @@ HandlePokedexListMenu:
 	call ClearScreenArea
 	hlcoord 1, 3
 	ld a, [wListScrollOffset]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ld d, 7
 	ld a, [wDexMaxSeenMon]
 	cp 7
@@ -233,17 +233,17 @@ HandlePokedexListMenu:
 ; loop to print pokemon pokedex numbers and names
 ; if the player has owned the pokemon, it puts a pokeball beside the name
 .printPokemonLoop
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	inc a
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	push af
 	push de
 	push hl
 	ld de, -SCREEN_WIDTH
 	add hl, de
-	ld de, wd11e
+	ld de, wPokedexNum
 	lb bc, LEADING_ZEROES | 1, 3
-	call PrintNumber ; print the pokedex number
+	call PrintNumber
 	ld de, SCREEN_WIDTH
 	add hl, de
 	dec hl
@@ -276,7 +276,7 @@ HandlePokedexListMenu:
 	add hl, bc
 	pop de
 	pop af
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	dec d
 	jr nz, .printPokemonLoop
 	ld a, 01
@@ -376,10 +376,10 @@ PokedexMenuItemsText:
 
 ; tests if a pokemon's bit is set in the seen or owned pokemon bit fields
 ; INPUT:
-; [wd11e] = pokedex number
+; [wPokedexNum] = pokedex number
 ; hl = address of bit field
 IsPokemonBitSet:
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld c, a
 	ld b, FLAG_TEST
@@ -403,13 +403,13 @@ ShowPokedexDataInternal:
 	ldh [rNR50], a
 	call GBPalWhiteOut ; zero all palettes
 	call ClearScreen
-	ld a, [wd11e] ; pokemon ID
+	ld a, [wPokedexNum]
 	ld [wCurPartySpecies], a
 	push af
 	ld b, SET_PAL_POKEDEX
 	call RunPaletteCommand
 	pop af
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ldh a, [hTileAnimations]
 	push af
 	xor a
@@ -455,7 +455,7 @@ ShowPokedexDataInternal:
 	call PlaceString
 
 	ld hl, PokedexEntryPointers
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld e, a
 	ld d, 0
@@ -487,7 +487,7 @@ ShowPokedexDataInternal:
 	ld hl, wPokedexOwned
 	call IsPokemonBitSet
 	pop af
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ld a, [wCurPartySpecies]
 	ld [wd0b5], a
 	pop de

--- a/engine/menus/pokedex.asm
+++ b/engine/menus/pokedex.asm
@@ -489,7 +489,7 @@ ShowPokedexDataInternal:
 	pop af
 	ld [wPokedexNum], a
 	ld a, [wCurPartySpecies]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	pop de
 
 	push af

--- a/engine/menus/start_sub_menus.asm
+++ b/engine/menus/start_sub_menus.asm
@@ -365,7 +365,7 @@ StartMenu_Item::
 	jp ItemMenuLoop
 .useOrTossItem ; if the player made the choice to use or toss the item
 	ld a, [wCurItem]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	call CopyToStringBuffer
 	ld a, [wCurItem]

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -60,7 +60,7 @@ DisplayCreditsMon:
 	add hl, bc ; go that far in the list of monsters and get the next one
 	ld a, [hl]
 	ld [wCurPartySpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	hlcoord 8, 6
 	call GetMonHeader
 	call LoadFrontSpriteByMonIndex

--- a/engine/movie/evolution.asm
+++ b/engine/movie/evolution.asm
@@ -4,7 +4,7 @@ EvolveMon:
 	push bc
 	ld a, [wCurPartySpecies]
 	push af
-	ld a, [wd0b5]
+	ld a, [wCurSpecies]
 	push af
 	xor a
 	ld [wLowHealthAlarm], a
@@ -26,7 +26,7 @@ EvolveMon:
 	call EvolutionSetWholeScreenPalette
 	ld a, [wEvoNewSpecies]
 	ld [wCurPartySpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call Evolution_LoadPic
 	ld de, vFrontPic
 	ld hl, vBackPic
@@ -34,7 +34,7 @@ EvolveMon:
 	call CopyVideoData
 	ld a, [wEvoOldSpecies]
 	ld [wCurPartySpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call Evolution_LoadPic
 	ld a, $1
 	ldh [hAutoBGTransferEnabled], a
@@ -75,7 +75,7 @@ EvolveMon:
 	ld c, 0
 	call EvolutionSetWholeScreenPalette
 	pop af
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	pop af
 	ld [wCurPartySpecies], a
 	pop bc

--- a/engine/movie/hall_of_fame.asm
+++ b/engine/movie/hall_of_fame.asm
@@ -102,7 +102,7 @@ HoFShowMonOrPlayer:
 	ldh [hSCX], a
 	ld a, [wHoFMonSpecies]
 	ld [wCurPartySpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	ld [wBattleMonSpecies2], a
 	ld [wWholeScreenPaletteMonSpecies], a
 	ld a, [wHoFMonOrPlayer]
@@ -171,7 +171,7 @@ HoFDisplayMonInfo:
 	hlcoord 8, 7
 	call PrintLevelCommon
 	ld a, [wHoFMonSpecies]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	hlcoord 3, 9
 	predef PrintMonType
 	ld a, [wHoFMonSpecies]

--- a/engine/movie/oak_speech/oak_speech.asm
+++ b/engine/movie/oak_speech/oak_speech.asm
@@ -73,7 +73,7 @@ OakSpeech:
 	call GBFadeOutToWhite
 	call ClearScreen
 	ld a, NIDORINO
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	ld [wCurPartySpecies], a
 	call GetMonHeader
 	hlcoord 6, 4

--- a/engine/movie/title.asm
+++ b/engine/movie/title.asm
@@ -362,7 +362,7 @@ ClearBothBGMaps:
 
 LoadTitleMonSprite:
 	ld [wCurPartySpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	hlcoord 5, 10
 	call GetMonHeader
 	jp LoadFrontSpriteByMonIndex

--- a/engine/movie/trade.asm
+++ b/engine/movie/trade.asm
@@ -186,14 +186,14 @@ LoadTradingGFXAndMonNames:
 	xor a
 	ldh [hAutoBGTransferEnabled], a
 	ld a, [wTradedPlayerMonSpecies]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld hl, wNameBuffer
 	ld de, wStringBuffer
 	ld bc, NAME_LENGTH
 	call CopyData
 	ld a, [wTradedEnemyMonSpecies]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	jp GetMonName
 
 Trade_LoadMonPartySpriteGfx:

--- a/engine/movie/trade.asm
+++ b/engine/movie/trade.asm
@@ -728,7 +728,7 @@ Trade_CircleOAM3:
 ; a = species
 Trade_LoadMonSprite:
 	ld [wCurPartySpecies], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	ld [wWholeScreenPaletteMonSpecies], a
 	ld b, SET_PAL_POKEMON_WHOLE_SCREEN
 	ld c, 0

--- a/engine/movie/trade2.asm
+++ b/engine/movie/trade2.asm
@@ -3,10 +3,10 @@ Trade_PrintPlayerMonInfoText:
 	ld de, Trade_MonInfoText
 	call PlaceString
 	ld a, [wTradedPlayerMonSpecies]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	predef IndexToPokedex
 	hlcoord 9, 0
-	ld de, wd11e
+	ld de, wPokedexNum
 	lb bc, LEADING_ZEROES | 1, 3
 	call PrintNumber
 	hlcoord 5, 2
@@ -25,10 +25,10 @@ Trade_PrintEnemyMonInfoText:
 	ld de, Trade_MonInfoText
 	call PlaceString
 	ld a, [wTradedEnemyMonSpecies]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	predef IndexToPokedex
 	hlcoord 9, 10
-	ld de, wd11e
+	ld de, wPokedexNum
 	lb bc, LEADING_ZEROES | 1, 3
 	call PrintNumber
 	hlcoord 5, 12

--- a/engine/pokemon/add_mon.asm
+++ b/engine/pokemon/add_mon.asm
@@ -65,7 +65,7 @@ _AddPartyMon::
 	ld d, h
 	push hl
 	ld a, [wCurPartySpecies]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld hl, wMonHeader
 	ld a, [hli]

--- a/engine/pokemon/add_mon.asm
+++ b/engine/pokemon/add_mon.asm
@@ -81,11 +81,11 @@ _AddPartyMon::
 
 ; If the mon is being added to the player's party, update the pokedex.
 	ld a, [wCurPartySpecies]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	push de
 	predef IndexToPokedex
 	pop de
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld c, a
 	ld b, FLAG_TEST
@@ -93,7 +93,7 @@ _AddPartyMon::
 	call FlagAction
 	ld a, c ; whether the mon was already flagged as owned
 	ld [wUnusedAlreadyOwnedFlag], a
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld c, a
 	ld b, FLAG_SET
@@ -323,9 +323,9 @@ _AddEnemyMonToPlayerParty::
 	ld bc, NAME_LENGTH
 	call CopyData    ; write new mon's nickname (from an enemy mon)
 	ld a, [wCurPartySpecies]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	predef IndexToPokedex
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld c, a
 	ld b, FLAG_SET

--- a/engine/pokemon/evos_moves.asm
+++ b/engine/pokemon/evos_moves.asm
@@ -153,12 +153,12 @@ Evolution_PartyMonLoop: ; loop over party mons
 	call DelayFrames
 	call ClearScreen
 	call RenameEvolvedMon
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	push af
 	ld a, [wd0b5]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	predef IndexToPokedex
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld hl, BaseStats
 	ld bc, BASE_DATA_SIZE
@@ -168,7 +168,7 @@ Evolution_PartyMonLoop: ; loop over party mons
 	ld a, [wd0b5]
 	ld [wMonHIndex], a
 	pop af
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ld hl, wLoadedMonHPExp - 1
 	ld de, wLoadedMonStats
 	ld b, $1
@@ -204,7 +204,7 @@ Evolution_PartyMonLoop: ; loop over party mons
 	pop bc
 	call CopyData
 	ld a, [wd0b5]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	xor a
 	ld [wMonDataLocation], a
 	call LearnMoveFromLevelUp
@@ -214,7 +214,7 @@ Evolution_PartyMonLoop: ; loop over party mons
 	and a
 	call z, Evolution_ReloadTilesetTilePatterns
 	predef IndexToPokedex
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	dec a
 	ld c, a
 	ld b, FLAG_SET

--- a/engine/pokemon/evos_moves.asm
+++ b/engine/pokemon/evos_moves.asm
@@ -319,7 +319,7 @@ Evolution_ReloadTilesetTilePatterns:
 
 LearnMoveFromLevelUp:
 	ld hl, EvosMovesPointerTable
-	ld a, [wd11e] ; species
+	ld a, [wPokedexNum] ; species
 	ld [wCurPartySpecies], a
 	dec a
 	ld bc, 0
@@ -372,7 +372,7 @@ LearnMoveFromLevelUp:
 	predef LearnMove
 .done
 	ld a, [wCurPartySpecies]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ret
 
 ; writes the moves a mon has at level [wCurEnemyLevel] to [de]

--- a/engine/pokemon/evos_moves.asm
+++ b/engine/pokemon/evos_moves.asm
@@ -366,7 +366,7 @@ LearnMoveFromLevelUp:
 	jr nz, .checkCurrentMovesLoop
 	ld a, d
 	ld [wMoveNum], a
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMoveName
 	call CopyToStringBuffer
 	predef LearnMove

--- a/engine/pokemon/evos_moves.asm
+++ b/engine/pokemon/evos_moves.asm
@@ -135,7 +135,7 @@ Evolution_PartyMonLoop: ; loop over party mons
 	call PrintText
 	pop hl
 	ld a, [hl]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	ld [wLoadedMonSpecies], a
 	ld [wEvoNewSpecies], a
 	ld a, MONSTER_NAME
@@ -155,7 +155,7 @@ Evolution_PartyMonLoop: ; loop over party mons
 	call RenameEvolvedMon
 	ld a, [wPokedexNum]
 	push af
-	ld a, [wd0b5]
+	ld a, [wCurSpecies]
 	ld [wPokedexNum], a
 	predef IndexToPokedex
 	ld a, [wPokedexNum]
@@ -165,7 +165,7 @@ Evolution_PartyMonLoop: ; loop over party mons
 	call AddNTimes
 	ld de, wMonHeader
 	call CopyData
-	ld a, [wd0b5]
+	ld a, [wCurSpecies]
 	ld [wMonHIndex], a
 	pop af
 	ld [wPokedexNum], a
@@ -203,7 +203,7 @@ Evolution_PartyMonLoop: ; loop over party mons
 	dec hl
 	pop bc
 	call CopyData
-	ld a, [wd0b5]
+	ld a, [wCurSpecies]
 	ld [wPokedexNum], a
 	xor a
 	ld [wMonDataLocation], a
@@ -260,13 +260,14 @@ Evolution_PartyMonLoop: ; loop over party mons
 RenameEvolvedMon:
 ; Renames the mon to its new, evolved form's standard name unless it had a
 ; nickname, in which case the nickname is kept.
-	ld a, [wd0b5]
+	assert wCurSpecies == wNameListIndex ; save+restore wCurSpecies while using wNameListIndex
+	ld a, [wCurSpecies]
 	push af
 	ld a, [wMonHIndex]
-	ld [wd0b5], a
+	ld [wNameListIndex], a
 	call GetName
 	pop af
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	ld hl, wNameBuffer
 	ld de, wStringBuffer
 .compareNamesLoop

--- a/engine/pokemon/experience.asm
+++ b/engine/pokemon/experience.asm
@@ -1,7 +1,7 @@
 ; calculates the level a mon should be based on its current exp
 CalcLevelFromExperience::
 	ld a, [wLoadedMonSpecies]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	call GetMonHeader
 	ld d, $1 ; init level to 1
 .loop

--- a/engine/pokemon/learn_move.asm
+++ b/engine/pokemon/learn_move.asm
@@ -29,7 +29,7 @@ DontAbandonLearning:
 	jp c, AbandonLearning
 	push hl
 	push de
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMoveName
 	ld hl, OneTwoAndText
 	call PrintText

--- a/engine/pokemon/load_mon_data.asm
+++ b/engine/pokemon/load_mon_data.asm
@@ -19,7 +19,7 @@ LoadMonData_::
 
 .GetMonHeader
 	ld a, [wCurPartySpecies]
-	ld [wd0b5], a ; input for GetMonHeader
+	ld [wCurSpecies], a
 	call GetMonHeader
 
 	ld hl, wPartyMons

--- a/engine/pokemon/set_types.asm
+++ b/engine/pokemon/set_types.asm
@@ -4,7 +4,7 @@ SetPartyMonTypes:
 	ld bc, wPartyMon1Type - wPartyMon1 ; $5
 	add hl, bc
 	ld a, [wPokedexNum]
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	push hl
 	call GetMonHeader
 	pop hl

--- a/engine/pokemon/set_types.asm
+++ b/engine/pokemon/set_types.asm
@@ -1,9 +1,9 @@
-; updates the types of a party mon (pointed to in hl) to the ones of the mon specified in wd11e
+; updates the types of a party mon (pointed to in hl) to the ones of the mon specified in [wPokedexNum]
 SetPartyMonTypes:
 	call GetPredefRegisters
 	ld bc, wPartyMon1Type - wPartyMon1 ; $5
 	add hl, bc
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	ld [wd0b5], a
 	push hl
 	call GetMonHeader

--- a/engine/pokemon/status_screen.asm
+++ b/engine/pokemon/status_screen.asm
@@ -420,7 +420,7 @@ StatusScreen2:
 	hlcoord 9, 1
 	call StatusScreen_ClearName
 	ld a, [wMonHIndex]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	hlcoord 9, 1
 	call PlaceString

--- a/engine/pokemon/status_screen.asm
+++ b/engine/pokemon/status_screen.asm
@@ -139,11 +139,11 @@ StatusScreen:
 	hlcoord 14, 2
 	call PrintLevel ; Pokémon level
 	ld a, [wMonHIndex]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ld [wd0b5], a
 	predef IndexToPokedex
 	hlcoord 3, 7
-	ld de, wd11e
+	ld de, wPokedexNum
 	lb bc, LEADING_ZEROES | 1, 3
 	call PrintNumber ; Pokémon no.
 	hlcoord 11, 10

--- a/engine/pokemon/status_screen.asm
+++ b/engine/pokemon/status_screen.asm
@@ -140,7 +140,7 @@ StatusScreen:
 	call PrintLevel ; Pokémon level
 	ld a, [wMonHIndex]
 	ld [wPokedexNum], a
-	ld [wd0b5], a
+	ld [wCurSpecies], a
 	predef IndexToPokedex
 	hlcoord 3, 7
 	ld de, wPokedexNum

--- a/home/give.asm
+++ b/home/give.asm
@@ -3,7 +3,7 @@ GiveItem::
 ; and copy the item's name to wStringBuffer.
 ; Return carry on success.
 	ld a, b
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	ld [wCurItem], a
 	ld a, c
 	ld [wItemQuantity], a

--- a/home/list_menu.asm
+++ b/home/list_menu.asm
@@ -367,7 +367,7 @@ PrintListMenuEntries::
 	ld a, b
 	ld [wWhichPokemon], a
 	ld a, [de]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	cp $ff
 	jp z, .printCancelMenuItem
 	push bc

--- a/home/list_menu.asm
+++ b/home/list_menu.asm
@@ -141,7 +141,7 @@ DisplayListMenuIDLoop::
 	ld [wMaxItemQuantity], a
 .skipGettingQuantity
 	ld a, [wCurItem]
-	ld [wd0b5], a
+	ld [wNameListIndex], a
 	ld a, BANK(ItemNames)
 	ld [wPredefBank], a
 	call GetName

--- a/home/list_menu.asm
+++ b/home/list_menu.asm
@@ -427,7 +427,7 @@ PrintListMenuEntries::
 	and a ; PCPOKEMONLISTMENU?
 	jr nz, .skipPrintingPokemonLevel
 .printPokemonLevel
-	ld a, [wd11e]
+	ld a, [wNamedObjectIndex]
 	push af
 	push hl
 	ld hl, wPartyCount
@@ -460,7 +460,7 @@ PrintListMenuEntries::
 	add hl, bc
 	call PrintLevel
 	pop af
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 .skipPrintingPokemonLevel
 	pop hl
 	pop de
@@ -469,7 +469,7 @@ PrintListMenuEntries::
 	cp ITEMLISTMENU
 	jr nz, .nextListEntry
 .printItemQuantity
-	ld a, [wd11e]
+	ld a, [wNamedObjectIndex]
 	ld [wCurItem], a
 	call IsKeyItem ; check if item is unsellable
 	ld a, [wIsKeyItem]
@@ -480,18 +480,18 @@ PrintListMenuEntries::
 	add hl, bc
 	ld a, "×"
 	ld [hli], a
-	ld a, [wd11e]
+	ld a, [wNamedObjectIndex]
 	push af
 	ld a, [de]
 	ld [wMaxItemQuantity], a
 	push de
-	ld de, wd11e
+	ld de, wTempByteValue
 	ld [de], a
 	lb bc, 1, 2
 	call PrintNumber
 	pop de
 	pop af
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	pop hl
 .skipPrintingItemQuantity
 	inc de

--- a/home/map_objects.asm
+++ b/home/map_objects.asm
@@ -71,7 +71,7 @@ IsItemInBag::
 	ret
 
 DisplayPokedex::
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	farjp _DisplayPokedex
 
 SetSpriteFacingDirectionAndDelay::

--- a/home/names.asm
+++ b/home/names.asm
@@ -5,7 +5,7 @@ GetMonName::
 	ld a, BANK(MonsterNames)
 	ldh [hLoadedROMBank], a
 	ld [MBC1RomBank], a
-	ld a, [wd11e]
+	ld a, [wNamedObjectIndex]
 	dec a
 	ld hl, MonsterNames
 	ld c, NAME_LENGTH - 1
@@ -25,10 +25,10 @@ GetMonName::
 	ret
 
 GetItemName::
-; given an item ID at [wd11e], store the name of the item in wNameBuffer
+; given an item ID at [wNamedObjectIndex], store the name of the item in wNameBuffer
 	push hl
 	push bc
-	ld a, [wd11e]
+	ld a, [wNamedObjectIndex]
 	cp HM01 ; is this a TM/HM?
 	jr nc, .Machine
 
@@ -49,18 +49,18 @@ GetItemName::
 	ret
 
 GetMachineName::
-; copies the name of the TM/HM in [wd11e] to wNameBuffer
+; copies the name of the TM/HM in [wNamedObjectIndex] to wNameBuffer
 	push hl
 	push de
 	push bc
-	ld a, [wd11e]
+	ld a, [wNamedObjectIndex]
 	push af
 	cp TM01 ; is this a TM? [not HM]
 	jr nc, .WriteTM
 ; if HM, then write "HM" and add NUM_HMS to the item ID, so we can reuse the
 ; TM printing code
 	add NUM_HMS
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	ld hl, HiddenPrefix ; points to "HM"
 	ld bc, 2
 	jr .WriteMachinePrefix
@@ -72,7 +72,7 @@ GetMachineName::
 	call CopyData
 
 ; now get the machine number and convert it to text
-	ld a, [wd11e]
+	ld a, [wNamedObjectIndex]
 	sub TM01 - 1
 	ld b, "0"
 .FirstDigit
@@ -94,7 +94,7 @@ GetMachineName::
 	ld a, "@"
 	ld [de], a
 	pop af
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	pop bc
 	pop de
 	pop hl
@@ -130,7 +130,7 @@ GetMoveName::
 	push hl
 	ld a, MOVE_NAME
 	ld [wNameListType], a
-	ld a, [wd11e]
+	ld a, [wNamedObjectIndex]
 	ld [wd0b5], a
 	ld a, BANK(MoveNames)
 	ld [wPredefBank], a

--- a/home/names.asm
+++ b/home/names.asm
@@ -32,7 +32,7 @@ GetItemName::
 	cp HM01 ; is this a TM/HM?
 	jr nc, .Machine
 
-	ld [wd0b5], a
+	ld [wNameListIndex], a
 	ld a, ITEM_NAME
 	ld [wNameListType], a
 	ld a, BANK(ItemNames)
@@ -131,7 +131,7 @@ GetMoveName::
 	ld a, MOVE_NAME
 	ld [wNameListType], a
 	ld a, [wNamedObjectIndex]
-	ld [wd0b5], a
+	ld [wNameListIndex], a
 	ld a, BANK(MoveNames)
 	ld [wPredefBank], a
 	call GetName

--- a/home/names2.asm
+++ b/home/names2.asm
@@ -16,7 +16,7 @@ GetName::
 ;
 ; returns pointer to name in de
 	ld a, [wd0b5]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 
 	; TM names are separate from item names.
 	; BUG: This applies to all names instead of just items.

--- a/home/names2.asm
+++ b/home/names2.asm
@@ -10,12 +10,12 @@ NamePointers::
 
 GetName::
 ; arguments:
-; [wd0b5] = which name
+; [wNameListIndex] = which name
 ; [wNameListType] = which list
 ; [wPredefBank] = bank of list
 ;
 ; returns pointer to name in de
-	ld a, [wd0b5]
+	ld a, [wNameListIndex]
 	ld [wNamedObjectIndex], a
 
 	; TM names are separate from item names.
@@ -67,7 +67,7 @@ GetName::
 	ld h, a
 	ldh a, [hSwapTemp + 1]
 	ld l, a
-	ld a, [wd0b5]
+	ld a, [wNameListIndex]
 	ld b, a ; wanted entry
 	ld c, 0 ; entry counter
 .nextName

--- a/home/pokemon.asm
+++ b/home/pokemon.asm
@@ -371,7 +371,7 @@ GetwMoves::
 
 ; copies the base stat data of a pokemon to wMonHeader
 ; INPUT:
-; [wd0b5] = pokemon ID
+; [wCurSpecies] = pokemon ID
 GetMonHeader::
 	ldh a, [hLoadedROMBank]
 	push af
@@ -383,7 +383,7 @@ GetMonHeader::
 	push hl
 	ld a, [wPokedexNum]
 	push af
-	ld a, [wd0b5]
+	ld a, [wCurSpecies]
 	ld [wPokedexNum], a
 	ld de, FossilKabutopsPic
 	ld b, $66 ; size of Kabutops fossil and Ghost sprites
@@ -423,7 +423,7 @@ GetMonHeader::
 	ld a, BANK(MewBaseStats)
 	call FarCopyData
 .done
-	ld a, [wd0b5]
+	ld a, [wCurSpecies]
 	ld [wMonHIndex], a
 	pop af
 	ld [wPokedexNum], a

--- a/home/pokemon.asm
+++ b/home/pokemon.asm
@@ -99,7 +99,7 @@ LoadFlippedFrontSpriteByMonIndex::
 
 LoadFrontSpriteByMonIndex::
 	push hl
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	push af
 	ld a, [wCurPartySpecies]
 	ld [wPokedexNum], a
@@ -355,8 +355,8 @@ PrintLevelFull::
 	ld a, [wLoadedMonLevel] ; level
 
 PrintLevelCommon::
-	ld [wd11e], a
-	ld de, wd11e
+	ld [wTempByteValue], a
+	ld de, wTempByteValue
 	ld b, LEFT_ALIGN | 1 ; 1 byte
 	jp PrintNumber
 
@@ -381,7 +381,7 @@ GetMonHeader::
 	push bc
 	push de
 	push hl
-	ld a, [wd11e]
+	ld a, [wPokedexNum]
 	push af
 	ld a, [wd0b5]
 	ld [wPokedexNum], a
@@ -426,7 +426,7 @@ GetMonHeader::
 	ld a, [wd0b5]
 	ld [wMonHIndex], a
 	pop af
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	pop hl
 	pop de
 	pop bc

--- a/home/pokemon.asm
+++ b/home/pokemon.asm
@@ -102,9 +102,9 @@ LoadFrontSpriteByMonIndex::
 	ld a, [wd11e]
 	push af
 	ld a, [wCurPartySpecies]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	predef IndexToPokedex
-	ld hl, wd11e
+	ld hl, wPokedexNum
 	ld a, [hl]
 	pop bc
 	ld [hl], b
@@ -384,7 +384,7 @@ GetMonHeader::
 	ld a, [wd11e]
 	push af
 	ld a, [wd0b5]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ld de, FossilKabutopsPic
 	ld b, $66 ; size of Kabutops fossil and Ghost sprites
 	cp FOSSIL_KABUTOPS ; Kabutops fossil
@@ -398,8 +398,8 @@ GetMonHeader::
 	jr z, .specialID
 	cp MEW
 	jr z, .mew
-	predef IndexToPokedex   ; convert pokemon ID in [wd11e] to pokedex number
-	ld a, [wd11e]
+	predef IndexToPokedex
+	ld a, [wPokedexNum]
 	dec a
 	ld bc, BASE_DATA_SIZE
 	ld hl, BaseStats

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1557,18 +1557,19 @@ wCapturedMonSpecies:: db
 wFirstMonsNotOutYet:: db
 
 wNamedObjectIndex::
+wNumSetBits::
+wTypeEffectiveness::
+wMoveType::
+wUsingPPUp::
+wMaxPP::
+wMoveGrammar::
+; 0 for player, non-zero for enemy
+wCalculateWhoseStats::
 wPokeBallCaptureCalcTemp::
 ; lower nybble: number of shakes
 ; upper nybble: number of animations to play
 wPokeBallAnimData::
-wUsingPPUp::
-wMaxPP::
-; 0 for player, non-zero for enemy
-wCalculateWhoseStats::
-wTypeEffectiveness::
-wMoveType::
-wNumSetBits::
-; used as a Pokemon and Item storage value. Also used as an output value for CountSetBits
+; used as a Pokemon and Item storage value.
 wd11e::
 	db
 

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1490,8 +1490,10 @@ wSpriteDecodeTable0Ptr:: dw
 ; pointer to differential decoding table (assuming initial value 1)
 wSpriteDecodeTable1Ptr:: dw
 
-wd0b5:: db ; used as a temp storage area for Pokemon Species, and other Pokemon/Battle related things
-
+; input for GetMonHeader
+wCurSpecies::
+; input for GetName
+wNameListIndex:: db
 wNameListType:: db
 
 wPredefBank:: db

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1557,10 +1557,12 @@ wCapturedMonSpecies:: db
 wFirstMonsNotOutYet:: db
 
 wNamedObjectIndex::
+wTempByteValue::
 wNumSetBits::
 wTypeEffectiveness::
 wMoveType::
 wPokedexNum::
+wTempTMHM::
 wUsingPPUp::
 wMaxPP::
 wMoveGrammar::
@@ -1570,8 +1572,6 @@ wPokeBallCaptureCalcTemp::
 ; lower nybble: number of shakes
 ; upper nybble: number of animations to play
 wPokeBallAnimData::
-; used as a Pokemon and Item storage value.
-wd11e::
 	db
 
 ; When this value is non-zero, the player isn't allowed to exit the party menu

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1556,6 +1556,7 @@ wCapturedMonSpecies:: db
 ; which will be the first mon sent out.
 wFirstMonsNotOutYet:: db
 
+wNamedObjectIndex::
 wPokeBallCaptureCalcTemp::
 ; lower nybble: number of shakes
 ; upper nybble: number of animations to play

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1560,6 +1560,7 @@ wNamedObjectIndex::
 wNumSetBits::
 wTypeEffectiveness::
 wMoveType::
+wPokedexNum::
 wUsingPPUp::
 wMaxPP::
 wMoveGrammar::

--- a/scripts/CeladonMartRoof.asm
+++ b/scripts/CeladonMartRoof.asm
@@ -13,15 +13,16 @@ CeladonMartRoofScript_GetDrinksInBag:
 	jr z, .done
 	push hl
 	push de
-	ld [wd11e], a
+	ld [wTempByteValue], a
 	ld b, a
 	predef GetQuantityOfItemInBag
 	pop de
 	pop hl
 	ld a, b
 	and a
-	jr z, .loop ; if the item isn't in the bag
-	ld a, [wd11e]
+	jr z, .loop
+	; A drink is in the bag
+	ld a, [wTempByteValue]
 	ld [de], a
 	inc de
 	push hl

--- a/scripts/CeladonMartRoof.asm
+++ b/scripts/CeladonMartRoof.asm
@@ -192,7 +192,7 @@ CeladonMartRoofScript_PrintDrinksInBag:
 	cp $ff
 	ret z
 	push hl
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	hlcoord 2, 2
 	ldh a, [hItemCounter]

--- a/scripts/ChampionsRoom.asm
+++ b/scripts/ChampionsRoom.asm
@@ -281,7 +281,7 @@ ChampionsRoomOakText:
 ChampionsRoomOakCongratulatesPlayerText:
 	text_asm
 	ld a, [wPlayerStarter]
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld hl, .Text
 	call PrintText

--- a/scripts/CinnabarLabFossilRoom.asm
+++ b/scripts/CinnabarLabFossilRoom.asm
@@ -18,7 +18,7 @@ Lab4Script_GetFossilsInBag:
 	jr z, .done
 	push hl
 	push de
-	ld [wd11e], a
+	ld [wTempByteValue], a
 	ld b, a
 	predef GetQuantityOfItemInBag
 	pop de
@@ -26,9 +26,8 @@ Lab4Script_GetFossilsInBag:
 	ld a, b
 	and a
 	jr z, .loop
-
-	; A fossil's in the bag
-	ld a, [wd11e]
+	; A fossil is in the bag
+	ld a, [wTempByteValue]
 	ld [de], a
 	inc de
 	push hl

--- a/scripts/OaksLab.asm
+++ b/scripts/OaksLab.asm
@@ -825,7 +825,7 @@ OaksLabBulbasaurPokeBallText:
 
 OaksLabSelectedPokeBallScript:
 	ld [wCurPartySpecies], a
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	ld a, b
 	ld [wSpriteIndex], a
 	CheckEvent EVENT_GOT_STARTER
@@ -927,7 +927,7 @@ OaksLabMonChoiceMenu:
 	ld a, 5
 	ld [wCurEnemyLevel], a
 	ld a, [wCurPartySpecies]
-	ld [wd11e], a
+	ld [wPokedexNum], a
 	call AddPartyMon
 	ld hl, wStatusFlags4
 	set BIT_GOT_STARTER, [hl]

--- a/scripts/OaksLab.asm
+++ b/scripts/OaksLab.asm
@@ -322,7 +322,7 @@ OaksLabRivalChoosesStarterScript:
 	ld a, [wRivalStarterTemp]
 	ld [wRivalStarter], a
 	ld [wCurPartySpecies], a
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld a, OAKSLAB_RIVAL
 	ldh [hSpriteIndex], a
@@ -899,7 +899,7 @@ OaksLabMonChoiceMenu:
 	jr nz, OaksLabMonChoiceEnd
 	ld a, [wCurPartySpecies]
 	ld [wPlayerStarter], a
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetMonName
 	ld a, [wSpriteIndex]
 	cp OAKSLAB_CHARMANDER_POKE_BALL

--- a/scripts/Route11Gate2F.asm
+++ b/scripts/Route11Gate2F.asm
@@ -24,7 +24,7 @@ Route11Gate2FOaksAideText:
 	ldh [hOaksAideRequirement], a
 	ld a, ITEMFINDER
 	ldh [hOaksAideRewardItem], a
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	ld h, d
 	ld l, e

--- a/scripts/Route15Gate2F.asm
+++ b/scripts/Route15Gate2F.asm
@@ -14,7 +14,7 @@ Route15Gate2FOaksAideText:
 	ldh [hOaksAideRequirement], a
 	ld a, EXP_ALL
 	ldh [hOaksAideRewardItem], a
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	ld hl, wNameBuffer
 	ld de, wOaksAideRewardItemName

--- a/scripts/Route2Gate.asm
+++ b/scripts/Route2Gate.asm
@@ -14,7 +14,7 @@ Route2GateOaksAideText:
 	ldh [hOaksAideRequirement], a
 	ld a, HM_FLASH
 	ldh [hOaksAideRewardItem], a
-	ld [wd11e], a
+	ld [wNamedObjectIndex], a
 	call GetItemName
 	ld hl, wNameBuffer
 	ld de, wOaksAideRewardItemName


### PR DESCRIPTION
Fixes #456, and makes pokered 100% labeled!

```console
$ tools/unnamed.py -r . -l 30 pokered.sym
Unnamed pokered symbols: 0 (100.00% complete)
```

Formerly `wd0b5`:

- `wCurSpecies` is copied from Gen 2. It's primarily the input argument to `GetMonHeader` (aka `GetBaseData` in Gen 2).
- `wNameListIndex` is one argument to `GetName`, along with `wNameListType` (which says whether the index is for a mon, move, item, or trainer).

Formerly `wd11e`:

- `wNamedObjectIndex` is copied from Gen 2. I could have defined separate labels for Pokemon, item, and move IDs, but there's enough overlap (e.g. functions that sometimes print one and sometimes another, or how the generic `GetName` outputs to this) that I thought this was better.
- `wTempByteValue` is copied from Gen 2. Used in a few places for very local values, e.g. a place to stash+retrieve a value that's used only in one function or even in one "paragraph" of one function.
- `wPokedexNum` is "the `IndexToPokedex` or `PokedexToIndex` variable"; it acts as both input and output, i.e. both species and Pokedex number.
- `wTempTMHM` is copied from Gen 2. It's "the `TMToMove` variable" (aka `GetTMHMMove` in Gen 2): it acts as both input and output, e.g. both TM item number and move number.
- `wMoveGrammar` is copied from Gen 2. It's "the `DetermineExclamationPointTextNum` variable" (aka `GetMoveGrammar` in Gen 2): it acts as both input and output, i.e. both move ID and grammar/exclamation index (0-3).
