### PR TITLE
Repair Iwata Asks URL

### DIFF
--- a/data/pokemon/mew.asm
+++ b/data/pokemon/mew.asm
@@ -6,7 +6,7 @@
 ; weren't going to be included in the final version of the game were removed,
 ; creating a miniscule 300 bytes of free space. So we thought that we could
 ; slot Mew in there. What we did would be unthinkable nowadays!"
-; http://iwataasks.nintendo.com/interviews/#/ds/pokemon/0/0
+; https://iwataasks.nintendo.com/interviews/ds/pokemon/0/0/
 
 MewPicFront:: INCBIN "gfx/pokemon/front/mew.pic"
 MewPicBack::  INCBIN "gfx/pokemon/back/mewb.pic"


### PR DESCRIPTION
Fixing an Iwata Asks URL in a comment. Nintendo have slightly changed how the URLs for Iwata Asks are structured, so the old URL no longer works.

I did a quick check of URLs in this project after finding a broken URL in pokecrystal (https://github.com/pret/pokecrystal/pull/1225).