### PR TITLE
Wrong macro used for EmotionBubblesOAM

### DIFF
--- a/engine/movie/trade.asm
+++ b/engine/movie/trade.asm
@@ -309,7 +309,7 @@ Trade_AnimateBallEnteringLinkCable:
 .moveBallInsideLinkCableLoop
 	push bc
 	xor a
-	ld de, Trade_BallInsideLinkCableOAM
+	ld de, Trade_BallInsideLinkCableOAMBlock
 	call WriteOAMBlock
 	ld a, [wLinkCableAnimBulgeToggle]
 	xor $1
@@ -345,9 +345,11 @@ Trade_AnimateBallEnteringLinkCable:
 	ldh [hAutoBGTransferEnabled], a
 	ret
 
-Trade_BallInsideLinkCableOAM:
-	dbsprite  0, 15,  0,  6, $7e, OAM_HFLIP
-	dbsprite  8, 15,  0,  6, $7e, OAM_HFLIP | OAM_VFLIP
+Trade_BallInsideLinkCableOAMBlock:
+	db $7e, 0
+	db $7e, OAM_HFLIP
+	db $7e, OAM_VFLIP
+	db $7e, OAM_HFLIP | OAM_VFLIP
 
 Trade_ShowEnemyMon:
 	ld a, TRADE_BALL_TILT_ANIM
@@ -616,7 +618,7 @@ Trade_AnimCircledMon:
 
 Trade_WriteCircledMonOAM:
 	farcall WriteMonPartySpriteOAMBySpecies
-	call Trade_WriteCircleOAM
+	call Trade_WriteCircleOAMBlock
 
 Trade_AddOffsetsToOAMCoords:
 	ld hl, wShadowOAM
@@ -670,11 +672,11 @@ Trade_AnimMonMoveVertical:
 	jr nz, .loop
 	ret
 
-Trade_WriteCircleOAM:
+Trade_WriteCircleOAMBlock:
 ; Writes the OAM blocks for the circle around the traded mon as it passes
 ; the link cable.
-	ld hl, Trade_CircleOAMPointers
-	ld c, $4
+	ld hl, Trade_CircleOAMBlocks
+	ld c, 4
 	xor a
 .loop
 	push bc
@@ -697,33 +699,41 @@ Trade_WriteCircleOAM:
 	jr nz, .loop
 	ret
 
-MACRO trade_circle_oam
+MACRO trade_circle_oam_block
+	; oam block pointer, upper-left x coord, upper-left y coord
 	dw \1
 	db \2, \3
 ENDM
 
-Trade_CircleOAMPointers:
-	; oam pointer, upper-left x coord, upper-left y coord
-	trade_circle_oam Trade_CircleOAM0, $08, $08
-	trade_circle_oam Trade_CircleOAM1, $18, $08
-	trade_circle_oam Trade_CircleOAM2, $08, $18
-	trade_circle_oam Trade_CircleOAM3, $18, $18
+Trade_CircleOAMBlocks:
+	trade_circle_oam_block .OAMBlock0,  8,  8
+	trade_circle_oam_block .OAMBlock1, 24,  8
+	trade_circle_oam_block .OAMBlock2,  8, 24
+	trade_circle_oam_block .OAMBlock3, 24, 24
 
-Trade_CircleOAM0:
-	dbsprite  2,  7,  0,  0, ICON_TRADEBUBBLE << 2 + 1, OAM_OBP1
-	dbsprite  2,  7,  0,  2, ICON_TRADEBUBBLE << 2 + 3, OAM_OBP1
+.OAMBlock0:
+	db ICON_TRADEBUBBLE << 2 + 0, OAM_OBP1
+	db ICON_TRADEBUBBLE << 2 + 1, OAM_OBP1
+	db ICON_TRADEBUBBLE << 2 + 2, OAM_OBP1
+	db ICON_TRADEBUBBLE << 2 + 3, OAM_OBP1
 
-Trade_CircleOAM1:
-	dbsprite  6,  7,  0,  1, ICON_TRADEBUBBLE << 2 + 0, OAM_OBP1 | OAM_HFLIP
-	dbsprite  6,  7,  0,  3, ICON_TRADEBUBBLE << 2 + 2, OAM_OBP1 | OAM_HFLIP
+.OAMBlock1:
+	db ICON_TRADEBUBBLE << 2 + 1, OAM_OBP1 | OAM_HFLIP
+	db ICON_TRADEBUBBLE << 2 + 0, OAM_OBP1 | OAM_HFLIP
+	db ICON_TRADEBUBBLE << 2 + 3, OAM_OBP1 | OAM_HFLIP
+	db ICON_TRADEBUBBLE << 2 + 2, OAM_OBP1 | OAM_HFLIP
 
-Trade_CircleOAM2:
-	dbsprite 10,  7,  0,  2, ICON_TRADEBUBBLE << 2 + 3, OAM_OBP1 | OAM_VFLIP
-	dbsprite 10,  7,  0,  0, ICON_TRADEBUBBLE << 2 + 1, OAM_OBP1 | OAM_VFLIP
+.OAMBlock2:
+	db ICON_TRADEBUBBLE << 2 + 2, OAM_OBP1 | OAM_VFLIP
+	db ICON_TRADEBUBBLE << 2 + 3, OAM_OBP1 | OAM_VFLIP
+	db ICON_TRADEBUBBLE << 2 + 0, OAM_OBP1 | OAM_VFLIP
+	db ICON_TRADEBUBBLE << 2 + 1, OAM_OBP1 | OAM_VFLIP
 
-Trade_CircleOAM3:
-	dbsprite 14,  7,  0,  3, ICON_TRADEBUBBLE << 2 + 2, OAM_OBP1 | OAM_HFLIP | OAM_VFLIP
-	dbsprite 14,  7,  0,  1, ICON_TRADEBUBBLE << 2 + 0, OAM_OBP1 | OAM_HFLIP | OAM_VFLIP
+.OAMBlock3:
+	db ICON_TRADEBUBBLE << 2 + 3, OAM_OBP1 | OAM_HFLIP | OAM_VFLIP
+	db ICON_TRADEBUBBLE << 2 + 2, OAM_OBP1 | OAM_HFLIP | OAM_VFLIP
+	db ICON_TRADEBUBBLE << 2 + 1, OAM_OBP1 | OAM_HFLIP | OAM_VFLIP
+	db ICON_TRADEBUBBLE << 2 + 0, OAM_OBP1 | OAM_HFLIP | OAM_VFLIP
 
 ; a = species
 Trade_LoadMonSprite:

--- a/engine/overworld/cut.asm
+++ b/engine/overworld/cut.asm
@@ -119,15 +119,15 @@ LoadCutGrassAnimationTilePattern:
 WriteCutOrBoulderDustAnimationOAMBlock:
 	call GetCutOrBoulderDustAnimationOffsets
 	ld a, $9
-	ld de, CutOrBoulderDustAnimationTilesAndAttributes
+	ld de, .OAMBlock
 	jp WriteOAMBlock
 
-CutOrBoulderDustAnimationTilesAndAttributes:
-	; tile ID, attributes
-	db $FC, OAM_OBP1
-	db $FD, OAM_OBP1
-	db $FE, OAM_OBP1
-	db $FF, OAM_OBP1
+.OAMBlock:
+; tile ID, attributes
+	db $fc, OAM_OBP1
+	db $fd, OAM_OBP1
+	db $fe, OAM_OBP1
+	db $ff, OAM_OBP1
 
 GetCutOrBoulderDustAnimationOffsets:
 	ld hl, wSpritePlayerStateData1YPixels

--- a/engine/overworld/cut.asm
+++ b/engine/overworld/cut.asm
@@ -124,10 +124,10 @@ WriteCutOrBoulderDustAnimationOAMBlock:
 
 CutOrBoulderDustAnimationTilesAndAttributes:
 	; tile ID, attributes
-	db $FC, %10010100
-	db $FD, %10010100
-	db $FE, %10010100
-	db $FF, %10010100
+	db $FC, OAM_OBP1
+	db $FD, OAM_OBP1
+	db $FE, OAM_OBP1
+	db $FF, OAM_OBP1
 
 GetCutOrBoulderDustAnimationOffsets:
 	ld hl, wSpritePlayerStateData1YPixels

--- a/engine/overworld/cut.asm
+++ b/engine/overworld/cut.asm
@@ -123,8 +123,11 @@ WriteCutOrBoulderDustAnimationOAMBlock:
 	jp WriteOAMBlock
 
 CutOrBoulderDustAnimationTilesAndAttributes:
-	dbsprite  2, -1,  0,  4, $fd, OAM_OBP1
-	dbsprite  2, -1,  0,  6, $ff, OAM_OBP1
+	; tile ID, attributes
+	db $FC, %10010100
+	db $FD, %10010100
+	db $FE, %10010100
+	db $FF, %10010100
 
 GetCutOrBoulderDustAnimationOffsets:
 	ld hl, wSpritePlayerStateData1YPixels

--- a/engine/overworld/emotion_bubbles.asm
+++ b/engine/overworld/emotion_bubbles.asm
@@ -67,9 +67,12 @@ EmotionBubblesPointerTable:
 	dw QuestionEmote
 	dw HappyEmote
 
+; tile ID and attribute
 EmotionBubblesOAM:
-	dbsprite  0, -1,  0,  0, $f9, 0
-	dbsprite  0, -1,  0,  2, $fb, 0
+	db $f8, 0
+	db $f9, 0
+	db $fa, 0
+	db $fb, 0
 
 EmotionBubbles:
 ShockEmote:    INCBIN "gfx/emotes/shock.2bpp"

--- a/engine/overworld/emotion_bubbles.asm
+++ b/engine/overworld/emotion_bubbles.asm
@@ -51,7 +51,7 @@ EmotionBubble:
 	add $8
 	ld c, a
 
-	ld de, EmotionBubblesOAM
+	ld de, EmotionBubblesOAMBlock
 	xor a
 	call WriteOAMBlock
 	ld c, 60
@@ -67,7 +67,7 @@ EmotionBubblesPointerTable:
 	dw QuestionEmote
 	dw HappyEmote
 
-EmotionBubblesOAM:
+EmotionBubblesOAMBlock:
 ; tile ID, attributes
 	db $f8, 0
 	db $f9, 0

--- a/engine/overworld/emotion_bubbles.asm
+++ b/engine/overworld/emotion_bubbles.asm
@@ -67,8 +67,8 @@ EmotionBubblesPointerTable:
 	dw QuestionEmote
 	dw HappyEmote
 
-; tile ID and attribute
 EmotionBubblesOAM:
+; tile ID, attributes
 	db $f8, 0
 	db $f9, 0
 	db $fa, 0

--- a/engine/overworld/ledges.asm
+++ b/engine/overworld/ledges.asm
@@ -63,7 +63,7 @@ LoadHoppingShadowOAM:
 	call CopyVideoDataDouble
 	ld a, $9
 	lb bc, $54, $48 ; b, c = y, x coordinates of shadow
-	ld de, LedgeHoppingShadowOAM
+	ld de, LedgeHoppingShadowOAMBlock
 	call WriteOAMBlock
 	ret
 
@@ -71,6 +71,9 @@ LedgeHoppingShadow:
 	INCBIN "gfx/overworld/shadow.1bpp"
 LedgeHoppingShadowEnd:
 
-LedgeHoppingShadowOAM:
-	dbsprite  2, -1,  0,  7, $ff, OAM_HFLIP
-	dbsprite  8, -1,  0,  7, $ff, OAM_HFLIP | OAM_VFLIP
+LedgeHoppingShadowOAMBlock:
+; tile ID, attributes
+	db $ff, OAM_OBP1
+	db $ff, OAM_HFLIP
+	db $ff, OAM_VFLIP
+	db $ff, OAM_HFLIP | OAM_VFLIP

--- a/scripts/VermilionDock.asm
+++ b/scripts/VermilionDock.asm
@@ -155,7 +155,7 @@ VermilionDock_EmitSmokePuff:
 	ret
 
 VermilionDockOAMBlock:
-	; tile id, attribute
+; tile ID, attributes
 	db $fc, $10
 	db $fd, $10
 	db $fe, $10


### PR DESCRIPTION
It's actually just the last 2 bytes of 4 OAM entries, see WriteOAMBlock for when it is used. BC is pre-loaded with the x and y pixels, whereas de (emotionBubblesOAM) is the tile id and attributes only. Not sure if there's a specific macro for this type of declaration.