### PR TITLE
This byte is written to, but not used

### DIFF
--- a/engine/movie/oak_speech/init_player_data.asm
+++ b/engine/movie/oak_speech/init_player_data.asm
@@ -34,7 +34,7 @@ DEF START_MONEY EQU $3000
 
 	ld hl, wObtainedBadges
 	ld [hli], a
-
+	assert wObtainedBadges + 1 == wUnusedObtainedBadges
 	ld [hl], a
 
 	ld hl, wPlayerCoins

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1743,7 +1743,7 @@ wOptions:: db
 
 wObtainedBadges:: flag_array NUM_BADGES
 
-wUnusedObtainedBadges:: db ; written but not read (see init_player_data.asm)
+wUnusedObtainedBadges:: db
 
 wLetterPrintingDelayFlags:: db
 

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1743,7 +1743,7 @@ wOptions:: db
 
 wObtainedBadges:: flag_array NUM_BADGES
 
-	ds 1
+wUnusedObtainedBadges:: db ; written but not read
 
 wLetterPrintingDelayFlags:: db
 

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1743,7 +1743,7 @@ wOptions:: db
 
 wObtainedBadges:: flag_array NUM_BADGES
 
-wUnusedObtainedBadges:: db ; written but not read
+wUnusedObtainedBadges:: db ; written but not read (see init_player_data.asm)
 
 wLetterPrintingDelayFlags:: db
 


### PR DESCRIPTION
it's written to in init_player_data.asm

```
ld hl, wObtainedBadges
	ld [hli], a
	ld [hl], a
```