### PR TITLE
Refactor AI to use jr where possible

### DIFF
--- a/engine/battle/trainer_ai.asm
+++ b/engine/battle/trainer_ai.asm
@@ -640,21 +640,21 @@ AIUseXAccuracy: ; unreferenced
 	ld hl, wEnemyBattleStatus2
 	set USING_X_ACCURACY, [hl]
 	ld a, X_ACCURACY
-	jp AIPrintItemUse
+	jr AIPrintItemUse
 
 AIUseGuardSpec:
 	call AIPlayRestoringSFX
 	ld hl, wEnemyBattleStatus2
 	set PROTECTED_BY_MIST, [hl]
 	ld a, GUARD_SPEC
-	jp AIPrintItemUse
+	jr AIPrintItemUse
 
 AIUseDireHit: ; unreferenced
 	call AIPlayRestoringSFX
 	ld hl, wEnemyBattleStatus2
 	set GETTING_PUMPED, [hl]
 	ld a, DIRE_HIT
-	jp AIPrintItemUse
+	jr AIPrintItemUse
 
 AICheckIfHPBelowFraction:
 ; return carry if enemy trainer's current HP is below 1 / a of the maximum


### PR DESCRIPTION
While working on some AI improvements, I noticed a few lines in `trainer_ai.asm` where the function being jumped to is close enough byte-wise to use `jr` instead of `jp`.