### PR TITLE
Only add link time optimization if system supoprts it

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,18 +3,6 @@
 CC := gcc
 CFLAGS := -O3 -std=c11 -Wall -Wextra -pedantic
 
-ifeq ($(OS),Windows_NT)
-    NULL := NUL
-else
-    NULL := /dev/null
-endif
-
-PROBE_LTO := $(shell echo 'int main(void){return 0;}' | $(CC) -flto -x c - -o $(NULL) 2>$(NULL) && echo y)
-
-ifeq ($(PROBE_LTO),y)
-    CFLAGS += -flto
-endif
-
 tools := \
 	gfx \
 	make_patch \


### PR DESCRIPTION
Some systems (such as some old 32 bit systems and some distributions of mingw-w64 on Windows like w64devkit) don't support link time optimizations, which is added in the `tools/Makefile` makefile. I suggest adding a probe to test if link time optimization is supported, and only use it if it is.