### PR TITLE
Identify `wCurrentMapScriptFlags` bits

### DIFF
--- a/constants/ram_constants.asm
+++ b/constants/ram_constants.asm
@@ -23,6 +23,12 @@ DEF BIT_TEXT_PREDEF EQU 0
 ; wFontLoaded
 DEF BIT_FONT_LOADED EQU 0
 
+; wCurrentMapScriptFlags
+	const_def 5
+	const BIT_CUR_MAP_LOADED_1 ; 5
+	const BIT_CUR_MAP_LOADED_2 ; 6
+	const BIT_CUR_MAP_USED_ELEVATOR ; 7
+
 ; wOptions
 DEF TEXT_DELAY_MASK EQU %111
 	const_def 6

--- a/engine/events/card_key.asm
+++ b/engine/events/card_key.asm
@@ -50,7 +50,7 @@ PrintCardKeyText:
 	ld [wNewTileBlockID], a
 	predef ReplaceTileBlock
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 	ld a, SFX_GO_INSIDE
 	jp PlaySound
 .noCardKey

--- a/engine/events/elevator.asm
+++ b/engine/events/elevator.asm
@@ -20,7 +20,7 @@ DisplayElevatorFloorMenu:
 	ld [wListScrollOffset], a
 	ret c
 	ld hl, wCurrentMapScriptFlags
-	set 7, [hl]
+	set BIT_CUR_MAP_USED_ELEVATOR, [hl]
 	ld hl, wElevatorWarpMaps
 	ld a, [wWhichPokemon]
 	add a

--- a/engine/events/hidden_objects/cinnabar_gym_quiz.asm
+++ b/engine/events/hidden_objects/cinnabar_gym_quiz.asm
@@ -83,7 +83,7 @@ CinnabarGymQuiz_AskQuestion:
 	cp c
 	jr nz, .wrongAnswer
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 	ldh a, [hGymGateIndex]
 	ldh [hBackupGymGateIndex], a
 	ld hl, CinnabarGymQuizCorrectText

--- a/engine/events/hidden_objects/vermilion_gym_trash.asm
+++ b/engine/events/hidden_objects/vermilion_gym_trash.asm
@@ -97,7 +97,7 @@ GymTrashScript:
 ; Completed the trash can puzzle.
 	SetEvent EVENT_2ND_LOCK_OPENED
 	ld hl, wCurrentMapScriptFlags
-	set 6, [hl]
+	set BIT_CUR_MAP_LOADED_2, [hl]
 
 	tx_pre_id VermilionGymTrashSuccessText3
 

--- a/engine/menus/main_menu.asm
+++ b/engine/menus/main_menu.asm
@@ -91,7 +91,7 @@ MainMenu:
 .choseContinue
 	call DisplayContinueGameInfo
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 .inputLoop
 	xor a
 	ldh [hJoyPressed], a

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -33,8 +33,8 @@ EnterMap::
 	res BIT_NO_NPC_FACE_PLAYER, [hl]
 	call UpdateSprites
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
-	set 6, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
+	set BIT_CUR_MAP_LOADED_2, [hl]
 	xor a
 	ld [wJoyIgnore], a
 
@@ -329,8 +329,8 @@ OverworldLoopLessDelay::
 	ld hl, wStatusFlags7
 	res BIT_TRAINER_BATTLE, [hl]
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
-	set 6, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
+	set BIT_CUR_MAP_LOADED_2, [hl]
 	xor a
 	ldh [hJoyHeld], a
 	ld a, [wCurMap]

--- a/home/trainers.asm
+++ b/home/trainers.asm
@@ -184,8 +184,8 @@ StartTrainerBattle::
 
 EndTrainerBattle::
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
-	set 6, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
+	set BIT_CUR_MAP_LOADED_2, [hl]
 	ld hl, wStatusFlags3
 	res BIT_PRINT_END_BATTLE_TEXT, [hl]
 	ld hl, wMiscFlags

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1593,7 +1593,10 @@ wIsKeyItem:: db
 
 wTextBoxID:: db
 
-wCurrentMapScriptFlags:: db ; not exactly sure what this is used for, but it seems to be used as a multipurpose temp flag value
+; bit 5:set when maps first load; can be reset to re-run a script
+; bit 6: set when maps first load; can be reset to re-run a script (used less often than bit 5)
+; bit 7: set when using an elevator map's menu; sets of the shaking animation
+wCurrentMapScriptFlags:: db
 
 wCurEnemyLevel:: db
 

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1593,9 +1593,9 @@ wIsKeyItem:: db
 
 wTextBoxID:: db
 
-; bit 5:set when maps first load; can be reset to re-run a script
+; bit 5: set when maps first load; can be reset to re-run a script
 ; bit 6: set when maps first load; can be reset to re-run a script (used less often than bit 5)
-; bit 7: set when using an elevator map's menu; sets of the shaking animation
+; bit 7: set when using an elevator map's menu; triggers the shaking animation
 wCurrentMapScriptFlags:: db
 
 wCurEnemyLevel:: db

--- a/scripts/AgathasRoom.asm
+++ b/scripts/AgathasRoom.asm
@@ -11,8 +11,8 @@ AgathasRoom_Script:
 AgathaShowOrHideExitBlock:
 ; Blocks or clears the exit to the next room.
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEvent EVENT_BEAT_AGATHAS_ROOM_TRAINER_0
 	jr z, .blockExitToNextRoom

--- a/scripts/BrunosRoom.asm
+++ b/scripts/BrunosRoom.asm
@@ -11,8 +11,8 @@ BrunosRoom_Script:
 BrunoShowOrHideExitBlock:
 ; Blocks or clears the exit to the next room.
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEvent EVENT_BEAT_BRUNOS_ROOM_TRAINER_0
 	jr z, .blockExitToNextRoom

--- a/scripts/CeladonGym.asm
+++ b/scripts/CeladonGym.asm
@@ -1,7 +1,7 @@
 CeladonGym_Script:
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	call nz, .LoadNames
 	call EnableAutoTextBoxDrawing
 	ld hl, CeladonGymTrainerHeaders

--- a/scripts/CeladonMartElevator.asm
+++ b/scripts/CeladonMartElevator.asm
@@ -1,12 +1,12 @@
 CeladonMartElevator_Script:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	push hl
 	call nz, CeladonMartElevatorStoreWarpEntriesScript
 	pop hl
-	bit 7, [hl]
-	res 7, [hl]
+	bit BIT_CUR_MAP_USED_ELEVATOR, [hl]
+	res BIT_CUR_MAP_USED_ELEVATOR, [hl]
 	call nz, CeladonMartElevatorShakeScript
 	xor a
 	ld [wAutoTextBoxDrawingControl], a

--- a/scripts/CeruleanGym.asm
+++ b/scripts/CeruleanGym.asm
@@ -1,7 +1,7 @@
 CeruleanGym_Script:
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	call nz, .LoadNames
 	call EnableAutoTextBoxDrawing
 	ld hl, CeruleanGymTrainerHeaders

--- a/scripts/CinnabarGym.asm
+++ b/scripts/CinnabarGym.asm
@@ -7,13 +7,13 @@ CinnabarGym_Script:
 
 CinnabarGymSetMapAndTiles:
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	push hl
 	call nz, .LoadNames
 	pop hl
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	call nz, UpdateCinnabarGymGateTileBlocks
 	ResetEvent EVENT_2A7
 	ret
@@ -170,7 +170,7 @@ CinnabarGymReceiveTM38:
 	SetEventRange EVENT_BEAT_CINNABAR_GYM_TRAINER_0, EVENT_BEAT_CINNABAR_GYM_TRAINER_6
 
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 
 	jp CinnabarGymResetScripts
 

--- a/scripts/CinnabarIsland.asm
+++ b/scripts/CinnabarIsland.asm
@@ -1,7 +1,7 @@
 CinnabarIsland_Script:
 	call EnableAutoTextBoxDrawing
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 	ResetEvent EVENT_MANSION_SWITCH_ON
 	ResetEvent EVENT_LAB_STILL_REVIVING_FOSSIL
 	ld hl, CinnabarIsland_ScriptPointers

--- a/scripts/FuchsiaGym.asm
+++ b/scripts/FuchsiaGym.asm
@@ -10,8 +10,8 @@ FuchsiaGym_Script:
 
 .LoadNames:
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	ret z
 	ld hl, .CityName
 	ld de, .LeaderName

--- a/scripts/GameCorner.asm
+++ b/scripts/GameCorner.asm
@@ -8,8 +8,8 @@ GameCorner_Script:
 
 GameCornerSelectLuckySlotMachine:
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	ret z
 	call Random
 	ldh a, [hRandomAdd]
@@ -25,8 +25,8 @@ GameCornerSelectLuckySlotMachine:
 
 GameCornerSetRocketHideoutDoorTile:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEvent EVENT_FOUND_ROCKET_HIDEOUT
 	ret nz
@@ -111,8 +111,8 @@ GameCornerRocketExitScript:
 	ld [wMissableObjectIndex], a
 	predef HideObject
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
-	set 6, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
+	set BIT_CUR_MAP_LOADED_2, [hl]
 	ld a, SCRIPT_GAMECORNER_DEFAULT
 	ld [wGameCornerCurScript], a
 	ret

--- a/scripts/IndigoPlateauLobby.asm
+++ b/scripts/IndigoPlateauLobby.asm
@@ -2,8 +2,8 @@ IndigoPlateauLobby_Script:
 	call Serial_TryEstablishingExternallyClockedConnection
 	call EnableAutoTextBoxDrawing
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	ret z
 	ResetEvent EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH
 	; Reset Elite Four events if the player started challenging them before

--- a/scripts/LancesRoom.asm
+++ b/scripts/LancesRoom.asm
@@ -10,8 +10,8 @@ LancesRoom_Script:
 
 LanceShowOrHideEntranceBlocks:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEvent EVENT_LANCES_ROOM_LOCK_DOOR
 	jr nz, .closeEntrance
@@ -71,7 +71,7 @@ LancesRoomDefaultScript:
 	CheckAndSetEvent EVENT_LANCES_ROOM_LOCK_DOOR
 	ret nz
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 	ld a, SFX_GO_INSIDE
 	call PlaySound
 	jp LanceShowOrHideEntranceBlocks

--- a/scripts/LoreleisRoom.asm
+++ b/scripts/LoreleisRoom.asm
@@ -11,8 +11,8 @@ LoreleisRoom_Script:
 LoreleiShowOrHideExitBlock:
 ; Blocks or clears the exit to the next room.
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, wElite4Flags
 	set BIT_STARTED_ELITE_4, [hl]

--- a/scripts/PewterGym.asm
+++ b/scripts/PewterGym.asm
@@ -1,7 +1,7 @@
 PewterGym_Script:
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	call nz, .LoadNames
 	call EnableAutoTextBoxDrawing
 	ld hl, PewterGymTrainerHeaders

--- a/scripts/PokemonMansion1F.asm
+++ b/scripts/PokemonMansion1F.asm
@@ -10,8 +10,8 @@ PokemonMansion1F_Script:
 
 Mansion1CheckReplaceSwitchDoorBlocks:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEvent EVENT_MANSION_SWITCH_ON
 	jr nz, .switchTurnedOn
@@ -103,7 +103,7 @@ PokemonMansion1FSwitchText:
 	ld a, $1
 	ld [wDoNotWaitForButtonPressAfterDisplayingText], a
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 	ld hl, .PressedText
 	call PrintText
 	ld a, SFX_GO_INSIDE

--- a/scripts/PokemonMansion2F.asm
+++ b/scripts/PokemonMansion2F.asm
@@ -10,8 +10,8 @@ PokemonMansion2F_Script:
 
 Mansion2CheckReplaceSwitchDoorBlocks:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEvent EVENT_MANSION_SWITCH_ON
 	jr nz, .switchTurnedOn
@@ -108,7 +108,7 @@ PokemonMansion2FSwitchText:
 	ld a, $1
 	ld [wDoNotWaitForButtonPressAfterDisplayingText], a
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 	ld hl, .PressedText
 	call PrintText
 	ld a, SFX_GO_INSIDE

--- a/scripts/PokemonMansion3F.asm
+++ b/scripts/PokemonMansion3F.asm
@@ -10,8 +10,8 @@ PokemonMansion3F_Script:
 
 Mansion3CheckReplaceSwitchDoorBlocks:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEvent EVENT_MANSION_SWITCH_ON
 	jr nz, .switchTurnedOn

--- a/scripts/PokemonMansionB1F.asm
+++ b/scripts/PokemonMansionB1F.asm
@@ -10,8 +10,8 @@ PokemonMansionB1F_Script:
 
 MansionB1FCheckReplaceSwitchDoorBlocks:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEvent EVENT_MANSION_SWITCH_ON
 	jr nz, .switchTurnedOn

--- a/scripts/RocketHideoutB1F.asm
+++ b/scripts/RocketHideoutB1F.asm
@@ -10,8 +10,8 @@ RocketHideoutB1F_Script:
 
 RocketHideoutB1FDoorCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEvent EVENT_677
 	jr nz, .door_open

--- a/scripts/RocketHideoutB4F.asm
+++ b/scripts/RocketHideoutB4F.asm
@@ -10,8 +10,8 @@ RocketHideoutB4F_Script:
 
 RocketHideoutB4FDoorCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEvent EVENT_ROCKET_HIDEOUT_4_DOOR_UNLOCKED
 	jr nz, .door_already_unlocked
@@ -67,7 +67,7 @@ RocketHideoutB4FBeatGiovanniScript:
 	xor a
 	ld [wJoyIgnore], a
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 	ld a, SCRIPT_ROCKETHIDEOUTB4F_DEFAULT
 	ld [wRocketHideoutB4FCurScript], a
 	ld [wCurMapScript], a

--- a/scripts/RocketHideoutElevator.asm
+++ b/scripts/RocketHideoutElevator.asm
@@ -1,12 +1,12 @@
 RocketHideoutElevator_Script:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	push hl
 	call nz, RocketHideoutElevatorStoreWarpEntriesScript
 	pop hl
-	bit 7, [hl]
-	res 7, [hl]
+	bit BIT_CUR_MAP_USED_ELEVATOR, [hl]
+	res BIT_CUR_MAP_USED_ELEVATOR, [hl]
 	call nz, RocketHideoutElevatorShakeScript
 	xor a
 	ld [wAutoTextBoxDrawingControl], a

--- a/scripts/Route23.asm
+++ b/scripts/Route23.asm
@@ -7,8 +7,8 @@ Route23_Script:
 
 Route23SetVictoryRoadBoulders:
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	ret z
 	ResetEvents EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH1, EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH2
 	ResetEvents EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH1, EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH2

--- a/scripts/Route25.asm
+++ b/scripts/Route25.asm
@@ -10,8 +10,8 @@ Route25_Script:
 
 Route25ShowHideBillScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	ret z
 	CheckEventHL EVENT_LEFT_BILLS_HOUSE_AFTER_HELPING
 	ret nz

--- a/scripts/SaffronGym.asm
+++ b/scripts/SaffronGym.asm
@@ -1,7 +1,7 @@
 SaffronGym_Script:
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	call nz, .LoadNames
 	call EnableAutoTextBoxDrawing
 	ld hl, SaffronGymTrainerHeaders

--- a/scripts/SilphCo10F.asm
+++ b/scripts/SilphCo10F.asm
@@ -10,8 +10,8 @@ SilphCo10F_Script:
 
 SilphCo10FGateCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, .GateCoordinates
 	call SilphCo2F_SetCardKeyDoorYScript

--- a/scripts/SilphCo11F.asm
+++ b/scripts/SilphCo11F.asm
@@ -10,8 +10,8 @@ SilphCo11F_Script:
 
 SilphCo11FGateCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, SilphCo11GateCoords
 	call SilphCo11F_SetCardKeyDoorYScript

--- a/scripts/SilphCo2F.asm
+++ b/scripts/SilphCo2F.asm
@@ -10,8 +10,8 @@ SilphCo2F_Script:
 
 SilphCo2FGateCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, .GateCoordinates
 	call SilphCo2F_SetCardKeyDoorYScript

--- a/scripts/SilphCo3F.asm
+++ b/scripts/SilphCo3F.asm
@@ -10,8 +10,8 @@ SilphCo3F_Script:
 
 SilphCo3FGateCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, .GateCoordinates
 	call SilphCo2F_SetCardKeyDoorYScript

--- a/scripts/SilphCo4F.asm
+++ b/scripts/SilphCo4F.asm
@@ -10,8 +10,8 @@ SilphCo4F_Script:
 
 SilphCo4FGateCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, .GateCoordinates
 	call SilphCo4F_SetCardKeyDoorYScript

--- a/scripts/SilphCo5F.asm
+++ b/scripts/SilphCo5F.asm
@@ -10,8 +10,8 @@ SilphCo5F_Script:
 
 SilphCo5FGateCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, .GateCoordinates
 	call SilphCo4F_SetCardKeyDoorYScript

--- a/scripts/SilphCo6F.asm
+++ b/scripts/SilphCo6F.asm
@@ -10,8 +10,8 @@ SilphCo6F_Script:
 
 SilphCo6F_GateCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, .GateCoordinates
 	call SilphCo4F_SetCardKeyDoorYScript

--- a/scripts/SilphCo7F.asm
+++ b/scripts/SilphCo7F.asm
@@ -10,8 +10,8 @@ SilphCo7F_Script:
 
 SilphCo7F_GateCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, .GateCoordinates
 	call SilphCo7F_SetCardKeyDoorYScript

--- a/scripts/SilphCo8F.asm
+++ b/scripts/SilphCo8F.asm
@@ -10,8 +10,8 @@ SilphCo8F_Script:
 
 SilphCo8FGateCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, .GateCoordinates
 	call SilphCo8F_SetCardKeyDoorYScript

--- a/scripts/SilphCo9F.asm
+++ b/scripts/SilphCo9F.asm
@@ -10,8 +10,8 @@ SilphCo9F_Script:
 
 SilphCo9FGateCallbackScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	ld hl, .GateCoordinates
 	call SilphCo9F_SetCardKeyDoorYScript

--- a/scripts/SilphCoElevator.asm
+++ b/scripts/SilphCoElevator.asm
@@ -1,12 +1,12 @@
 SilphCoElevator_Script:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	push hl
 	call nz, SilphCoElevatorStoreWarpEntriesScript
 	pop hl
-	bit 7, [hl]
-	res 7, [hl]
+	bit BIT_CUR_MAP_USED_ELEVATOR, [hl]
+	res BIT_CUR_MAP_USED_ELEVATOR, [hl]
 	call nz, SilphCoElevatorShakeScript
 	xor a
 	ld [wAutoTextBoxDrawingControl], a

--- a/scripts/VermilionCity.asm
+++ b/scripts/VermilionCity.asm
@@ -1,13 +1,13 @@
 VermilionCity_Script:
 	call EnableAutoTextBoxDrawing
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	push hl
 	call nz, VermilionCityLeftSSAnneCallbackScript
 	pop hl
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	call nz, .setFirstLockTrashCanIndex
 	ld hl, VermilionCity_ScriptPointers
 	ld a, [wVermilionCityCurScript]

--- a/scripts/VermilionGym.asm
+++ b/scripts/VermilionGym.asm
@@ -1,12 +1,12 @@
 VermilionGym_Script:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	push hl
 	call nz, .LoadNames
 	pop hl
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	call nz, VermilionGymSetDoorTile
 	call EnableAutoTextBoxDrawing
 	ld hl, VermilionGymTrainerHeaders

--- a/scripts/VictoryRoad1F.asm
+++ b/scripts/VictoryRoad1F.asm
@@ -1,7 +1,7 @@
 VictoryRoad1F_Script:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	call nz, .next
 	call EnableAutoTextBoxDrawing
 	ld hl, VictoryRoad1TrainerHeaders
@@ -31,7 +31,7 @@ VictoryRoad1FDefaultScript:
 	call CheckBoulderCoords
 	jp nc, CheckFightingMapTrainers
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 	SetEvent EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH
 	ret
 

--- a/scripts/VictoryRoad2F.asm
+++ b/scripts/VictoryRoad2F.asm
@@ -1,11 +1,11 @@
 VictoryRoad2F_Script:
 	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
+	bit BIT_CUR_MAP_LOADED_2, [hl]
+	res BIT_CUR_MAP_LOADED_2, [hl]
 	call nz, VictoryRoad2FResetBoulderEventScript
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	call nz, VictoryRoad2FCheckBoulderEventScript
 	call EnableAutoTextBoxDrawing
 	ld hl, VictoryRoad2TrainerHeaders
@@ -60,7 +60,7 @@ VictoryRoad2FDefaultScript:
 	ret nz
 .set_script_flag
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 	ret
 
 .SwitchCoords:

--- a/scripts/VictoryRoad3F.asm
+++ b/scripts/VictoryRoad3F.asm
@@ -10,8 +10,8 @@ VictoryRoad3F_Script:
 
 VictoryRoad3FCheckBoulderEventScript:
 	ld hl, wCurrentMapScriptFlags
-	bit 5, [hl]
-	res 5, [hl]
+	bit BIT_CUR_MAP_LOADED_1, [hl]
+	res BIT_CUR_MAP_LOADED_1, [hl]
 	ret z
 	CheckEventHL EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH1
 	ret z
@@ -38,7 +38,7 @@ VictoryRoad3FDefaultScript:
 	cp $1
 	jr nz, .handle_hole
 	ld hl, wCurrentMapScriptFlags
-	set 5, [hl]
+	set BIT_CUR_MAP_LOADED_1, [hl]
 	SetEvent EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH1
 	ret
 .handle_hole


### PR DESCRIPTION
`BIT_CUR_MAP_LOADED_1` is the more frequently used flag, mostly used for updating map blocks (when you use a Card Key, press a switch, enter an Elite 4 room, etc).

`BIT_CUR_MAP_LOADED_2` is mostly used for making Gyms load their statue sign names, and never re-`set` (with one exception in GameCorner.asm, which uses it to select a lucky slot machine, and re-`set`s it when the Rocket runs away).

But since they're not *exclusively* for "changing blocks" and "loading Gym names", I didn't want to name the constants after those.