### PR TITLE
Use less generic labels in ReadTrainer's party finding loops

### DIFF
--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -31,14 +31,14 @@ ReadTrainer:
 ; and hl points to the trainer class.
 ; Our next task is to iterate through the trainers,
 ; decrementing b each time, until we get to the right one.
-.outer
+.CheckNextTrainer
 	dec b
 	jr z, .IterateTrainer
-.inner
+.SkipTrainer
 	ld a, [hli]
 	and a
-	jr nz, .inner
-	jr .outer
+	jr nz, .SkipTrainer
+	jr .CheckNextTrainer
 
 ; if the first byte of trainer data is FF,
 ; - each pokemon has a specific level


### PR DESCRIPTION
This PR relabels the loop to find the correct party in read trainer.

I know pokecrystal uses `skip_trainer` as a label for the outer loop but I think that name fits the inner loop better.
For the outer loop label, I hesitated between `CheckTrainer` and `CheckNextTrainer` and I figured that `CheckNextTrainer` was clearer in the jump context.