### PR TITLE
Use constants in `PrintBCDNumber` calls

### DIFF
--- a/constants/text_constants.asm
+++ b/constants/text_constants.asm
@@ -2,7 +2,7 @@ DEF NAME_LENGTH EQU 11
 DEF ITEM_NAME_LENGTH EQU 13
 DEF NAME_BUFFER_LENGTH EQU 20
 
-; PrintNumber
+; PrintNumber, PrintBCDNumber
 	const_def 5
 	const BIT_MONEY_SIGN     ; 5
 	const BIT_LEFT_ALIGN     ; 6

--- a/engine/events/prize_menu.asm
+++ b/engine/events/prize_menu.asm
@@ -126,18 +126,15 @@ GetPrizeMenuId:
 ; put prices on the right side of the textbox
 	ld de, wPrize1Price
 	hlcoord 13, 5
-; reg. c:
-; [low nybble] number of bytes
-; [bits 765 = %100] space-padding (not zero-padding)
-	ld c, (1 << 7) | 2
+	ld c, 2 | LEADING_ZEROES
 	call PrintBCDNumber
 	ld de, wPrize2Price
 	hlcoord 13, 7
-	ld c, (1 << 7) | 2
+	ld c, 2 | LEADING_ZEROES
 	call PrintBCDNumber
 	ld de, wPrize3Price
 	hlcoord 13, 9
-	ld c, (1 << 7) | 2
+	ld c, 2 | LEADING_ZEROES
 	jp PrintBCDNumber
 
 INCLUDE "data/events/prizes.asm"
@@ -156,7 +153,7 @@ PrintPrizePrice:
 	call PlaceString
 	hlcoord 13, 1
 	ld de, wPlayerCoins
-	ld c, %10000010
+	ld c, 2 | LEADING_ZEROES
 	call PrintBCDNumber
 	ret
 

--- a/engine/menus/start_sub_menus.asm
+++ b/engine/menus/start_sub_menus.asm
@@ -552,7 +552,7 @@ DrawTrainerInfo:
 	call PlaceString
 	hlcoord 8, 4
 	ld de, wPlayerMoney
-	ld c, $e3
+	ld c, 3 | LEADING_ZEROES | LEFT_ALIGN | MONEY_SIGN
 	call PrintBCDNumber
 	hlcoord 9, 6
 	ld de, wPlayTimeHours ; hours

--- a/engine/menus/text_box.asm
+++ b/engine/menus/text_box.asm
@@ -139,7 +139,7 @@ DisplayMoneyBox:
 	call ClearScreenArea
 	hlcoord 12, 1
 	ld de, wPlayerMoney
-	ld c, $a3
+	ld c, 3 | LEADING_ZEROES | MONEY_SIGN
 	call PrintBCDNumber
 	ld hl, wStatusFlags5
 	res BIT_NO_TEXT_DELAY, [hl]

--- a/engine/movie/hall_of_fame.asm
+++ b/engine/movie/hall_of_fame.asm
@@ -237,7 +237,7 @@ HoFDisplayPlayerStats:
 	call PlaceString
 	hlcoord 4, 10
 	ld de, wPlayerMoney
-	ld c, $a3
+	ld c, 3 | LEADING_ZEROES | MONEY_SIGN
 	call PrintBCDNumber
 	ld hl, DexSeenOwnedText
 	call HoFPrintTextAndDelay

--- a/engine/slots/slot_machine.asm
+++ b/engine/slots/slot_machine.asm
@@ -645,7 +645,7 @@ SlotMachine_SubtractBetFromPlayerCoins:
 SlotMachine_PrintCreditCoins:
 	hlcoord 5, 1
 	ld de, wPlayerCoins
-	ld c, $2
+	ld c, 2
 	jp PrintBCDNumber
 
 SlotMachine_PrintPayoutCoins:

--- a/home/list_menu.asm
+++ b/home/list_menu.asm
@@ -295,7 +295,7 @@ DisplayChooseQuantityMenu::
 	ld de, SpacesBetweenQuantityAndPriceText
 	call PlaceString
 	ld de, hMoney ; total price
-	ld c, $a3
+	ld c, 3 | LEADING_ZEROES | MONEY_SIGN
 	call PrintBCDNumber
 	hlcoord 9, 10
 .printQuantity
@@ -420,7 +420,7 @@ PrintListMenuEntries::
 	pop hl
 	ld bc, SCREEN_WIDTH + 5 ; 1 row down and 5 columns right
 	add hl, bc
-	ld c, $a3 ; no leading zeroes, right-aligned, print currency symbol, 3 bytes
+	ld c, 3 | LEADING_ZEROES | MONEY_SIGN
 	call PrintBCDNumber
 .skipPrintingItemPrice
 	ld a, [wListMenuID]

--- a/scripts/GameCorner.asm
+++ b/scripts/GameCorner.asm
@@ -511,7 +511,7 @@ GameCornerDrawCoinBox:
 	call PlaceString
 	hlcoord 15, 5
 	ld de, wPlayerCoins
-	ld c, $82
+	ld c, 2 | LEADING_ZEROES
 	call PrintBCDNumber
 	ld hl, wStatusFlags5
 	res BIT_NO_TEXT_DELAY, [hl]


### PR DESCRIPTION
The format `ld c, BYTE | FLAGS` is consistent with that of `text_bcd` macro.