### PR TITLE
Update comment for clarity

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -1794,7 +1794,8 @@ AnimateRetreatingPlayerMon:
 	lb bc, 7, 7
 	jp ClearScreenArea
 
-; Copies battle pokemon's current HP and status into the party struct data so it stays after battle or switching
+; Copies player's current pokemon's current HP and status into the party
+; struct data so it stays after battle or switching
 ReadPlayerMonCurHPAndStatus:
 	ld a, [wPlayerMonNumber]
 	ld hl, wPartyMon1HP


### PR DESCRIPTION
Actually copies from battle struct to party struct to make HP and status changes to a pokemon permanent