### PR TITLE
Clarify how the order of map constants matters for the Town Map

### DIFF
--- a/constants/map_constants.asm
+++ b/constants/map_constants.asm
@@ -4,6 +4,13 @@ MACRO map_const
 	DEF \1_HEIGHT EQU \3
 ENDM
 
+; "Indoor" maps are grouped sequentially (see data/maps/town_map_entries.asm)
+DEF NUM_INDOOR_MAP_GROUPS EQU 0
+MACRO end_indoor_group
+	DEF INDOORGROUP_\1 EQU const_value
+	REDEF NUM_INDOOR_MAP_GROUPS EQU NUM_INDOOR_MAP_GROUPS + 1
+ENDM
+
 ; map ids
 ; indexes for:
 ; - MapHeaderBanks (see data/maps/map_header_banks.asm)
@@ -28,7 +35,9 @@ ENDM
 	map_const INDIGO_PLATEAU,                10,  9 ; $09
 	map_const SAFFRON_CITY,                  20, 18 ; $0A
 DEF NUM_CITY_MAPS EQU const_value
+
 	map_const UNUSED_MAP_0B,                  0,  0 ; $0B
+
 DEF FIRST_ROUTE_MAP EQU const_value
 	map_const ROUTE_1,                       10, 18 ; $0C
 	map_const ROUTE_2,                       10, 36 ; $0D
@@ -55,22 +64,31 @@ DEF FIRST_ROUTE_MAP EQU const_value
 	map_const ROUTE_23,                      10, 72 ; $22
 	map_const ROUTE_24,                      10, 18 ; $23
 	map_const ROUTE_25,                      30,  9 ; $24
+
 DEF FIRST_INDOOR_MAP EQU const_value
 	map_const REDS_HOUSE_1F,                  4,  4 ; $25
 	map_const REDS_HOUSE_2F,                  4,  4 ; $26
 	map_const BLUES_HOUSE,                    4,  4 ; $27
 	map_const OAKS_LAB,                       5,  6 ; $28
+	end_indoor_group PALLET_TOWN
+
 	map_const VIRIDIAN_POKECENTER,            7,  4 ; $29
 	map_const VIRIDIAN_MART,                  4,  4 ; $2A
 	map_const VIRIDIAN_SCHOOL_HOUSE,          4,  4 ; $2B
 	map_const VIRIDIAN_NICKNAME_HOUSE,        4,  4 ; $2C
 	map_const VIRIDIAN_GYM,                  10,  9 ; $2D
+	end_indoor_group VIRIDIAN_CITY
+
 	map_const DIGLETTS_CAVE_ROUTE_2,          4,  4 ; $2E
 	map_const VIRIDIAN_FOREST_NORTH_GATE,     5,  4 ; $2F
 	map_const ROUTE_2_TRADE_HOUSE,            4,  4 ; $30
 	map_const ROUTE_2_GATE,                   5,  4 ; $31
 	map_const VIRIDIAN_FOREST_SOUTH_GATE,     5,  4 ; $32
+	end_indoor_group ROUTE_2
+
 	map_const VIRIDIAN_FOREST,               17, 24 ; $33
+	end_indoor_group VIRIDIAN_FOREST
+
 	map_const MUSEUM_1F,                     10,  4 ; $34
 	map_const MUSEUM_2F,                      7,  4 ; $35
 	map_const PEWTER_GYM,                     5,  7 ; $36
@@ -78,42 +96,72 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const PEWTER_MART,                    4,  4 ; $38
 	map_const PEWTER_SPEECH_HOUSE,            4,  4 ; $39
 	map_const PEWTER_POKECENTER,              7,  4 ; $3A
+	end_indoor_group PEWTER_CITY
+
 	map_const MT_MOON_1F,                    20, 18 ; $3B
 	map_const MT_MOON_B1F,                   14, 14 ; $3C
 	map_const MT_MOON_B2F,                   20, 18 ; $3D
+	end_indoor_group MT_MOON
+
 	map_const CERULEAN_TRASHED_HOUSE,         4,  4 ; $3E
 	map_const CERULEAN_TRADE_HOUSE,           4,  4 ; $3F
 	map_const CERULEAN_POKECENTER,            7,  4 ; $40
 	map_const CERULEAN_GYM,                   5,  7 ; $41
 	map_const BIKE_SHOP,                      4,  4 ; $42
 	map_const CERULEAN_MART,                  4,  4 ; $43
+	end_indoor_group CERULEAN_CITY
+
 	map_const MT_MOON_POKECENTER,             7,  4 ; $44
+	end_indoor_group ROUTE_4
+
 	map_const CERULEAN_TRASHED_HOUSE_COPY,    4,  4 ; $45
+	end_indoor_group CERULEAN_CITY_2
+
 	map_const ROUTE_5_GATE,                   4,  3 ; $46
 	map_const UNDERGROUND_PATH_ROUTE_5,       4,  4 ; $47
 	map_const DAYCARE,                        4,  4 ; $48
+	end_indoor_group ROUTE_5
+
 	map_const ROUTE_6_GATE,                   4,  3 ; $49
 	map_const UNDERGROUND_PATH_ROUTE_6,       4,  4 ; $4A
 	map_const UNDERGROUND_PATH_ROUTE_6_COPY,  4,  4 ; $4B
+	end_indoor_group ROUTE_6
+
 	map_const ROUTE_7_GATE,                   3,  4 ; $4C
 	map_const UNDERGROUND_PATH_ROUTE_7,       4,  4 ; $4D
 	map_const UNDERGROUND_PATH_ROUTE_7_COPY,  4,  4 ; $4E
+	end_indoor_group ROUTE_7
+
 	map_const ROUTE_8_GATE,                   3,  4 ; $4F
 	map_const UNDERGROUND_PATH_ROUTE_8,       4,  4 ; $50
+	end_indoor_group ROUTE_8
+
 	map_const ROCK_TUNNEL_POKECENTER,         7,  4 ; $51
 	map_const ROCK_TUNNEL_1F,                20, 18 ; $52
+	end_indoor_group ROCK_TUNNEL
+
 	map_const POWER_PLANT,                   20, 18 ; $53
+	end_indoor_group POWER_PLANT
+
 	map_const ROUTE_11_GATE_1F,               4,  5 ; $54
 	map_const DIGLETTS_CAVE_ROUTE_11,         4,  4 ; $55
 	map_const ROUTE_11_GATE_2F,               4,  4 ; $56
+	end_indoor_group ROUTE_11
+
 	map_const ROUTE_12_GATE_1F,               5,  4 ; $57
+	end_indoor_group ROUTE_12
+
 	map_const BILLS_HOUSE,                    4,  4 ; $58
+	end_indoor_group SEA_COTTAGE
+
 	map_const VERMILION_POKECENTER,           7,  4 ; $59
 	map_const POKEMON_FAN_CLUB,               4,  4 ; $5A
 	map_const VERMILION_MART,                 4,  4 ; $5B
 	map_const VERMILION_GYM,                  5,  9 ; $5C
 	map_const VERMILION_PIDGEY_HOUSE,         4,  4 ; $5D
 	map_const VERMILION_DOCK,                14,  6 ; $5E
+	end_indoor_group VERMILION_CITY
+
 	map_const SS_ANNE_1F,                    20,  9 ; $5F
 	map_const SS_ANNE_2F,                    20,  9 ; $60
 	map_const SS_ANNE_3F,                    10,  3 ; $61
@@ -124,10 +172,14 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const SS_ANNE_1F_ROOMS,              12,  8 ; $66
 	map_const SS_ANNE_2F_ROOMS,              12,  8 ; $67
 	map_const SS_ANNE_B1F_ROOMS,             12,  8 ; $68
+	end_indoor_group SS_ANNE
+
 	map_const UNUSED_MAP_69,                  0,  0 ; $69
 	map_const UNUSED_MAP_6A,                  0,  0 ; $6A
 	map_const UNUSED_MAP_6B,                  0,  0 ; $6B
 	map_const VICTORY_ROAD_1F,               10,  9 ; $6C
+	end_indoor_group VICTORY_ROAD
+
 	map_const UNUSED_MAP_6D,                  0,  0 ; $6D
 	map_const UNUSED_MAP_6E,                  0,  0 ; $6E
 	map_const UNUSED_MAP_6F,                  0,  0 ; $6F
@@ -138,9 +190,17 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const UNUSED_MAP_74,                  0,  0 ; $74
 	map_const UNUSED_MAP_75,                  0,  0 ; $75
 	map_const HALL_OF_FAME,                   5,  4 ; $76
+	end_indoor_group POKEMON_LEAGUE
+
 	map_const UNDERGROUND_PATH_NORTH_SOUTH,   4, 24 ; $77 ; UndergroundPathNorthSouth.blk is actually 4x23
+	end_indoor_group UNDERGROUND_PATH
+
 	map_const CHAMPIONS_ROOM,                 4,  4 ; $78
+	end_indoor_group POKEMON_LEAGUE_2
+
 	map_const UNDERGROUND_PATH_WEST_EAST,    25,  4 ; $79
+	end_indoor_group UNDERGROUND_PATH_2
+
 	map_const CELADON_MART_1F,               10,  4 ; $7A
 	map_const CELADON_MART_2F,               10,  4 ; $7B
 	map_const CELADON_MART_3F,               10,  4 ; $7C
@@ -160,7 +220,11 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const CELADON_DINER,                  5,  4 ; $8A
 	map_const CELADON_CHIEF_HOUSE,            4,  4 ; $8B
 	map_const CELADON_HOTEL,                  7,  4 ; $8C
+	end_indoor_group CELADON_CITY
+
 	map_const LAVENDER_POKECENTER,            7,  4 ; $8D
+	end_indoor_group LAVENDER_TOWN
+
 	map_const POKEMON_TOWER_1F,              10,  9 ; $8E
 	map_const POKEMON_TOWER_2F,              10,  9 ; $8F
 	map_const POKEMON_TOWER_3F,              10,  9 ; $90
@@ -168,23 +232,41 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const POKEMON_TOWER_5F,              10,  9 ; $92
 	map_const POKEMON_TOWER_6F,              10,  9 ; $93
 	map_const POKEMON_TOWER_7F,              10,  9 ; $94
+	end_indoor_group POKEMON_TOWER
+
 	map_const MR_FUJIS_HOUSE,                 4,  4 ; $95
 	map_const LAVENDER_MART,                  4,  4 ; $96
 	map_const LAVENDER_CUBONE_HOUSE,          4,  4 ; $97
+	end_indoor_group LAVENDER_TOWN_2
+
 	map_const FUCHSIA_MART,                   4,  4 ; $98
 	map_const FUCHSIA_BILLS_GRANDPAS_HOUSE,   4,  4 ; $99
 	map_const FUCHSIA_POKECENTER,             7,  4 ; $9A
 	map_const WARDENS_HOUSE,                  5,  4 ; $9B
+	end_indoor_group FUCHSIA_CITY
+
 	map_const SAFARI_ZONE_GATE,               4,  3 ; $9C
+	end_indoor_group SAFARI_ZONE
+
 	map_const FUCHSIA_GYM,                    5,  9 ; $9D
 	map_const FUCHSIA_MEETING_ROOM,           7,  4 ; $9E
+	end_indoor_group FUCHSIA_CITY_2
+
 	map_const SEAFOAM_ISLANDS_B1F,           15,  9 ; $9F
 	map_const SEAFOAM_ISLANDS_B2F,           15,  9 ; $A0
 	map_const SEAFOAM_ISLANDS_B3F,           15,  9 ; $A1
 	map_const SEAFOAM_ISLANDS_B4F,           15,  9 ; $A2
+	end_indoor_group SEAFOAM_ISLANDS
+
 	map_const VERMILION_OLD_ROD_HOUSE,        4,  4 ; $A3
+	end_indoor_group VERMILION_CITY_2
+
 	map_const FUCHSIA_GOOD_ROD_HOUSE,         4,  4 ; $A4
+	end_indoor_group FUCHSIA_CITY_3
+
 	map_const POKEMON_MANSION_1F,            15, 14 ; $A5
+	end_indoor_group POKEMON_MANSION
+
 	map_const CINNABAR_GYM,                  10,  9 ; $A6
 	map_const CINNABAR_LAB,                   9,  4 ; $A7
 	map_const CINNABAR_LAB_TRADE_ROOM,        4,  4 ; $A8
@@ -193,7 +275,11 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const CINNABAR_POKECENTER,            7,  4 ; $AB
 	map_const CINNABAR_MART,                  4,  4 ; $AC
 	map_const CINNABAR_MART_COPY,             4,  4 ; $AD
+	end_indoor_group CINNABAR_ISLAND
+
 	map_const INDIGO_PLATEAU_LOBBY,           8,  6 ; $AE
+	end_indoor_group INDIGO_PLATEAU
+
 	map_const COPYCATS_HOUSE_1F,              4,  4 ; $AF
 	map_const COPYCATS_HOUSE_2F,              4,  4 ; $B0
 	map_const FIGHTING_DOJO,                  5,  6 ; $B1
@@ -203,21 +289,45 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const SILPH_CO_1F,                   15,  9 ; $B5
 	map_const SAFFRON_POKECENTER,             7,  4 ; $B6
 	map_const MR_PSYCHICS_HOUSE,              4,  4 ; $B7
+	end_indoor_group SAFFRON_CITY
+
 	map_const ROUTE_15_GATE_1F,               4,  5 ; $B8
 	map_const ROUTE_15_GATE_2F,               4,  4 ; $B9
+	end_indoor_group ROUTE_15
+
 	map_const ROUTE_16_GATE_1F,               4,  7 ; $BA
 	map_const ROUTE_16_GATE_2F,               4,  4 ; $BB
 	map_const ROUTE_16_FLY_HOUSE,             4,  4 ; $BC
+	end_indoor_group ROUTE_16
+
 	map_const ROUTE_12_SUPER_ROD_HOUSE,       4,  4 ; $BD
+	end_indoor_group ROUTE_12_2
+
 	map_const ROUTE_18_GATE_1F,               4,  5 ; $BE
 	map_const ROUTE_18_GATE_2F,               4,  4 ; $BF
+	end_indoor_group ROUTE_18
+
 	map_const SEAFOAM_ISLANDS_1F,            15,  9 ; $C0
+	end_indoor_group SEAFOAM_ISLANDS_2
+
 	map_const ROUTE_22_GATE,                  5,  4 ; $C1
+	end_indoor_group ROUTE_22
+
 	map_const VICTORY_ROAD_2F,               15,  9 ; $C2
+	end_indoor_group VICTORY_ROAD_2
+
 	map_const ROUTE_12_GATE_2F,               4,  4 ; $C3
+	end_indoor_group ROUTE_12_3
+
 	map_const VERMILION_TRADE_HOUSE,          4,  4 ; $C4
+	end_indoor_group VERMILION_CITY_3
+
 	map_const DIGLETTS_CAVE,                 20, 18 ; $C5
+	end_indoor_group DIGLETTS_CAVE
+
 	map_const VICTORY_ROAD_3F,               15,  9 ; $C6
+	end_indoor_group VICTORY_ROAD_3
+
 	map_const ROCKET_HIDEOUT_B1F,            15, 14 ; $C7
 	map_const ROCKET_HIDEOUT_B2F,            15, 14 ; $C8
 	map_const ROCKET_HIDEOUT_B3F,            15, 14 ; $C9
@@ -226,6 +336,8 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const UNUSED_MAP_CC,                  0,  0 ; $CC
 	map_const UNUSED_MAP_CD,                  0,  0 ; $CD
 	map_const UNUSED_MAP_CE,                  0,  0 ; $CE
+	end_indoor_group ROCKET_HQ
+
 	map_const SILPH_CO_2F,                   15,  9 ; $CF
 	map_const SILPH_CO_3F,                   15,  9 ; $D0
 	map_const SILPH_CO_4F,                   15,  9 ; $D1
@@ -233,9 +345,13 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const SILPH_CO_6F,                   13,  9 ; $D3
 	map_const SILPH_CO_7F,                   13,  9 ; $D4
 	map_const SILPH_CO_8F,                   13,  9 ; $D5
+	end_indoor_group SILPH_CO
+
 	map_const POKEMON_MANSION_2F,            15, 14 ; $D6
 	map_const POKEMON_MANSION_3F,            15,  9 ; $D7
 	map_const POKEMON_MANSION_B1F,           15, 14 ; $D8
+	end_indoor_group POKEMON_MANSION_2
+
 	map_const SAFARI_ZONE_EAST,              15, 13 ; $D9
 	map_const SAFARI_ZONE_NORTH,             20, 18 ; $DA
 	map_const SAFARI_ZONE_WEST,              15, 13 ; $DB
@@ -245,17 +361,29 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const SAFARI_ZONE_WEST_REST_HOUSE,    4,  4 ; $DF
 	map_const SAFARI_ZONE_EAST_REST_HOUSE,    4,  4 ; $E0
 	map_const SAFARI_ZONE_NORTH_REST_HOUSE,   4,  4 ; $E1
+	end_indoor_group SAFARI_ZONE_2
+
 	map_const CERULEAN_CAVE_2F,              15,  9 ; $E2
 	map_const CERULEAN_CAVE_B1F,             15,  9 ; $E3
 	map_const CERULEAN_CAVE_1F,              15,  9 ; $E4
+	end_indoor_group CERULEAN_CAVE
+
 	map_const NAME_RATERS_HOUSE,              4,  4 ; $E5
+	end_indoor_group LAVENDER_TOWN_3
+
 	map_const CERULEAN_BADGE_HOUSE,           4,  4 ; $E6
+	end_indoor_group CERULEAN_CITY_3
+
 	map_const UNUSED_MAP_E7,                  0,  0 ; $E7
 	map_const ROCK_TUNNEL_B1F,               20, 18 ; $E8
+	end_indoor_group ROCK_TUNNEL_2
+
 	map_const SILPH_CO_9F,                   13,  9 ; $E9
 	map_const SILPH_CO_10F,                   8,  9 ; $EA
 	map_const SILPH_CO_11F,                   9,  9 ; $EB
 	map_const SILPH_CO_ELEVATOR,              2,  2 ; $EC
+	end_indoor_group SILPH_CO_2
+
 	map_const UNUSED_MAP_ED,                  0,  0 ; $ED
 	map_const UNUSED_MAP_EE,                  0,  0 ; $EE
 	map_const TRADE_CENTER,                   5,  4 ; $EF
@@ -267,8 +395,11 @@ DEF FIRST_INDOOR_MAP EQU const_value
 	map_const LORELEIS_ROOM,                  5,  6 ; $F5
 	map_const BRUNOS_ROOM,                    5,  6 ; $F6
 	map_const AGATHAS_ROOM,                   5,  6 ; $F7
+	end_indoor_group POKEMON_LEAGUE_3
 DEF NUM_MAPS EQU const_value
 
 ; Indoor maps, such as houses, use this as the Map ID in their exit warps
 ; This map ID takes the player back to the last outdoor map they were on, stored in wLastMap
-DEF LAST_MAP EQU -1
+DEF LAST_MAP EQU $ff
+
+ASSERT NUM_MAPS <= LAST_MAP, "map IDs overlap LAST_MAP"

--- a/data/maps/town_map_entries.asm
+++ b/data/maps/town_map_entries.asm
@@ -1,4 +1,4 @@
-MACRO external_map
+MACRO outdoor_map
 	dn \2, \1
 	dw \3
 ENDM
@@ -7,113 +7,115 @@ ENDM
 ExternalMapEntries:
 	table_width 3
 	; x, y, name
-	external_map  2, 11, PalletTownName
-	external_map  2,  8, ViridianCityName
-	external_map  2,  3, PewterCityName
-	external_map 10,  2, CeruleanCityName
-	external_map 14,  5, LavenderTownName
-	external_map 10,  9, VermilionCityName
-	external_map  7,  5, CeladonCityName
-	external_map  8, 13, FuchsiaCityName
-	external_map  2, 15, CinnabarIslandName
-	external_map  0,  2, IndigoPlateauName
-	external_map 10,  5, SaffronCityName
-	external_map  0,  0, PalletTownName ; unused
-	external_map  2, 10, Route1Name
-	external_map  2,  6, Route2Name
-	external_map  4,  3, Route3Name
-	external_map  8,  2, Route4Name
-	external_map 10,  3, Route5Name
-	external_map 10,  8, Route6Name
-	external_map  8,  5, Route7Name
-	external_map 13,  5, Route8Name
-	external_map 13,  2, Route9Name
-	external_map 14,  4, Route10Name
-	external_map 12,  9, Route11Name
-	external_map 14,  9, Route12Name
-	external_map 13, 11, Route13Name
-	external_map 11, 12, Route14Name
-	external_map 10, 13, Route15Name
-	external_map  5,  5, Route16Name
-	external_map  4,  8, Route17Name
-	external_map  6, 13, Route18Name
-	external_map  6, 15, Route19Name
-	external_map  4, 15, Route20Name
-	external_map  2, 13, Route21Name
-	external_map  0,  8, Route22Name
-	external_map  0,  6, Route23Name
-	external_map 10,  1, Route24Name
-	external_map 11,  0, Route25Name
+	outdoor_map  2, 11, PalletTownName
+	outdoor_map  2,  8, ViridianCityName
+	outdoor_map  2,  3, PewterCityName
+	outdoor_map 10,  2, CeruleanCityName
+	outdoor_map 14,  5, LavenderTownName
+	outdoor_map 10,  9, VermilionCityName
+	outdoor_map  7,  5, CeladonCityName
+	outdoor_map  8, 13, FuchsiaCityName
+	outdoor_map  2, 15, CinnabarIslandName
+	outdoor_map  0,  2, IndigoPlateauName
+	outdoor_map 10,  5, SaffronCityName
+	outdoor_map  0,  0, PalletTownName ; unused
+	outdoor_map  2, 10, Route1Name
+	outdoor_map  2,  6, Route2Name
+	outdoor_map  4,  3, Route3Name
+	outdoor_map  8,  2, Route4Name
+	outdoor_map 10,  3, Route5Name
+	outdoor_map 10,  8, Route6Name
+	outdoor_map  8,  5, Route7Name
+	outdoor_map 13,  5, Route8Name
+	outdoor_map 13,  2, Route9Name
+	outdoor_map 14,  4, Route10Name
+	outdoor_map 12,  9, Route11Name
+	outdoor_map 14,  9, Route12Name
+	outdoor_map 13, 11, Route13Name
+	outdoor_map 11, 12, Route14Name
+	outdoor_map 10, 13, Route15Name
+	outdoor_map  5,  5, Route16Name
+	outdoor_map  4,  8, Route17Name
+	outdoor_map  6, 13, Route18Name
+	outdoor_map  6, 15, Route19Name
+	outdoor_map  4, 15, Route20Name
+	outdoor_map  2, 13, Route21Name
+	outdoor_map  0,  8, Route22Name
+	outdoor_map  0,  6, Route23Name
+	outdoor_map 10,  1, Route24Name
+	outdoor_map 11,  0, Route25Name
 	assert_table_length FIRST_INDOOR_MAP
 
 
-MACRO internal_map
-	db \1 + 1
+MACRO indoor_map
+	db INDOORGROUP_\1
 	dn \3, \2
 	dw \4
 ENDM
 
 ; the appearance of buildings and dungeons in the town map
 InternalMapEntries:
-	; maximum map id subject to this rule, x, y, name
-	internal_map OAKS_LAB,                       2, 11, PalletTownName
-	internal_map VIRIDIAN_GYM,                   2,  8, ViridianCityName
-	internal_map VIRIDIAN_FOREST_SOUTH_GATE,     2,  6, Route2Name
-	internal_map VIRIDIAN_FOREST,                2,  4, ViridianForestName
-	internal_map PEWTER_POKECENTER,              2,  3, PewterCityName
-	internal_map MT_MOON_B2F,                    6,  2, MountMoonName
-	internal_map CERULEAN_MART,                 10,  2, CeruleanCityName
-	internal_map MT_MOON_POKECENTER,             5,  2, Route4Name
-	internal_map CERULEAN_TRASHED_HOUSE_COPY,   10,  2, CeruleanCityName
-	internal_map DAYCARE,                       10,  4, Route5Name
-	internal_map UNDERGROUND_PATH_ROUTE_6_COPY, 10,  6, Route6Name
-	internal_map UNDERGROUND_PATH_ROUTE_7_COPY,  9,  5, Route7Name
-	internal_map UNDERGROUND_PATH_ROUTE_8,      11,  5, Route8Name
-	internal_map ROCK_TUNNEL_1F,                14,  3, RockTunnelName
-	internal_map POWER_PLANT,                   15,  4, PowerPlantName
-	internal_map ROUTE_11_GATE_2F,              13,  9, Route11Name
-	internal_map ROUTE_12_GATE_1F,              14,  7, Route12Name
-	internal_map BILLS_HOUSE,                   12,  0, SeaCottageName
-	internal_map VERMILION_DOCK,                10,  9, VermilionCityName
-	internal_map SS_ANNE_B1F_ROOMS,              9, 10, SSAnneName
-	internal_map VICTORY_ROAD_1F,                0,  4, VictoryRoadName
-	internal_map HALL_OF_FAME,                   0,  2, PokemonLeagueName
-	internal_map UNDERGROUND_PATH_NORTH_SOUTH,  10,  5, UndergroundPathName
-	internal_map CHAMPIONS_ROOM,                 0,  2, PokemonLeagueName
-	internal_map UNDERGROUND_PATH_WEST_EAST,    10,  5, UndergroundPathName
-	internal_map CELADON_HOTEL,                  7,  5, CeladonCityName
-	internal_map LAVENDER_POKECENTER,           14,  5, LavenderTownName
-	internal_map POKEMON_TOWER_7F,              15,  5, PokemonTowerName
-	internal_map LAVENDER_CUBONE_HOUSE,         14,  5, LavenderTownName
-	internal_map WARDENS_HOUSE,                  8, 13, FuchsiaCityName
-	internal_map SAFARI_ZONE_GATE,               8, 12, SafariZoneName
-	internal_map FUCHSIA_MEETING_ROOM,           8, 13, FuchsiaCityName
-	internal_map SEAFOAM_ISLANDS_B4F,            5, 15, SeafoamIslandsName
-	internal_map VERMILION_OLD_ROD_HOUSE,       10,  9, VermilionCityName
-	internal_map FUCHSIA_GOOD_ROD_HOUSE,         8, 13, FuchsiaCityName
-	internal_map POKEMON_MANSION_1F,             2, 15, PokemonMansionName
-	internal_map CINNABAR_MART_COPY,             2, 15, CinnabarIslandName
-	internal_map INDIGO_PLATEAU_LOBBY,           0,  2, IndigoPlateauName
-	internal_map MR_PSYCHICS_HOUSE,             10,  5, SaffronCityName
-	internal_map ROUTE_15_GATE_2F,               9, 13, Route15Name
-	internal_map ROUTE_16_FLY_HOUSE,             4,  5, Route16Name
-	internal_map ROUTE_12_SUPER_ROD_HOUSE,      14, 10, Route12Name
-	internal_map ROUTE_18_GATE_2F,               7, 13, Route18Name
-	internal_map SEAFOAM_ISLANDS_1F,             5, 15, SeafoamIslandsName
-	internal_map ROUTE_22_GATE,                  0,  7, Route22Name
-	internal_map VICTORY_ROAD_2F,                0,  4, VictoryRoadName
-	internal_map ROUTE_12_GATE_2F,              14,  7, Route12Name
-	internal_map VERMILION_TRADE_HOUSE,         10,  9, VermilionCityName
-	internal_map DIGLETTS_CAVE,                  3,  4, DiglettsCaveName
-	internal_map VICTORY_ROAD_3F,                0,  4, VictoryRoadName
-	internal_map UNUSED_MAP_CE,                  7,  5, RocketHQName
-	internal_map SILPH_CO_8F,                   10,  5, SilphCoName
-	internal_map POKEMON_MANSION_B1F,            2, 15, PokemonMansionName
-	internal_map SAFARI_ZONE_NORTH_REST_HOUSE,   8, 12, SafariZoneName
-	internal_map CERULEAN_CAVE_1F,               9,  1, CeruleanCaveName
-	internal_map NAME_RATERS_HOUSE,             14,  5, LavenderTownName
-	internal_map CERULEAN_BADGE_HOUSE,          10,  2, CeruleanCityName
-	internal_map ROCK_TUNNEL_B1F,               14,  3, RockTunnelName
-	internal_map SILPH_CO_ELEVATOR,             10,  5, SilphCoName
-	internal_map AGATHAS_ROOM,                   0,  2, PokemonLeagueName
+	table_width 4
+	; indoor map group, x, y, name
+	indoor_map PALLET_TOWN,         2, 11, PalletTownName
+	indoor_map VIRIDIAN_CITY,       2,  8, ViridianCityName
+	indoor_map ROUTE_2,             2,  6, Route2Name
+	indoor_map VIRIDIAN_FOREST,     2,  4, ViridianForestName
+	indoor_map PEWTER_CITY,         2,  3, PewterCityName
+	indoor_map MT_MOON,             6,  2, MountMoonName
+	indoor_map CERULEAN_CITY,      10,  2, CeruleanCityName
+	indoor_map ROUTE_4,             5,  2, Route4Name
+	indoor_map CERULEAN_CITY_2,    10,  2, CeruleanCityName
+	indoor_map ROUTE_5,            10,  4, Route5Name
+	indoor_map ROUTE_6,            10,  6, Route6Name
+	indoor_map ROUTE_7,             9,  5, Route7Name
+	indoor_map ROUTE_8,            11,  5, Route8Name
+	indoor_map ROCK_TUNNEL,        14,  3, RockTunnelName
+	indoor_map POWER_PLANT,        15,  4, PowerPlantName
+	indoor_map ROUTE_11,           13,  9, Route11Name
+	indoor_map ROUTE_12,           14,  7, Route12Name
+	indoor_map SEA_COTTAGE,        12,  0, SeaCottageName
+	indoor_map VERMILION_CITY,     10,  9, VermilionCityName
+	indoor_map SS_ANNE,             9, 10, SSAnneName
+	indoor_map VICTORY_ROAD,        0,  4, VictoryRoadName
+	indoor_map POKEMON_LEAGUE,      0,  2, PokemonLeagueName
+	indoor_map UNDERGROUND_PATH,   10,  5, UndergroundPathName
+	indoor_map POKEMON_LEAGUE_2,    0,  2, PokemonLeagueName
+	indoor_map UNDERGROUND_PATH_2, 10,  5, UndergroundPathName
+	indoor_map CELADON_CITY,        7,  5, CeladonCityName
+	indoor_map LAVENDER_TOWN,      14,  5, LavenderTownName
+	indoor_map POKEMON_TOWER,      15,  5, PokemonTowerName
+	indoor_map LAVENDER_TOWN_2,    14,  5, LavenderTownName
+	indoor_map FUCHSIA_CITY,        8, 13, FuchsiaCityName
+	indoor_map SAFARI_ZONE,         8, 12, SafariZoneName
+	indoor_map FUCHSIA_CITY_2,      8, 13, FuchsiaCityName
+	indoor_map SEAFOAM_ISLANDS,     5, 15, SeafoamIslandsName
+	indoor_map VERMILION_CITY_2,   10,  9, VermilionCityName
+	indoor_map FUCHSIA_CITY_3,      8, 13, FuchsiaCityName
+	indoor_map POKEMON_MANSION,     2, 15, PokemonMansionName
+	indoor_map CINNABAR_ISLAND,     2, 15, CinnabarIslandName
+	indoor_map INDIGO_PLATEAU,      0,  2, IndigoPlateauName
+	indoor_map SAFFRON_CITY,       10,  5, SaffronCityName
+	indoor_map ROUTE_15,            9, 13, Route15Name
+	indoor_map ROUTE_16,            4,  5, Route16Name
+	indoor_map ROUTE_12_2,         14, 10, Route12Name
+	indoor_map ROUTE_18,            7, 13, Route18Name
+	indoor_map SEAFOAM_ISLANDS_2,   5, 15, SeafoamIslandsName
+	indoor_map ROUTE_22,            0,  7, Route22Name
+	indoor_map VICTORY_ROAD_2,      0,  4, VictoryRoadName
+	indoor_map ROUTE_12_3,         14,  7, Route12Name
+	indoor_map VERMILION_CITY_3,   10,  9, VermilionCityName
+	indoor_map DIGLETTS_CAVE,       3,  4, DiglettsCaveName
+	indoor_map VICTORY_ROAD_3,      0,  4, VictoryRoadName
+	indoor_map ROCKET_HQ,           7,  5, RocketHQName
+	indoor_map SILPH_CO,           10,  5, SilphCoName
+	indoor_map POKEMON_MANSION_2,   2, 15, PokemonMansionName
+	indoor_map SAFARI_ZONE_2,       8, 12, SafariZoneName
+	indoor_map CERULEAN_CAVE,       9,  1, CeruleanCaveName
+	indoor_map LAVENDER_TOWN_3,    14,  5, LavenderTownName
+	indoor_map CERULEAN_CITY_3,    10,  2, CeruleanCityName
+	indoor_map ROCK_TUNNEL_2,      14,  3, RockTunnelName
+	indoor_map SILPH_CO_2,         10,  5, SilphCoName
+	indoor_map POKEMON_LEAGUE_3,    0,  2, PokemonLeagueName
+	assert_table_length NUM_INDOOR_MAP_GROUPS
 	db -1 ; end


### PR DESCRIPTION
This replaces the arbitrary last-in-sequence map IDs with map group names.

You still end up with two, three, four of the same location repeated (including many of the indoor maps repeating outdoor coordinates and names). We could use more macros to avoid redundancy there, but it might not be worth the extra complexity, whereas I think this is worthwhile on its own.