### PR TITLE
Fix label typos, add some constants instead of raw numbers

### DIFF
--- a/data/maps/objects/Route3.asm
+++ b/data/maps/objects/Route3.asm
@@ -15,7 +15,7 @@ Route3_Object:
 	def_warp_events
 
 	def_bg_events
-	bg_event 59,  9, 10 ; Route3SignText
+	bg_event 59,  9, TEXT_ROUTE3_SIGN
 
 	def_object_events
 	object_event 57, 11, SPRITE_SUPER_NERD, STAY, NONE, TEXT_ROUTE3_SUPER_NERD

--- a/data/maps/objects/TradeCenter.asm
+++ b/data/maps/objects/TradeCenter.asm
@@ -9,6 +9,6 @@ TradeCenter_Object:
 	def_bg_events
 
 	def_object_events
-	object_event  2,  2, SPRITE_RED, STAY, 0, TEXT_TRADECENTER_OPPONENT
+	object_event  2,  2, SPRITE_RED, STAY, ANY_DIR, TEXT_TRADECENTER_OPPONENT
 
 	def_warps_to TRADE_CENTER

--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -1935,7 +1935,7 @@ AnimationSubstitute:
 ; Changes the pokemon's sprite to the mini sprite
 	ld hl, wTempPic
 	xor a
-	ld bc, $310
+	ld bc, 7 * 7 tiles
 	call FillMemory
 	ldh a, [hWhoseTurn]
 	and a
@@ -2120,7 +2120,7 @@ GetMonSpriteTileMapPointerFromRowCount:
 	ldh a, [hWhoseTurn]
 	and a
 	jr nz, .enemyTurn
-	ld a, 20 * 5 + 1
+	ld a, 5 * SCREEN_WIDTH + 1
 	jr .next
 .enemyTurn
 	ld a, 12
@@ -2133,7 +2133,7 @@ GetMonSpriteTileMapPointerFromRowCount:
 	sub b
 	and a
 	jr z, .done
-	ld de, 20
+	ld de, SCREEN_WIDTH
 .loop
 	add hl, de
 	dec a
@@ -2294,7 +2294,7 @@ CopyTileIDs:
 	dec c
 	jr nz, .columnLoop
 	pop hl
-	ld bc, 20
+	ld bc, SCREEN_WIDTH
 	add hl, bc
 	pop bc
 	dec b

--- a/engine/overworld/trainer_sight.asm
+++ b/engine/overworld/trainer_sight.asm
@@ -97,8 +97,8 @@ TrainerWalkUpToPlayer::
 	swap a
 	dec a
 	ld c, a             ; bc = steps yet to go to reach player
-	xor a
-	ld b, a           ; a = direction to go to
+	xor a ; NPC_MOVEMENT_DOWN
+	ld b, a
 	jr .writeWalkScript
 .facingUp
 	ld a, [wTrainerScreenY]
@@ -111,7 +111,7 @@ TrainerWalkUpToPlayer::
 	dec a
 	ld c, a             ; bc = steps yet to go to reach player
 	ld b, $0
-	ld a, $40           ; a = direction to go to
+	ld a, NPC_MOVEMENT_UP
 	jr .writeWalkScript
 .facingRight
 	ld a, [wTrainerScreenX]
@@ -124,7 +124,7 @@ TrainerWalkUpToPlayer::
 	dec a
 	ld c, a             ; bc = steps yet to go to reach player
 	ld b, $0
-	ld a, $c0           ; a = direction to go to
+	ld a, NPC_MOVEMENT_RIGHT
 	jr .writeWalkScript
 .facingLeft
 	ld a, [wTrainerScreenX]
@@ -137,7 +137,7 @@ TrainerWalkUpToPlayer::
 	dec a
 	ld c, a             ; bc = steps yet to go to reach player
 	ld b, $0
-	ld a, $80           ; a = direction to go to
+	ld a, NPC_MOVEMENT_LEFT
 .writeWalkScript
 	ld hl, wNPCMovementDirections2
 	ld de, wNPCMovementDirections2

--- a/macros/scripts/maps.asm
+++ b/macros/scripts/maps.asm
@@ -106,8 +106,8 @@ ENDM
 ;\1 event flag
 ;\2 view range
 ;\3 TextBeforeBattle
-;\4 TextAfterBattle
-;\5 TextEndBattle
+;\4 TextEndBattle
+;\5 TextAfterBattle
 MACRO trainer
 	DEF _ev_bit = \1 % 8
 	DEF _cur_bit = CURRENT_TRAINER_BIT % 8

--- a/scripts/ChampionsRoom.asm
+++ b/scripts/ChampionsRoom.asm
@@ -5,7 +5,7 @@ ChampionsRoom_Script:
 	jp CallFunctionInTable
 
 ResetRivalScript:
-	xor a ; SCENE_CHAMPIONSROOM_DEFAULT
+	xor a ; SCRIPT_CHAMPIONSROOM_DEFAULT
 	ld [wJoyIgnore], a
 	ld [wChampionsRoomCurScript], a
 	ret

--- a/scripts/PokemonTower6F.asm
+++ b/scripts/PokemonTower6F.asm
@@ -74,7 +74,7 @@ PokemonTower6FMarowakBattleScript:
 .did_not_defeat
 	ld a, $1
 	ld [wSimulatedJoypadStatesIndex], a
-	ld a, $10
+	ld a, D_RIGHT
 	ld [wSimulatedJoypadStatesEnd], a
 	xor a
 	ld [wSpritePlayerStateData2MovementByte1], a

--- a/scripts/RocketHideoutB2F.asm
+++ b/scripts/RocketHideoutB2F.asm
@@ -281,7 +281,7 @@ RocketHideoutB2F_TextPointers:
 RocketHideout2TrainerHeaders:
 	def_trainers
 RocketHideout2TrainerHeader0:
-	trainer EVENT_BEAT_ROCKET_HIDEOUT_2_TRAINER_0, 4, RocketHideoutB1FRocketBattleText, RocketHideoutB1FRocketEndBattleText, RocketHideoutB1FRocketAfterBattleText
+	trainer EVENT_BEAT_ROCKET_HIDEOUT_2_TRAINER_0, 4, RocketHideoutB2FRocketBattleText, RocketHideoutB2FRocketEndBattleText, RocketHideoutB2FRocketAfterBattleText
 	db -1 ; end
 
 RocketHideoutB2FRocketText:
@@ -290,14 +290,14 @@ RocketHideoutB2FRocketText:
 	call TalkToTrainer
 	jp TextScriptEnd
 
-RocketHideoutB1FRocketBattleText:
-	text_far _RocketHideoutB1FRocketBattleText
+RocketHideoutB2FRocketBattleText:
+	text_far _RocketHideoutB2FRocketBattleText
 	text_end
 
-RocketHideoutB1FRocketEndBattleText:
-	text_far _RocketHideoutB1FRocketEndBattleText
+RocketHideoutB2FRocketEndBattleText:
+	text_far _RocketHideoutB2FRocketEndBattleText
 	text_end
 
-RocketHideoutB1FRocketAfterBattleText:
-	text_far _RocketHideoutB1FRocketAfterBattleText
+RocketHideoutB2FRocketAfterBattleText:
+	text_far _RocketHideoutB2FRocketAfterBattleText
 	text_end

--- a/scripts/RocketHideoutB4F.asm
+++ b/scripts/RocketHideoutB4F.asm
@@ -89,11 +89,11 @@ RocketHideoutB4F_TextPointers:
 RocketHideout4TrainerHeaders:
 	def_trainers 2
 RocketHideout4TrainerHeader0:
-	trainer EVENT_BEAT_ROCKET_HIDEOUT_4_TRAINER_0, 0, RocketHideoutB4FGiovanniBattleText, RocketHideoutB4FGiovanniEndBattleText, RocketHideoutB4FGiovanniAfterBattleText
+	trainer EVENT_BEAT_ROCKET_HIDEOUT_4_TRAINER_0, 0, RocketHideoutB4FRocket1BattleText, RocketHideoutB4FRocket1EndBattleText, RocketHideoutB4FRocket1AfterBattleText
 RocketHideout4TrainerHeader1:
-	trainer EVENT_BEAT_ROCKET_HIDEOUT_4_TRAINER_1, 0, RocketHideoutB4FRocket1BattleText, RocketHideoutB4FRocket1EndBattleText, RocketHideoutB4FRocket1AfterBattleText
+	trainer EVENT_BEAT_ROCKET_HIDEOUT_4_TRAINER_1, 0, RocketHideoutB4FRocket2BattleText, RocketHideoutB4FRocket2EndBattleText, RocketHideoutB4FRocket2AfterBattleText
 RocketHideout4TrainerHeader2:
-	trainer EVENT_BEAT_ROCKET_HIDEOUT_4_TRAINER_2, 1, RocketHideoutB4FRocket2BattleText, RocketHideoutB4FRocket2EndBattleText, RocketHideoutB4FRocket2AfterBattleText
+	trainer EVENT_BEAT_ROCKET_HIDEOUT_4_TRAINER_2, 1, RocketHideoutB4FRocket3BattleText, RocketHideoutB4FRocket3EndBattleText, RocketHideoutB4FRocket3AfterBattleText
 	db -1 ; end
 
 RocketHideoutB4FGiovanniText:
@@ -142,24 +142,6 @@ RocketHideoutB4FRocket1Text:
 	call TalkToTrainer
 	jp TextScriptEnd
 
-RocketHideoutB4FGiovanniBattleText:
-	text_far _RocketHideoutB4FGiovanniBattleText
-	text_end
-
-RocketHideoutB4FGiovanniEndBattleText:
-	text_far _RocketHideoutB4FGiovanniEndBattleText
-	text_end
-
-RocketHideoutB4FGiovanniAfterBattleText:
-	text_far _RocketHideoutB4FGiovanniAfterBattleText
-	text_end
-
-RocketHideoutB4FRocket2Text:
-	text_asm
-	ld hl, RocketHideout4TrainerHeader1
-	call TalkToTrainer
-	jp TextScriptEnd
-
 RocketHideoutB4FRocket1BattleText:
 	text_far _RocketHideoutB4FRocket1BattleText
 	text_end
@@ -172,9 +154,9 @@ RocketHideoutB4FRocket1AfterBattleText:
 	text_far _RocketHideoutB4FRocket1AfterBattleText
 	text_end
 
-RocketHideoutB4FRocket3Text:
+RocketHideoutB4FRocket2Text:
 	text_asm
-	ld hl, RocketHideout4TrainerHeader2
+	ld hl, RocketHideout4TrainerHeader1
 	call TalkToTrainer
 	jp TextScriptEnd
 
@@ -187,6 +169,24 @@ RocketHideoutB4FRocket2EndBattleText:
 	text_end
 
 RocketHideoutB4FRocket2AfterBattleText:
+	text_far _RocketHideoutB4FRocket2AfterBattleText
+	text_end
+
+RocketHideoutB4FRocket3Text:
+	text_asm
+	ld hl, RocketHideout4TrainerHeader2
+	call TalkToTrainer
+	jp TextScriptEnd
+
+RocketHideoutB4FRocket3BattleText:
+	text_far _RocketHideoutB4FRocket3BattleText
+	text_end
+
+RocketHideoutB4FRocket3EndBattleText:
+	text_far _RocketHideoutB4FRocket3EndBattleText
+	text_end
+
+RocketHideoutB4FRocket3AfterBattleText:
 	text_asm
 	ld hl, .Text
 	call PrintText
@@ -199,5 +199,5 @@ RocketHideoutB4FRocket2AfterBattleText:
 	jp TextScriptEnd
 
 .Text:
-	text_far _RocketHideoutB4FRocket2AfterBattleText
+	text_far _RocketHideoutB4FRocket3AfterBattleText
 	text_end

--- a/scripts/RocketHideoutElevator.asm
+++ b/scripts/RocketHideoutElevator.asm
@@ -32,7 +32,7 @@ RocketHideoutElevatorStoreWarpEntriesScript:
 	ret
 
 RocketHideoutElevatorScript:
-	ld hl, RocketHideoutElavatorFloors
+	ld hl, RocketHideoutElevatorFloors
 	call LoadItemList
 	ld hl, RocketHideoutElevatorWarpMaps
 	ld de, wElevatorWarpMaps
@@ -40,7 +40,7 @@ RocketHideoutElevatorScript:
 	call CopyData
 	ret
 
-RocketHideoutElavatorFloors:
+RocketHideoutElevatorFloors:
 	db 3 ; #
 	db FLOOR_B1F
 	db FLOOR_B2F

--- a/scripts/Route8.asm
+++ b/scripts/Route8.asm
@@ -35,7 +35,7 @@ Route8TrainerHeader1:
 Route8TrainerHeader2:
 	trainer EVENT_BEAT_ROUTE_8_TRAINER_2, 4, Route8SuperNerd2BattleText, Route8SuperNerd2EndBattleText, Route8SuperNerd2AfterBattleText
 Route8TrainerHeader3:
-	trainer EVENT_BEAT_ROUTE_8_TRAINER_3, 2, Route8CooltrainerF1BattleText, Route8CooltrainerF21EndBattleText, Route8CooltrainerF1AfterBattleText
+	trainer EVENT_BEAT_ROUTE_8_TRAINER_3, 2, Route8CooltrainerF1BattleText, Route8CooltrainerF1EndBattleText, Route8CooltrainerF1AfterBattleText
 Route8TrainerHeader4:
 	trainer EVENT_BEAT_ROUTE_8_TRAINER_4, 3, Route8SuperNerd3BattleText, Route8SuperNerd3EndBattleText, Route8SuperNerd3AfterBattleText
 Route8TrainerHeader5:
@@ -112,8 +112,8 @@ Route8CooltrainerF1BattleText:
 	text_far _Route8CooltrainerF1BattleText
 	text_end
 
-Route8CooltrainerF21EndBattleText:
-	text_far _Route8CooltrainerF21EndBattleText
+Route8CooltrainerF1EndBattleText:
+	text_far _Route8CooltrainerF1EndBattleText
 	text_end
 
 Route8CooltrainerF1AfterBattleText:

--- a/scripts/SilphCo6F.asm
+++ b/scripts/SilphCo6F.asm
@@ -56,7 +56,7 @@ SilphCo6F_TextPointers:
 SilphCo6TrainerHeaders:
 	def_trainers 6
 SilphCo6TrainerHeader0:
-	trainer EVENT_BEAT_SILPH_CO_6F_TRAINER_0, 2, SilphCo6FRocket1BattleText, SilphCo6Rocket1EndBattleText, SilphCo6Rocket1AfterBattleText
+	trainer EVENT_BEAT_SILPH_CO_6F_TRAINER_0, 2, SilphCo6FRocket1BattleText, SilphCo6FRocket1EndBattleText, SilphCo6FRocket1AfterBattleText
 SilphCo6TrainerHeader1:
 	trainer EVENT_BEAT_SILPH_CO_6F_TRAINER_1, 3, SilphCo6FScientistBattleText, SilphCo6FScientistEndBattleText, SilphCo6FScientistAfterBattleText
 SilphCo6TrainerHeader2:
@@ -158,12 +158,12 @@ SilphCo6FRocket1BattleText:
 	text_far _SilphCo6FRocket1BattleText
 	text_end
 
-SilphCo6Rocket1EndBattleText:
-	text_far _SilphCo6Rocket1EndBattleText
+SilphCo6FRocket1EndBattleText:
+	text_far _SilphCo6FRocket1EndBattleText
 	text_end
 
-SilphCo6Rocket1AfterBattleText:
-	text_far _SilphCo6Rocket1AfterBattleText
+SilphCo6FRocket1AfterBattleText:
+	text_far _SilphCo6FRocket1AfterBattleText
 	text_end
 
 SilphCo6FScientistText:

--- a/scripts/SilphCo7F.asm
+++ b/scripts/SilphCo7F.asm
@@ -310,7 +310,7 @@ SilphCo7FSilphWorkerM1Text:
 	lb bc, LAPRAS, 15
 	call GivePokemon
 	jr nc, .done
-	ld a, [wSimulatedJoypadStatesEnd]
+	ld a, [wAddedToParty]
 	and a
 	call z, WaitForTextScrollButtonPress
 	call EnableAutoTextBoxDrawing

--- a/text/RocketHideoutB2F.asm
+++ b/text/RocketHideoutB2F.asm
@@ -1,15 +1,15 @@
-_RocketHideoutB1FRocketBattleText::
+_RocketHideoutB2FRocketBattleText::
 	text "BOSS said you can"
 	line "see GHOSTs with"
 	cont "the SILPH SCOPE!"
 	done
 
-_RocketHideoutB1FRocketEndBattleText::
+_RocketHideoutB2FRocketEndBattleText::
 	text "I"
 	line "surrender!"
 	prompt
 
-_RocketHideoutB1FRocketAfterBattleText::
+_RocketHideoutB2FRocketAfterBattleText::
 	text "The TEAM ROCKET"
 	line "HQ has 4 basement"
 	cont "floors. Can you"

--- a/text/RocketHideoutB4F.asm
+++ b/text/RocketHideoutB4F.asm
@@ -26,49 +26,49 @@ _RocketHideoutB4FGiovanniHopeWeMeetAgainText::
 	line "again..."
 	done
 
-_RocketHideoutB4FGiovanniBattleText::
+_RocketHideoutB4FRocket1BattleText::
 	text "I know you! You"
 	line "ruined our plans"
 	cont "at MT.MOON!"
 	done
 
-_RocketHideoutB4FGiovanniEndBattleText::
+_RocketHideoutB4FRocket1EndBattleText::
 	text "Burned"
 	line "again!"
 	prompt
 
-_RocketHideoutB4FGiovanniAfterBattleText::
+_RocketHideoutB4FRocket1AfterBattleText::
 	text "Do you have"
 	line "something against"
 	cont "TEAM ROCKET?"
 	done
 
-_RocketHideoutB4FRocket1BattleText::
+_RocketHideoutB4FRocket2BattleText::
 	text "How can you not"
 	line "see the beauty of"
 	cont "our evil?"
 	done
 
-_RocketHideoutB4FRocket1EndBattleText::
+_RocketHideoutB4FRocket2EndBattleText::
 	text "Ayaya!"
 	prompt
 
-_RocketHideoutB4FRocket1AfterBattleText::
+_RocketHideoutB4FRocket2AfterBattleText::
 	text "BOSS! I'm sorry I"
 	line "failed you!"
 	done
 
-_RocketHideoutB4FRocket2BattleText::
+_RocketHideoutB4FRocket3BattleText::
 	text "The elevator"
 	line "doesn't work? Who"
 	cont "has the LIFT KEY?"
 	done
 
-_RocketHideoutB4FRocket2EndBattleText::
+_RocketHideoutB4FRocket3EndBattleText::
 	text "No!"
 	prompt
 
-_RocketHideoutB4FRocket2AfterBattleText::
+_RocketHideoutB4FRocket3AfterBattleText::
 	text "Oh no! I dropped"
 	line "the LIFT KEY!"
 	done

--- a/text/Route8.asm
+++ b/text/Route8.asm
@@ -50,7 +50,7 @@ _Route8CooltrainerF1BattleText::
 	line "I collect them!"
 	done
 
-_Route8CooltrainerF21EndBattleText::
+_Route8CooltrainerF1EndBattleText::
 	text "Why? Why??"
 	prompt
 

--- a/text/SilphCo6F.asm
+++ b/text/SilphCo6F.asm
@@ -60,12 +60,12 @@ _SilphCo6FRocket1BattleText::
 	line "ROCKET BROTHERS!"
 	done
 
-_SilphCo6Rocket1EndBattleText::
+_SilphCo6FRocket1EndBattleText::
 	text "Flame"
 	line "out!"
 	prompt
 
-_SilphCo6Rocket1AfterBattleText::
+_SilphCo6FRocket1AfterBattleText::
 	text "No matter!"
 	line "My brothers will"
 	cont "avenge me!"


### PR DESCRIPTION
- In the macro **trainer**, arguments 4 and 5 descriptions are swapped.

- In `SilphCo7FSilphWorkerM1Text`, `wSimulatedJoypadStatesEnd` is more likely a reference to `wAddedToParty`, which is written to by `_GivePokemon` to address text delay issues when returning.

- The 3 entries in `RocketHideout4TrainerHeaders` are for the Rocket trainers on that floor. The battle with Giovanni is triggered within `RocketHideoutB4FGiovanniText` text entry.