### PR TITLE
Make DebugSetPokedexEntries automatically adapt to NUM_POKEMON changes

### DIFF
--- a/engine/debug/debug_party.asm
+++ b/engine/debug/debug_party.asm
@@ -126,14 +126,16 @@ IF DEF(_DEBUG)
 	ret
 
 DebugSetPokedexEntries:
-	ld b, NUM_POKEMON / 8
+IF NUM_POKEMON / 8 != 0
+	ld b, NUM_POKEMON / 8 ; 151 / 8 == 18
 	ld a, %11111111
 .loop
 	ld [hli], a
 	dec b
 	jr nz, .loop
-IF (NUM_POKEMON % 8) != 0 ; true by default
-	ld [hl], ((1 << (NUM_POKEMON % 8)) - 1) ; %01111111 by default
+ENDC
+IF NUM_POKEMON % 8 != 0
+	ld [hl], (1 << (NUM_POKEMON % 8)) - 1 ; (1 << 151 % 8)) - 1 == %01111111
 ENDC
 	ret
 


### PR DESCRIPTION
Today is not the first time I've seen people struggle with that function and ask for help in discord, so I decided to make it more user friendly.

Instead of hard-coding the value for the last dex data byte, this PR generates it from `NUM_POKEMON`, handling the case where `NUM_POKEMON` is a multiple of 8 by including the last byte in the loop and removing the post loop instruction that fills the next byte.

The constants are not useful outside the file so they get purged after use.