### PR TITLE
Further improve NPC trade labels and comments

### DIFF
--- a/data/events/trades.asm
+++ b/data/events/trades.asm
@@ -4,8 +4,11 @@ TradeMons:
 	; give mon, get mon, dialog id, nickname
 	; The two instances of TRADE_DIALOGSET_EVOLUTION are a leftover
 	; from the Japanese Blue trades, which used species that evolve.
-	; Japanese Red and Green used TRADE_DIALOGSET_CASUAL, and had
-	; the same species as English Red and Blue.
+	; TRADE_DIALOGSET_EVOLUTION did not refer to evolution in Japanese
+	; Red/Green. Japanese Blue changed _AfterTrade2Text to say your Pokémon
+	; "went and evolved" and also changed the trades to match. English
+	; Red/Blue uses the original JP Red/Green trades but with the JP Blue
+	; post-trade text.
 	db NIDORINO,   NIDORINA,  TRADE_DIALOGSET_CASUAL,    "TERRY@@@@@@"
 	db ABRA,       MR_MIME,   TRADE_DIALOGSET_CASUAL,    "MARCEL@@@@@"
 	db BUTTERFREE, BEEDRILL,  TRADE_DIALOGSET_HAPPY,     "CHIKUCHIKU@" ; unused

--- a/engine/events/evolve_trade.asm
+++ b/engine/events/evolve_trade.asm
@@ -1,36 +1,20 @@
 InGameTrade_CheckForTradeEvo:
-; Verify the TradeMon's species name before
-; attempting to initiate a trade evolution.
-
-; The names of the trade evolutions in Blue (JP)
-; are checked. In that version, TradeMons that
-; can evolve are Graveler and Haunter.
-
-; In localization, this check was translated
-; before monster names were finalized.
-; Then, Haunter's name was "Spectre".
-; Since its name no longer starts with
-; "SP", it is prevented from evolving.
-
-; This may have been why Red/Green's trades
-; were used instead, where none can evolve.
-
-; This was fixed in Yellow.
-
+; In Japanese Blue, TradeMons include a Graveler and a Haunter,
+; both of which have Japanese names that start with "ご",
+; which is what this routine originally checked in that game.
+; For English Red and Blue, this routine was adjusted for
+; Graveler's English name and Haunter's early English name "Spectre".
+; The final release replaced Graveler and Haunter in TradeMons.
 	ld a, [wInGameTradeReceiveMonName]
-
-	; GRAVELER
-	cp "G"
-	jr z, .ok
-
+	cp "G" ; GRAVELER
+	jr z, .nameMatched
 	; "SPECTRE" (HAUNTER)
 	cp "S"
 	ret nz
 	ld a, [wInGameTradeReceiveMonName + 1]
 	cp "P"
 	ret nz
-
-.ok
+.nameMatched
 	ld a, [wPartyCount]
 	dec a
 	ld [wWhichPokemon], a

--- a/engine/events/evolve_trade.asm
+++ b/engine/events/evolve_trade.asm
@@ -1,6 +1,6 @@
 InGameTrade_CheckForTradeEvo:
 ; In Japanese Blue, TradeMons include a Graveler and a Haunter,
-; both of which have Japanese names that start with "ご",
+; both of which have Japanese names that start with "ゴ",
 ; which is what this routine originally checked in that game.
 ; For English Red and Blue, this routine was adjusted for
 ; Graveler's English name and Haunter's early English name "Spectre".


### PR DESCRIPTION
This PR partially amends #384 by correcting the information about the previously mentioned localization oversight and reworks the documentation of `InGameTrade_CheckForTradeEvo` a bit.

Should `evolve_trade.asm` be renamed to avoid confusion with `EVOLVE_TRADE` since the file is only for `InGameTrade_CheckForTradeEvo`?