### PR TITLE
Rewrite `transpose_tiles` to be in-place

### DIFF
--- a/tools/pkmncompress.c
+++ b/tools/pkmncompress.c
@@ -44,15 +44,18 @@ int read_bit(uint8_t *data) {
 }
 
 void transpose_tiles(uint8_t *data, int width) {
-	int size = width * width * 0x10;
-	uint8_t *transposed = xmalloc(size);
+	int size = width * width;
 	for (int i = 0; i < size; i++) {
-		int j = (i / 0x10) * width * 0x10;
-		j = (j % size) + 0x10 * (j / size) + (i % 0x10);
-		transposed[j] = data[i];
+		int j = (i * width + i / width) % size;
+		if (i < j) {
+			uint8_t tmp[0x10];
+			uint8_t *p = data + i * COUNTOF(tmp);
+			uint8_t *q = data + j * COUNTOF(tmp);
+			memcpy(tmp, p, COUNTOF(tmp));
+			memcpy(p, q, COUNTOF(tmp));
+			memcpy(q, tmp, COUNTOF(tmp));
+		}
 	}
-	memcpy(data, transposed, size);
-	free(transposed);
 }
 
 void compress_plane(uint8_t *plane, int width) {


### PR DESCRIPTION
Follow-up to #470. Makes the `transpose_tiles` function more efficient (no memory allocation, and no redundant assignment operations), with identical outputs.

```sh
for f in `find gfx -name '*.pic'`; do x=${f%.pic}; tools/pkmncompress -u $x.pic $x.tmp; cmp $x.tmp $x.2bpp; rm -f $x.tmp; done
```