### PR TITLE
Remove unnecessary periods from types names

### DIFF
--- a/data/types/names.asm
+++ b/data/types/names.asm
@@ -1,43 +1,44 @@
 TypeNames:
+; entries correspond to types (see constants/type_constants.asm)
 	table_width 2
 
-	dw .Normal
-	dw .Fighting
-	dw .Flying
-	dw .Poison
-	dw .Ground
-	dw .Rock
-	dw .Bird
-	dw .Bug
-	dw .Ghost
+	dw Normal
+	dw Fighting
+	dw Flying
+	dw Poison
+	dw Ground
+	dw Rock
+	dw Bird
+	dw Bug
+	dw Ghost
 
 REPT UNUSED_TYPES_END - UNUSED_TYPES
-	dw .Normal
+	dw Normal
 ENDR
 
-	dw .Fire
-	dw .Water
-	dw .Grass
-	dw .Electric
-	dw .Psychic
-	dw .Ice
-	dw .Dragon
+	dw Fire
+	dw Water
+	dw Grass
+	dw Electric
+	dw Psychic
+	dw Ice
+	dw Dragon
 
 	assert_table_length NUM_TYPES
 
-.Normal:   db "NORMAL@"
-.Fighting: db "FIGHTING@"
-.Flying:   db "FLYING@"
-.Poison:   db "POISON@"
-.Fire:     db "FIRE@"
-.Water:    db "WATER@"
-.Grass:    db "GRASS@"
-.Electric: db "ELECTRIC@"
-.Psychic:  db "PSYCHIC@"
-.Ice:      db "ICE@"
-.Ground:   db "GROUND@"
-.Rock:     db "ROCK@"
-.Bird:     db "BIRD@"
-.Bug:      db "BUG@"
-.Ghost:    db "GHOST@"
-.Dragon:   db "DRAGON@"
+Normal:   db "NORMAL@"
+Fighting: db "FIGHTING@"
+Flying:   db "FLYING@"
+Poison:   db "POISON@"
+Fire:     db "FIRE@"
+Water:    db "WATER@"
+Grass:    db "GRASS@"
+Electric: db "ELECTRIC@"
+Psychic:  db "PSYCHIC@"
+Ice:      db "ICE@"
+Ground:   db "GROUND@"
+Rock:     db "ROCK@"
+Bird:     db "BIRD@"
+Bug:      db "BUG@"
+Ghost:    db "GHOST@"
+Dragon:   db "DRAGON@"


### PR DESCRIPTION
To better match the formatting of pokecrystal