### PR TITLE
Use constants for PP masks instead of magic numbers

### DIFF
--- a/constants/move_constants.asm
+++ b/constants/move_constants.asm
@@ -214,3 +214,9 @@ DEF NUM_ATTACKS EQU const_value - 1
 	const BAIT_ANIM ; throw bait
 
 DEF NUM_ATTACK_ANIMS EQU const_value - 1
+
+; The PP value stored for pokemon in the party contains two values. The upper
+; two bits count the number of PP up used and the rest count the currently
+; remaining PP
+DEF PP_UP_MASK    EQU %11000000
+DEF PP_VALUE_MASK EQU ~PP_UP_MASK

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -2644,7 +2644,7 @@ SelectMenuItem:
 	ld b, $0
 	add hl, bc
 	ld a, [hl]
-	and $3f
+	and PP_VALUE_MASK
 	jr z, .noPP
 	ld a, [wPlayerDisabledMove]
 	swap a
@@ -2724,7 +2724,7 @@ AnyMoveToSelect:
 	or [hl]
 	inc hl
 	or [hl]
-	and $3f
+	and PP_VALUE_MASK
 	ret nz
 	jr .noMovesLeft
 .handleDisabledMove
@@ -2878,7 +2878,7 @@ PrintMenuItem:
 	ld hl, wBattleMonPP
 	add hl, bc
 	ld a, [hl]
-	and $3f
+	and PP_VALUE_MASK
 	ld [wBattleMenuCurrentPP], a
 ; print TYPE/<type> and <curPP>/<maxPP>
 	hlcoord 1, 9
@@ -4071,18 +4071,18 @@ CheckForDisobedience:
 	ld hl, wBattleMonPP
 	push hl
 	ld a, [hli]
-	and $3f
+	and PP_VALUE_MASK
 	ld b, a
 	ld a, [hli]
-	and $3f
+	and PP_VALUE_MASK
 	add b
 	ld b, a
 	ld a, [hli]
-	and $3f
+	and PP_VALUE_MASK
 	add b
 	ld b, a
 	ld a, [hl]
-	and $3f
+	and PP_VALUE_MASK
 	add b
 	pop hl
 	push af
@@ -4091,7 +4091,7 @@ CheckForDisobedience:
 	ld b, $0
 	add hl, bc
 	ld a, [hl]
-	and $3f
+	and PP_VALUE_MASK
 	ld b, a
 	pop af
 	cp b

--- a/engine/battle/effects.asm
+++ b/engine/battle/effects.asm
@@ -1332,7 +1332,7 @@ DisableEffect:
 	or [hl]
 	inc hl
 	or [hl]
-	and $3f
+	and PP_VALUE_MASK
 	pop hl ; wBattleMonPP or wEnemyMonPP
 	jr z, .moveMissedPopHL ; nothing to do if all moves have no PP left
 	add hl, bc

--- a/engine/events/heal_party.asm
+++ b/engine/events/heal_party.asm
@@ -50,7 +50,7 @@ HealParty:
 	push bc
 	ld b, a
 	ld a, [hl]
-	and $c0
+	and PP_UP_MASK
 	add b
 	ld [hl], a
 	pop bc

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -2058,7 +2058,7 @@ ItemUsePPRestore:
 	cp MAX_ETHER
 	jr z, .fullyRestorePP
 	ld a, [hl] ; move PP
-	and %00111111 ; lower 6 bit bits store current PP
+	and PP_VALUE_MASK ; lower 6 bit bits store current PP
 	cp b ; does current PP equal max PP?
 	ret z ; if so, return
 	add 10 ; increase current PP by 10
@@ -2071,7 +2071,7 @@ ItemUsePPRestore:
 	ld b, a
 .storeNewAmount
 	ld a, [hl] ; move PP
-	and %11000000 ; PP Up counter bits
+	and PP_UP_MASK ; PP Up counter bits
 	add b
 	ld [hl], a
 	ret
@@ -2403,7 +2403,7 @@ RestoreBonusPP:
 	jr nz, .nextMove
 .skipMenuItemIDCheck
 	ld a, [hl]
-	and %11000000 ; have any PP Ups been used?
+	and PP_UP_MASK ; have any PP Ups been used?
 	call nz, AddBonusPP ; if so, add bonus PP
 .nextMove
 	inc hl
@@ -2509,7 +2509,7 @@ GetMaxPP:
 .addPPOffset
 	add hl, bc
 	ld a, [hl] ; a = current PP
-	and %11000000 ; get PP Up count
+	and PP_UP_MASK ; get PP Up count
 	pop bc
 	or b ; place normal max PP in 6 lower bits of a
 	ASSERT wMoveData + MOVE_PP + 1 == wPPUpCountAndMaxPP
@@ -2521,7 +2521,7 @@ GetMaxPP:
 	ld [wUsingPPUp], a
 	call AddBonusPP ; add bonus PP from PP Ups
 	ld a, [hl]
-	and %00111111 ; mask out the PP Up count
+	and PP_VALUE_MASK ; mask out the PP Up count
 	ld [wMaxPP], a ; store max PP
 	ret
 

--- a/engine/pokemon/status_screen.asm
+++ b/engine/pokemon/status_screen.asm
@@ -364,7 +364,7 @@ StatusScreen2:
 	ld bc, wPartyMon1PP - wPartyMon1Moves - 1
 	add hl, bc
 	ld a, [hl]
-	and $3f
+	and PP_VALUE_MASK
 	ld [wStatusScreenCurrentPP], a
 	ld h, d
 	ld l, e


### PR DESCRIPTION
Adds the constants `PP_UP_MASK` and `PP_VALUE_MASK` and replaces the hardcoded values with them.

I wasn't sure which file to put this in, since they are used in many different places. move_constants.asm seemed the most fitting.

Fixes part of https://github.com/pret/pokered/issues/479