### PR TITLE
Correct vc_patch length

### DIFF
--- a/data/text/text_4.asm
+++ b/data/text/text_4.asm
@@ -216,7 +216,7 @@ IF DEF(_RED_VC) || DEF(_BLUE_VC)
 	text "Please come again!"
 	done
 	text_start
-	text "sed because of"
+	db   "osed because of"
 	cont "inactivity."
 ELSE
 	text "The link has been"


### PR DESCRIPTION
The patch for `Change_link_closed_inactivity_message` is 20 bytes long.
This fix removes the extra $00 byte that was added in the text data.

Alternatively, this can be written as:

 	text "Please come again!"
 	done
 	text "osed because of"
 	cont "inactivity."