### PR TITLE
Label cleanup, add some constants instead of raw numbers

### DIFF
--- a/constants/gfx_constants.asm
+++ b/constants/gfx_constants.asm
@@ -1,3 +1,13 @@
+; * LCD enabled
+; * Window tile map at $9C00
+; * Window display enabled
+; * BG and window tile data at $8800
+; * BG tile map at $9800
+; * 8x8 OBJ size
+; * OBJ display enabled
+; * BG display enabled
+DEF LCDC_DEFAULT EQU LCDC_ON | LCDC_WIN_9C00 | LCDC_WIN_ON | LCDC_BLOCK21 | LCDC_BG_9800 | LCDC_OBJ_8 | LCDC_OBJ_ON | LCDC_BG_ON
+
 DEF TILE_1BPP_SIZE EQU TILE_SIZE / 2 ; bytes
 
 DEF BLOCK_WIDTH EQU 4 ; tiles

--- a/data/maps/objects/Route2Gate.asm
+++ b/data/maps/objects/Route2Gate.asm
@@ -1,6 +1,6 @@
 	object_const_def
-	const_export ROUTE2_OAKS_AIDE
-	const_export ROUTE2_YOUNGSTER
+	const_export ROUTE2GATE_OAKS_AIDE
+	const_export ROUTE2GATE_YOUNGSTER
 
 Route2Gate_Object:
 	db $a ; border block

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3137,30 +3137,30 @@ PlayerCalcMoveDamage:
 	jp c, .moveHitTest ; SetDamageEffects moves (e.g. Seismic Toss and Super Fang) skip damage calculation
 	call CriticalHitTest
 	call HandleCounterMove
-	jr z, handleIfPlayerMoveMissed
+	jr z, HandleIfPlayerMoveMissed
 	call GetDamageVarsForPlayerAttack
 	call CalculateDamage
-	jp z, playerCheckIfFlyOrChargeEffect ; for moves with 0 BP, skip any further damage calculation and, for now, skip MoveHitTest
+	jp z, PlayerCheckIfFlyOrChargeEffect ; for moves with 0 BP, skip any further damage calculation and, for now, skip MoveHitTest
 	               ; for these moves, accuracy tests will only occur if they are called as part of the effect itself
 	call AdjustDamageForMoveType
 	call RandomizeDamage
 .moveHitTest
 	call MoveHitTest
-handleIfPlayerMoveMissed:
+HandleIfPlayerMoveMissed:
 	ld a, [wMoveMissed]
 	and a
-	jr z, getPlayerAnimationType
+	jr z, GetPlayerAnimationType
 	ld a, [wPlayerMoveEffect]
 	sub EXPLODE_EFFECT
-	jr z, playPlayerMoveAnimation ; don't play any animation if the move missed, unless it was EXPLODE_EFFECT
-	jr playerCheckIfFlyOrChargeEffect
-getPlayerAnimationType:
+	jr z, PlayPlayerMoveAnimation ; don't play any animation if the move missed, unless it was EXPLODE_EFFECT
+	jr PlayerCheckIfFlyOrChargeEffect
+GetPlayerAnimationType:
 	ld a, [wPlayerMoveEffect]
 	and a
 	ld a, ANIMATIONTYPE_BLINK_ENEMY_MON_SPRITE ; move has no effect other than dealing damage
-	jr z, playPlayerMoveAnimation
+	jr z, PlayPlayerMoveAnimation
 	ld a, ANIMATIONTYPE_SHAKE_SCREEN_HORIZONTALLY_LIGHT ; move has effect
-playPlayerMoveAnimation:
+PlayPlayerMoveAnimation:
 	push af
 	ld a, [wPlayerBattleStatus2]
 	bit HAS_SUBSTITUTE_UP, a
@@ -3179,7 +3179,7 @@ playPlayerMoveAnimation:
 	ld b, BANK(ReshowSubstituteAnim)
 	call nz, Bankswitch
 	jr MirrorMoveCheck
-playerCheckIfFlyOrChargeEffect:
+PlayerCheckIfFlyOrChargeEffect:
 	ld c, 30
 	call DelayFrames
 	ld a, [wPlayerMoveEffect]
@@ -3246,7 +3246,7 @@ MirrorMoveCheck:
 	ld a, [wPlayerNumAttacksLeft]
 	dec a
 	ld [wPlayerNumAttacksLeft], a
-	jp nz, getPlayerAnimationType ; for multi-hit moves, apply attack until PlayerNumAttacksLeft hits 0 or the enemy faints.
+	jp nz, GetPlayerAnimationType ; for multi-hit moves, apply attack until PlayerNumAttacksLeft hits 0 or the enemy faints.
 	                             ; damage calculation and accuracy tests only happen for the first hit
 	res ATTACKING_MULTIPLE_TIMES, [hl] ; clear attacking multiple times status when all attacks are over
 	ld hl, MultiHitText
@@ -3523,7 +3523,7 @@ CheckPlayerStatusConditions:
 	ld [hl], a
 	ld a, BIDE
 	ld [wPlayerMoveNum], a
-	ld hl, handleIfPlayerMoveMissed ; skip damage calculation, DecrementPP and MoveHitTest
+	ld hl, HandleIfPlayerMoveMissed ; skip damage calculation, DecrementPP and MoveHitTest
 	jp .returnToHL
 
 .ThrashingAboutCheck
@@ -3557,7 +3557,7 @@ CheckPlayerStatusConditions:
 	ld a, [wPlayerNumAttacksLeft]
 	dec a ; did multi-turn move end?
 	ld [wPlayerNumAttacksLeft], a
-	ld hl, getPlayerAnimationType ; if it didn't, skip damage calculation (deal damage equal to last hit),
+	ld hl, GetPlayerAnimationType ; if it didn't, skip damage calculation (deal damage equal to last hit),
 	                ; DecrementPP and MoveHitTest
 	jp nz, .returnToHL
 	jp .returnToHL
@@ -5567,7 +5567,7 @@ RandomizeDamage:
 .loop
 	call BattleRandom
 	rrca
-	cp 217
+	cp 85 percent + 1
 	jr c, .loop
 	ldh [hMultiplier], a
 	call Multiply ; multiply damage by the random number, which is in the range [217, 255]
@@ -5660,7 +5660,7 @@ EnemyCalcMoveDamage:
 	jp c, EnemyMoveHitTest
 	call CriticalHitTest
 	call HandleCounterMove
-	jr z, handleIfEnemyMoveMissed
+	jr z, HandleIfEnemyMoveMissed
 	call SwapPlayerAndEnemyLevels
 	call GetDamageVarsForEnemyAttack
 	call SwapPlayerAndEnemyLevels
@@ -5671,13 +5671,13 @@ EnemyCalcMoveDamage:
 
 EnemyMoveHitTest:
 	call MoveHitTest
-handleIfEnemyMoveMissed:
+HandleIfEnemyMoveMissed:
 	ld a, [wMoveMissed]
 	and a
 	jr z, .moveDidNotMiss
 	ld a, [wEnemyMoveEffect]
 	cp EXPLODE_EFFECT
-	jr z, handleExplosionMiss
+	jr z, HandleExplosionMiss
 	jr EnemyCheckIfFlyOrChargeEffect
 .moveDidNotMiss
 	call SwapPlayerAndEnemyLevels
@@ -5686,13 +5686,13 @@ GetEnemyAnimationType:
 	ld a, [wEnemyMoveEffect]
 	and a
 	ld a, ANIMATIONTYPE_SHAKE_SCREEN_VERTICALLY
-	jr z, playEnemyMoveAnimation
+	jr z, PlayEnemyMoveAnimation
 	ld a, ANIMATIONTYPE_SHAKE_SCREEN_HORIZONTALLY_HEAVY
-	jr playEnemyMoveAnimation
-handleExplosionMiss:
+	jr PlayEnemyMoveAnimation
+HandleExplosionMiss:
 	call SwapPlayerAndEnemyLevels
 	xor a
-playEnemyMoveAnimation:
+PlayEnemyMoveAnimation:
 	push af
 	ld a, [wEnemyBattleStatus2]
 	bit HAS_SUBSTITUTE_UP, a ; does mon have a substitute?
@@ -6031,7 +6031,7 @@ CheckEnemyStatusConditions:
 	ld a, BIDE
 	ld [wEnemyMoveNum], a
 	call SwapPlayerAndEnemyLevels
-	ld hl, handleIfEnemyMoveMissed ; skip damage calculation, DecrementPP and MoveHitTest
+	ld hl, HandleIfEnemyMoveMissed ; skip damage calculation, DecrementPP and MoveHitTest
 	jp .enemyReturnToHL
 .checkIfThrashingAbout
 	bit THRASHING_ABOUT, [hl] ; is mon using thrash or petal dance?

--- a/engine/battle/effects.asm
+++ b/engine/battle/effects.asm
@@ -7,9 +7,9 @@ _JumpMoveEffect:
 	ldh a, [hWhoseTurn]
 	and a
 	ld a, [wPlayerMoveEffect]
-	jr z, .next1
+	jr z, .next
 	ld a, [wEnemyMoveEffect]
-.next1
+.next
 	dec a ; subtract 1, there is no special effect for 00
 	add a ; x2, 16bit pointers
 	ld hl, MoveEffectPointerTable
@@ -680,14 +680,14 @@ UpdateLoweredStatDone:
 	call PrintStatText
 	pop de
 	ld a, [de]
-	cp $44
+	cp ATTACK_DOWN_SIDE_EFFECT ; for all side effects, move animation has already played, skip it
 	jr nc, .ApplyBadgeBoostsAndStatusPenalties
 	call PlayCurrentMoveAnimation2
 .ApplyBadgeBoostsAndStatusPenalties
 	ldh a, [hWhoseTurn]
 	and a
 	call nz, ApplyBadgeStatBoosts ; whenever the player uses a stat-down move, badge boosts get reapplied again to every stat,
-	                              ; even to those not affected by the stat-up move (will be boosted further)
+	                              ; even to those not affected by the stat-down move (will be boosted further)
 	ld hl, MonsStatsFellText
 	call PrintText
 
@@ -1438,9 +1438,9 @@ CheckTargetSubstitute:
 	ld hl, wEnemyBattleStatus2
 	ldh a, [hWhoseTurn]
 	and a
-	jr z, .next1
+	jr z, .next
 	ld hl, wPlayerBattleStatus2
-.next1
+.next
 	bit HAS_SUBSTITUTE_UP, [hl]
 	pop hl
 	ret

--- a/engine/events/prize_menu.asm
+++ b/engine/events/prize_menu.asm
@@ -2,12 +2,12 @@ CeladonPrizeMenu::
 	ld b, COIN_CASE
 	call IsItemInBag
 	jr nz, .havingCoinCase
-	ld hl, RequireCoinCaseTextPtr
+	ld hl, RequireCoinCaseText
 	jp PrintText
 .havingCoinCase
 	ld hl, wStatusFlags5
 	set BIT_NO_TEXT_DELAY, [hl]
-	ld hl, ExchangeCoinsForPrizesTextPtr
+	ld hl, ExchangeCoinsForPrizesText
 	call PrintText
 ; the following are the menu settings
 	xor a
@@ -28,7 +28,7 @@ CeladonPrizeMenu::
 	call TextBoxBorder
 	call GetPrizeMenuId
 	call UpdateSprites
-	ld hl, WhichPrizeTextPtr
+	ld hl, WhichPrizeText
 	call PrintText
 	call HandleMenuInput ; menu choice handler
 	bit B_PAD_B, a
@@ -42,16 +42,16 @@ CeladonPrizeMenu::
 	res BIT_NO_TEXT_DELAY, [hl]
 	ret
 
-RequireCoinCaseTextPtr:
+RequireCoinCaseText:
 	text_far _RequireCoinCaseText
 	text_waitbutton
 	text_end
 
-ExchangeCoinsForPrizesTextPtr:
+ExchangeCoinsForPrizesText:
 	text_far _ExchangeCoinsForPrizesText
 	text_end
 
-WhichPrizeTextPtr:
+WhichPrizeText:
 	text_far _WhichPrizeText
 	text_end
 

--- a/engine/gfx/palettes.asm
+++ b/engine/gfx/palettes.asm
@@ -523,15 +523,15 @@ CopyGfxToSuperNintendoVRAM:
 	call CopySGBBorderTiles
 	jr .next
 .notCopyingTileData
-	ld bc, $1000
+	ld bc, 256 tiles
 	call CopyData
 .next
 	ld hl, vBGMap0
-	ld de, $c
+	ld de, TILEMAP_WIDTH - SCREEN_WIDTH
 	ld a, $80
-	ld c, $d
+	ld c, 13 ; enough screen lines to fit 256 tiles
 .loop
-	ld b, $14
+	ld b, SCREEN_WIDTH
 .innerLoop
 	ld [hli], a
 	inc a
@@ -540,7 +540,7 @@ CopyGfxToSuperNintendoVRAM:
 	add hl, de
 	dec c
 	jr nz, .loop
-	ld a, $e3
+	ld a, LCDC_DEFAULT
 	ldh [rLCDC], a
 	pop hl
 	call SendSGBPacket

--- a/engine/menus/display_text_id_init.asm
+++ b/engine/menus/display_text_id_init.asm
@@ -69,7 +69,7 @@ DisplayTextIDInit::
 	add hl, de
 	dec c
 	jr nz, .spriteStandStillLoop
-	ld b, $9c ; window background address
+	ld b, HIGH(vBGMap1)
 	call CopyScreenTileBufferToVRAM ; transfer background in WRAM to VRAM
 	xor a
 	ldh [hWY], a ; put the window on the screen

--- a/engine/menus/save.asm
+++ b/engine/menus/save.asm
@@ -606,10 +606,11 @@ SAVCheckRandomID:
 ; checks if Sav file is the same by checking player's name 1st letter
 ; and the two random numbers generated at game beginning
 ; (which are stored at wPlayerID)s
-	ld a, $0a
+	ld a, RAMG_SRAM_ENABLE
 	ld [rRAMG], a
-	ld a, $01
+	ld a, BMODE_ADVANCED
 	ld [rBMODE], a
+	ASSERT BANK("Save Data") == BMODE_ADVANCED
 	ld [rRAMB], a
 	ld a, [sPlayerName]
 	and a
@@ -631,7 +632,7 @@ SAVCheckRandomID:
 	ld a, [wPlayerID + 1]
 	cp h
 .next
-	ld a, $00
+	ld a, RAMG_SRAM_DISABLE ; BMODE_SIMPLE
 	ld [rBMODE], a
 	ld [rRAMG], a
 	ret
@@ -674,7 +675,7 @@ LoadHallOfFameTeams:
 HallOfFame_Copy:
 	ld a, RAMG_SRAM_ENABLE
 	ld [rRAMG], a
-	ld a, $1
+	ld a, BMODE_ADVANCED
 	ld [rBMODE], a
 	xor a
 	ld [rRAMB], a
@@ -687,15 +688,15 @@ HallOfFame_Copy:
 ClearSAV:
 	ld a, RAMG_SRAM_ENABLE
 	ld [rRAMG], a
-	ld a, $1
+	ld a, BMODE_ADVANCED
 	ld [rBMODE], a
 	xor a
 	call PadSRAM_FF
-	ld a, $1
+	ld a, BANK("Save Data")
 	call PadSRAM_FF
-	ld a, $2
+	ld a, BANK("Saved Boxes 1")
 	call PadSRAM_FF
-	ld a, $3
+	ld a, BANK("Saved Boxes 2")
 	call PadSRAM_FF
 	xor a
 	ld [rBMODE], a

--- a/engine/menus/start_sub_menus.asm
+++ b/engine/menus/start_sub_menus.asm
@@ -1,6 +1,6 @@
 StartMenu_Pokedex::
 	predef ShowPokedexMenu
-	call LoadScreenTilesFromBuffer2 ; restore saved screen
+	call LoadScreenTilesFromBuffer2
 	call Delay3
 	call LoadGBPal
 	call UpdateSprites
@@ -63,7 +63,7 @@ StartMenu_Pokemon::
 	ld [hl], a
 	call HandleMenuInput
 	push af
-	call LoadScreenTilesFromBuffer1 ; restore saved screen
+	call LoadScreenTilesFromBuffer1
 	pop af
 	bit B_PAD_B, a
 	jp nz, .loop
@@ -117,7 +117,7 @@ StartMenu_Pokemon::
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [wObtainedBadges] ; badges obtained
+	ld a, [wObtainedBadges]
 	jp hl
 .outOfBattleMovePointers
 	dw .cut
@@ -286,7 +286,7 @@ StartMenu_Pokemon::
 ; writes a blank tile to all possible menu cursor positions on the party menu
 ErasePartyMenuCursors::
 	hlcoord 0, 1
-	ld bc, 2 * 20 ; menu cursor positions are 2 rows apart
+	ld bc, 2 * SCREEN_WIDTH ; menu cursor positions are 2 rows apart
 	ld a, 6 ; 6 menu cursor positions
 .loop
 	ld [hl], " "
@@ -296,7 +296,7 @@ ErasePartyMenuCursors::
 	ret
 
 ItemMenuLoop:
-	call LoadScreenTilesFromBuffer2DisableBGTransfer ; restore saved screen
+	call LoadScreenTilesFromBuffer2DisableBGTransfer
 	call RunDefaultPaletteCommand
 
 StartMenu_Item::
@@ -323,7 +323,7 @@ StartMenu_Item::
 	ld [wBagSavedMenuItem], a
 	jr nc, .choseItem
 .exitMenu
-	call LoadScreenTilesFromBuffer2 ; restore saved screen
+	call LoadScreenTilesFromBuffer2
 	call LoadTextBoxTilePatterns
 	call UpdateSprites
 	jp RedisplayStartMenu
@@ -363,7 +363,7 @@ StartMenu_Item::
 	bit B_PAD_B, a
 	jr z, .useOrTossItem
 	jp ItemMenuLoop
-.useOrTossItem ; if the player made the choice to use or toss the item
+.useOrTossItem
 	ld a, [wCurItem]
 	ld [wNamedObjectIndex], a
 	call GetItemName
@@ -459,14 +459,14 @@ StartMenu_TrainerInfo::
 	xor a
 	ldh [hTileAnimations], a
 	call DrawTrainerInfo
-	predef DrawBadges ; draw badges
+	predef DrawBadges
 	ld b, SET_PAL_TRAINER_CARD
 	call RunPaletteCommand
 	call GBPalNormal
-	call WaitForTextScrollButtonPress ; wait for button press
+	call WaitForTextScrollButtonPress
 	call GBPalWhiteOut
 	call LoadFontTilePatterns
-	call LoadScreenTilesFromBuffer2 ; restore saved screen
+	call LoadScreenTilesFromBuffer2
 	call RunDefaultPaletteCommand
 	call ReloadMapData
 	call LoadGBPal
@@ -489,7 +489,7 @@ DrawTrainerInfo:
 	ld de, vChars2 tile $00
 	ld bc, $1c tiles
 	call CopyData
-	ld hl, TrainerInfoTextBoxTileGraphics ; trainer info text box tile patterns
+	ld hl, TrainerInfoTextBoxTileGraphics
 	ld de, vChars2 tile $77
 	ld bc, 8 tiles
 	push bc
@@ -499,10 +499,10 @@ DrawTrainerInfo:
 	ld bc, $17 tiles
 	call TrainerInfo_FarCopyData
 	pop bc
-	ld hl, BadgeNumbersTileGraphics  ; badge number tile patterns
+	ld hl, BadgeNumbersTileGraphics
 	ld de, vChars1 tile $58
 	call TrainerInfo_FarCopyData
-	ld hl, GymLeaderFaceAndBadgeTileGraphics  ; gym leader face and badge tile patterns
+	ld hl, GymLeaderFaceAndBadgeTileGraphics
 	ld de, vChars2 tile $20
 	ld bc, 8 * 8 tiles
 	ld a, BANK(GymLeaderFaceAndBadgeTileGraphics)
@@ -555,12 +555,12 @@ DrawTrainerInfo:
 	ld c, 3 | LEADING_ZEROES | LEFT_ALIGN | MONEY_SIGN
 	call PrintBCDNumber
 	hlcoord 9, 6
-	ld de, wPlayTimeHours ; hours
+	ld de, wPlayTimeHours
 	lb bc, LEFT_ALIGN | 1, 3
 	call PrintNumber
 	ld [hl], $d6 ; colon tile ID
 	inc hl
-	ld de, wPlayTimeMinutes ; minutes
+	ld de, wPlayTimeMinutes
 	lb bc, LEADING_ZEROES | 1, 2
 	jp PrintNumber
 
@@ -642,8 +642,8 @@ StartMenu_SaveReset::
 	ld a, [wStatusFlags4]
 	bit BIT_LINK_CONNECTED, a
 	jp nz, Init
-	predef SaveSAV ; save the game
-	call LoadScreenTilesFromBuffer2 ; restore saved screen
+	predef SaveSAV
+	call LoadScreenTilesFromBuffer2
 	jp HoldTextDisplayOpen
 
 StartMenu_Option::
@@ -652,7 +652,7 @@ StartMenu_Option::
 	call ClearScreen
 	call UpdateSprites
 	callfar DisplayOptionMenu
-	call LoadScreenTilesFromBuffer2 ; restore saved screen
+	call LoadScreenTilesFromBuffer2
 	call LoadTextBoxTilePatterns
 	call UpdateSprites
 	jp RedisplayStartMenu

--- a/engine/movie/hall_of_fame.asm
+++ b/engine/movie/hall_of_fame.asm
@@ -7,7 +7,7 @@ AnimateHallOfFame:
 	call LoadTextBoxTilePatterns
 	call DisableLCD
 	ld hl, vBGMap0
-	ld bc, $800
+	ld bc, 2 * TILEMAP_AREA
 	ld a, " "
 	call FillMemory
 	call EnableLCD

--- a/engine/movie/trade.asm
+++ b/engine/movie/trade.asm
@@ -167,7 +167,7 @@ LoadTradingGFXAndMonNames:
 	ld a, BANK(TradingAnimationGraphics2)
 	call FarCopyData2
 	ld hl, vBGMap0
-	ld bc, $800
+	ld bc, 2 * TILEMAP_AREA
 	ld a, " "
 	call FillMemory
 	call ClearSprites
@@ -223,7 +223,7 @@ Trade_Cleanup:
 	ret
 
 Trade_ShowPlayerMon:
-	ld a, %10101011
+	ld a, LCDC_ON | LCDC_WIN_9800 | LCDC_WIN_ON | LCDC_BLOCK21 | LCDC_BG_9C00 | LCDC_OBJ_8 | LCDC_BG_ON | LCDC_OBJ_ON
 	ldh [rLCDC], a
 	ld a, $50
 	ldh [hWY], a
@@ -279,7 +279,7 @@ Trade_DrawOpenEndOfLinkCable:
 	ld a, $a0
 	ldh [hSCX], a
 	call DelayFrame
-	ld a, %10001011
+	ld a, LCDC_ON | LCDC_WIN_9800 | LCDC_WIN_OFF | LCDC_BLOCK21 | LCDC_BG_9C00 | LCDC_OBJ_8 | LCDC_BG_ON | LCDC_OBJ_ON
 	ldh [rLCDC], a
 	hlcoord 6, 2
 	ld b, TILEMAP_LINK_CABLE
@@ -338,7 +338,7 @@ Trade_AnimateBallEnteringLinkCable:
 	ld a, $1
 	ldh [hAutoBGTransferEnabled], a
 	call ClearScreen
-	ld b, $98
+	ld b, HIGH(vBGMap0)
 	call CopyScreenTileBufferToVRAM
 	call Delay3
 	xor a
@@ -452,7 +452,7 @@ Trade_InitGameboyTransferGfx:
 	ldh [hAutoBGTransferEnabled], a
 	call Trade_LoadMonPartySpriteGfx
 	call DelayFrame
-	ld a, %10101011
+	ld a, LCDC_ON | LCDC_WIN_9800 | LCDC_WIN_ON | LCDC_BLOCK21 | LCDC_BG_9C00 | LCDC_OBJ_8 | LCDC_OBJ_ON | LCDC_BG_ON
 	ldh [rLCDC], a
 	xor a
 	ldh [hSCX], a
@@ -757,7 +757,7 @@ Trade_ShowClearedWindow:
 	ld a, $1
 	ldh [hAutoBGTransferEnabled], a
 	call ClearScreen
-	ld a, %11100011
+	ld a, LCDC_DEFAULT
 	ldh [rLCDC], a
 	ld a, $7
 	ldh [rWX], a

--- a/engine/overworld/missable_objects.asm
+++ b/engine/overworld/missable_objects.asm
@@ -15,9 +15,6 @@ MarkTownVisitedAndLoadMissableObjects::
 	add hl, bc
 	ld a, [hli]                ; load missable objects pointer in hl
 	ld h, [hl]
-	; fall through
-
-LoadMissableObjects:
 	ld l, a
 	push hl
 	ld de, MissableObjects     ; calculate difference between out pointer and the base pointer

--- a/engine/pokemon/bills_pc.asm
+++ b/engine/pokemon/bills_pc.asm
@@ -538,6 +538,7 @@ JustAMomentText::
 	text_far _JustAMomentText
 	text_end
 
+UnusedOpenBillsPC: ; unreferenced
 	ld a, [wSpritePlayerStateData1FacingDirection]
 	cp SPRITE_FACING_UP
 	ret nz

--- a/engine/pokemon/status_screen.asm
+++ b/engine/pokemon/status_screen.asm
@@ -427,7 +427,7 @@ StatusScreen2:
 	ld a, $1
 	ldh [hAutoBGTransferEnabled], a
 	call Delay3
-	call WaitForTextScrollButtonPress ; wait for button
+	call WaitForTextScrollButtonPress
 	pop af
 	ldh [hTileAnimations], a
 	ld hl, wStatusFlags2

--- a/home/init.asm
+++ b/home/init.asm
@@ -7,17 +7,6 @@ SoftReset::
 
 Init::
 ;  Program init.
-
-; * LCD enabled
-; * Window tile map at $9C00
-; * Window display enabled
-; * BG and window tile data at $8800
-; * BG tile map at $9800
-; * 8x8 OBJ size
-; * OBJ display enabled
-; * BG display enabled
-DEF LCDC_DEFAULT EQU LCDC_ON | LCDC_WIN_9C00 | LCDC_WIN_ON | LCDC_BLOCK21 | LCDC_BG_9800 | LCDC_OBJ_8 | LCDC_OBJ_ON | LCDC_BG_ON
-
 	di
 
 	xor a

--- a/home/map_objects.asm
+++ b/home/map_objects.asm
@@ -30,27 +30,25 @@ TextScript_ItemStoragePC::
 	call SaveScreenTilesToBuffer2
 	ld b, BANK(PlayerPC)
 	ld hl, PlayerPC
-	jr bankswitchAndContinue
+	jr BankswitchAndContinue
 
 TextScript_BillsPC::
 	call SaveScreenTilesToBuffer2
 	ld b, BANK(BillsPC_)
 	ld hl, BillsPC_
-	jr bankswitchAndContinue
+	jr BankswitchAndContinue
 
 TextScript_GameCornerPrizeMenu::
-; XXX find a better name for this function
-; special_F7
 	ld b, BANK(CeladonPrizeMenu)
 	ld hl, CeladonPrizeMenu
-bankswitchAndContinue::
+BankswitchAndContinue::
 	call Bankswitch
 	jp HoldTextDisplayOpen        ; continue to main text-engine function
 
 TextScript_PokemonCenterPC::
 	ld b, BANK(ActivatePC)
 	ld hl, ActivatePC
-	jr bankswitchAndContinue
+	jr BankswitchAndContinue
 
 StartSimulatingJoypadStates::
 	xor a

--- a/home/text_script.asm
+++ b/home/text_script.asm
@@ -84,7 +84,7 @@ ENDM
 	dict  TX_SCRIPT_PRIZE_VENDOR,            TextScript_GameCornerPrizeMenu
 	dict2 TX_SCRIPT_CABLE_CLUB_RECEPTIONIST, callfar CableClubNPC
 
-	call PrintText_NoCreatingTextBox ; display the text
+	call PrintText_NoCreatingTextBox
 	ld a, [wDoNotWaitForButtonPressAfterDisplayingText]
 	and a
 	jr nz, HoldTextDisplayOpen
@@ -93,7 +93,7 @@ AfterDisplayingTextID::
 	ld a, [wEnteringCableClub]
 	and a
 	jr nz, HoldTextDisplayOpen
-	call WaitForTextScrollButtonPress ; wait for a button press after displaying all the text
+	call WaitForTextScrollButtonPress
 
 ; loop to hold the dialogue box open as long as the player keeps holding down the A button
 HoldTextDisplayOpen::

--- a/scripts/PokemonMansionB1F.asm
+++ b/scripts/PokemonMansionB1F.asm
@@ -16,30 +16,30 @@ MansionB1FCheckReplaceSwitchDoorBlocks:
 	CheckEvent EVENT_MANSION_SWITCH_ON
 	jr nz, .switchTurnedOn
 	ld a, $e
-	ld bc, $80d
+	lb bc, 8, 13
 	call Mansion2ReplaceBlock
 	ld a, $e
-	ld bc, $b06
+	lb bc, 11, 6
 	call Mansion2ReplaceBlock
 	ld a, $5f
-	ld bc, $304
+	lb bc, 3, 4
 	call Mansion2ReplaceBlock
 	ld a, $54
-	ld bc, $808
+	lb bc, 8, 8
 	call Mansion2ReplaceBlock
 	ret
 .switchTurnedOn
 	ld a, $2d
-	ld bc, $80d
+	lb bc, 8, 13
 	call Mansion2ReplaceBlock
 	ld a, $5f
-	ld bc, $b06
+	lb bc, 11, 6
 	call Mansion2ReplaceBlock
 	ld a, $e
-	ld bc, $304
+	lb bc, 3, 4
 	call Mansion2ReplaceBlock
 	ld a, $e
-	ld bc, $808
+	lb bc, 8, 8
 	call Mansion2ReplaceBlock
 	ret
 

--- a/scripts/SeafoamIslandsB4F.asm
+++ b/scripts/SeafoamIslandsB4F.asm
@@ -37,7 +37,7 @@ SeafoamIslandsB4FDefaultScript:
 	ld a, [wCoordIndex]
 	cp $3
 	jr nc, .only1UpInputNeeded
-	ld a, NPC_MOVEMENT_UP
+	ld a, PAD_UP
 	ld [wSimulatedJoypadStatesEnd + 1], a
 	ld a, 2
 	jr .forcePlayerUpFromSurfExit

--- a/scripts/VermilionDock.asm
+++ b/scripts/VermilionDock.asm
@@ -50,7 +50,7 @@ VermilionDockSSAnneLeavesScript:
 	ld [wSpritePlayerStateData1ImageIndex], a
 	ld c, 120
 	call DelayFrames
-	ld b, $9c
+	ld b, HIGH(vBGMap1)
 	call CopyScreenTileBufferToVRAM
 	hlcoord 0, 10
 	ld bc, SCREEN_WIDTH * 6


### PR DESCRIPTION
- Added the new constants in hardware.inc when writing to `rLCDC`. `LCDC_DEFAULT` is moved out of init.asm, because it's used in 2 more files. Is gfx_constants.asm a suitable location?
- Removed `LoadMissableObjects`, this symbol is unused and was initially assumed to be the target of a Predef function.
- Added `UnusedOpenBillsPC` to set it apart from the text data immediately above.
- Removed some redundant comments.
- Fix some constants in Route2Gate.asm and SeafoamIslandsB4F.asm.
- I am not very familiar with SGB-SNES video transfer, I'd welcome comments on changes to `CopyGfxToSuperNintendoVRAM`.