### PR TITLE
Use hardware constants for tile attributes in VermilionDockOAMBlock

### DIFF
--- a/scripts/VermilionDock.asm
+++ b/scripts/VermilionDock.asm
@@ -156,10 +156,10 @@ VermilionDock_EmitSmokePuff:
 
 VermilionDockOAMBlock:
 ; tile ID, attributes
-	db $fc, $10
-	db $fd, $10
-	db $fe, $10
-	db $ff, $10
+	db $fc, OAM_PAL1
+	db $fd, OAM_PAL1
+	db $fe, OAM_PAL1
+	db $ff, OAM_PAL1
 
 VermilionDock_SyncScrollWithLY:
 	ld h, d


### PR DESCRIPTION
This is a small PR that replaces the raw hex values for attributes with the corresponding hardware constant in VermilionDockOAMBlock.