### PR TITLE
Fix some text formatting, constants, unreferenced local labels

### DIFF
--- a/data/text/text_2.asm
+++ b/data/text/text_2.asm
@@ -777,6 +777,7 @@ _FoundHiddenCoins2Text::
 
 _DroppedHiddenCoinsText::
 	text_start
+
 	para "Oops! Dropped"
 	line "some coins!"
 	done

--- a/data/text/text_4.asm
+++ b/data/text/text_4.asm
@@ -141,6 +141,7 @@ _PoofText::
 
 _ForgotAndText::
 	text_start
+
 	para "@"
 	text_ram wLearnMoveMonName
 	text " forgot"

--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -116,7 +116,7 @@ DrawFrameBlock:
 	ld a, [hli]
 	bit B_OAM_XFLIP, a
 	jr nz, .disableHorizontalFlip
-.enableHorizontalFlip
+; enable horizontal flip
 	set B_OAM_XFLIP, a
 	jr .storeFlags2
 .disableHorizontalFlip
@@ -2493,14 +2493,14 @@ AnimationShakeEnemyHUD:
 
 ; Copy wTileMap to VRAM such that the row below the enemy HUD (in wTileMap) is
 ; lined up with row 0 of the window.
-	ld hl, vBGMap1 - $20 * 7
+	ld hl, vBGMap1 - TILEMAP_WIDTH * 7
 	call BattleAnimCopyTileMapToVRAM
 
 ; Move the window so that the row below the enemy HUD (in BG map 0) lines up
 ; with the top row of the window on the screen. This makes it so that the window
 ; covers everything below the enemy HD with a copy that looks just like what
 ; was there before.
-	ld a, 7 * 8
+	ld a, 7 * TILE_HEIGHT
 	ldh [hWY], a
 
 ; Write OAM entries so that the copy of the back pic from the top of this

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3561,7 +3561,7 @@ CheckPlayerStatusConditions:
 	ld [wPlayerNumAttacksLeft], a
 	ld hl, GetPlayerAnimationType ; skip damage calculation (deal damage equal to last hit),
 	                              ; DecrementPP and MoveHitTest
-	jp nz, .returnToHL  ; redundant leftover code, the case wEnemyNumAttacksLeft == 0
+	jp nz, .returnToHL  ; redundant leftover code, the case wPlayerNumAttacksLeft == 0
 						; is handled within CheckNumAttacksLeft
 	jp .returnToHL
 
@@ -6790,8 +6790,7 @@ _LoadTrainerPic:
 	ld c, a
 	jp LoadUncompressedSpriteData
 
-; unreferenced
-ResetCryModifiers:
+ResetCryModifiers: ; unreferenced
 	xor a
 	ld [wFrequencyModifier], a
 	ld [wTempoModifier], a

--- a/engine/battle/print_type.asm
+++ b/engine/battle/print_type.asm
@@ -26,9 +26,9 @@ PrintType:
 ; erase "TYPE2/" if the mon only has 1 type
 EraseType2Text:
 	ld a, ' '
-	ld bc, $13
+	ld bc, SCREEN_WIDTH - 1
 	add hl, bc
-	ld bc, $6
+	ld bc, 6
 	jp FillMemory
 
 PrintMoveType:

--- a/engine/battle/print_type.asm
+++ b/engine/battle/print_type.asm
@@ -28,7 +28,7 @@ EraseType2Text:
 	ld a, ' '
 	ld bc, SCREEN_WIDTH - 1
 	add hl, bc
-	ld bc, 6
+	ld bc, CHARLEN("TYPE2/")
 	jp FillMemory
 
 PrintMoveType:

--- a/engine/events/pokemart.asm
+++ b/engine/events/pokemart.asm
@@ -67,7 +67,7 @@ DisplayPokemartDialogue_::
 	ld [wListMenuID], a
 	call DisplayListMenuID
 	jp c, .returnToMainPokemartMenu ; if the player closed the menu
-; confirm item sale, if the player is trying to sell a specific item
+; if the player is trying to sell a specific item, confirm the sale
 	call IsKeyItem
 	ld a, [wIsKeyItem]
 	and a

--- a/engine/events/pokemart.asm
+++ b/engine/events/pokemart.asm
@@ -67,7 +67,7 @@ DisplayPokemartDialogue_::
 	ld [wListMenuID], a
 	call DisplayListMenuID
 	jp c, .returnToMainPokemartMenu ; if the player closed the menu
-.confirmItemSale ; if the player is trying to sell a specific item
+; confirm item sale, if the player is trying to sell a specific item
 	call IsKeyItem
 	ld a, [wIsKeyItem]
 	and a

--- a/engine/menus/party_menu.asm
+++ b/engine/menus/party_menu.asm
@@ -157,7 +157,7 @@ RedrawPartyMenu_::
 ; if it does match
 	ld de, .ableToEvolveText
 .placeEvolutionStoneString
-	ld bc, 20 + 9 ; down 1 row and right 9 columns
+	ld bc, SCREEN_WIDTH + 9 ; down 1 row and right 9 columns
 	pop hl
 	push hl
 	add hl, bc

--- a/engine/menus/text_box.asm
+++ b/engine/menus/text_box.asm
@@ -112,7 +112,7 @@ GetTextBoxIDText:
 GetAddressOfScreenCoords:
 	push bc
 	hlcoord 0, 0
-	ld bc, 20
+	ld bc, SCREEN_WIDTH
 .loop ; loop to add d rows to the base address
 	ld a, d
 	and a
@@ -266,9 +266,9 @@ DisplayTwoOptionMenu:
 	pop hl
 	ld a, [hli]
 	and a ; put blank line before first menu item?
-	ld bc, 20 + 2
+	ld bc, SCREEN_WIDTH + 2
 	jr z, .noBlankLine
-	ld bc, 2 * 20 + 2
+	ld bc, 2 * SCREEN_WIDTH + 2
 .noBlankLine
 	ld a, [hli]
 	ld e, a

--- a/engine/movie/title2.asm
+++ b/engine/movie/title2.asm
@@ -24,12 +24,12 @@ TitleScroll:
 	ld e, 0 ; don't animate titleball
 
 	and a
-	jr nz, .ok
+	jr nz, _TitleScroll
 
 	ld bc, TitleScroll_Out
 	ld d, $00
 	ld e, 0 ; don't animate titleball
-.ok
+	; fallthrough
 
 _TitleScroll:
 	ld a, [bc]

--- a/engine/overworld/movement.asm
+++ b/engine/overworld/movement.asm
@@ -29,7 +29,7 @@ UpdatePlayerSprite:
 ; check if down
 	bit PLAYER_DIR_BIT_DOWN, a
 	jr z, .checkIfUp
-	xor a ; ld a, SPRITE_FACING_DOWN
+	xor a ; SPRITE_FACING_DOWN
 	jr .next
 .checkIfUp
 	bit PLAYER_DIR_BIT_UP, a

--- a/home/copy2.asm
+++ b/home/copy2.asm
@@ -91,7 +91,7 @@ CopyVideoData::
 	cp 8
 	jr nc, .keepgoing
 
-.done
+; done
 	ldh [hVBlankCopySize], a
 	call DelayFrame
 	ldh a, [hROMBankTemp]
@@ -140,7 +140,7 @@ CopyVideoDataDouble::
 	cp 8
 	jr nc, .keepgoing
 
-.done
+; done
 	ldh [hVBlankCopyDoubleSize], a
 	call DelayFrame
 	ldh a, [hROMBankTemp]

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -1132,7 +1132,7 @@ IsSpriteInFrontOfPlayer::
 IsSpriteInFrontOfPlayer2::
 	lb bc, $3c, $40 ; Y and X position of player sprite
 	ld a, [wSpritePlayerStateData1FacingDirection]
-; check if Player facing up
+; check if player facing up
 	cp SPRITE_FACING_UP
 	jr nz, .checkIfPlayerFacingDown
 ; facing up

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -935,7 +935,7 @@ LoadTileBlockMap::
 .noCarry
 	dec b
 	jr nz, .rowLoop
-.northConnection
+; north connection
 	ld a, [wNorthConnectedMap]
 	cp $ff
 	jr z, .southConnection
@@ -1132,7 +1132,7 @@ IsSpriteInFrontOfPlayer::
 IsSpriteInFrontOfPlayer2::
 	lb bc, $3c, $40 ; Y and X position of player sprite
 	ld a, [wSpritePlayerStateData1FacingDirection]
-.checkIfPlayerFacingUp
+; check if Player facing up
 	cp SPRITE_FACING_UP
 	jr nz, .checkIfPlayerFacingDown
 ; facing up
@@ -1400,7 +1400,7 @@ LoadCurrentMapView::
 	jr nz, .rowLoop
 	ld hl, wSurroundingTiles
 	ld bc, 0
-.adjustForYCoordWithinTileBlock
+; adjust for Y coord within tile block
 	ld a, [wYBlockCoord]
 	and a
 	jr z, .adjustForXCoordWithinTileBlock
@@ -1898,7 +1898,7 @@ CollisionCheckOnWater::
 	call CheckForJumpingAndTilePairCollisions
 	jr c, .collision
 	predef GetTileAndCoordsInFrontOfPlayer ; get tile in front of player (puts it in c and [wTileInFrontOfPlayer])
-	ld a, [wTileInFrontOfPlayer] ; tile in front of player
+	ld a, [wTileInFrontOfPlayer]
 	cp $14 ; water tile
 	jr z, .noCollision ; keep surfing if it's a water tile
 	cp $32 ; either the left tile of the S.S. Anne boarding platform or the tile on eastern coastlines (depending on the current tileset)
@@ -1939,11 +1939,10 @@ CollisionCheckOnWater::
 	jr .noCollision
 .checkIfVermilionDockTileset
 	ld a, [wCurMapTileset]
-	cp SHIP_PORT ; Vermilion Dock tileset
+	cp SHIP_PORT
 	jr nz, .noCollision ; keep surfing if it's not the boarding platform tile
 	jr .stopSurfing ; if it is the boarding platform tile, stop surfing
 
-; function to run the current map's script
 RunMapScript::
 	push hl
 	push de
@@ -1958,15 +1957,15 @@ RunMapScript::
 	pop de
 	pop hl
 	call RunNPCMovementScript
-	ld a, [wCurMap] ; current map number
-	call SwitchToMapRomBank ; change to the ROM bank the map's data is in
+	ld a, [wCurMap]
+	call SwitchToMapRomBank
 	ld hl, wCurMapScriptPtr
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
 	ld de, .return
 	push de
-	jp hl ; jump to script
+	jp hl
 .return
 	ret
 

--- a/home/pokemon.asm
+++ b/home/pokemon.asm
@@ -279,8 +279,8 @@ HandlePartyMenuInput::
 	ret
 .swappingPokemon
 	bit B_PAD_B, b
-	jr z, .handleSwap ; if not, handle swapping the pokemon
-.cancelSwap ; if the B button was pressed
+	jr z, .handleSwap
+; cancel swap if the B button was pressed
 	farcall ErasePartyMenuCursors
 	xor a
 	ld [wMenuItemToSwap], a

--- a/scripts/OaksLab.asm
+++ b/scripts/OaksLab.asm
@@ -502,7 +502,7 @@ OaksLabPlayerWatchRivalExitScript:
 .turnPlayerDown
 	cp $4
 	ret nz
-	xor a ; ld a, SPRITE_FACING_DOWN
+	xor a ; SPRITE_FACING_DOWN
 	ld [wSpritePlayerStateData1FacingDirection], a
 .done
 	ret

--- a/scripts/PalletTown.asm
+++ b/scripts/PalletTown.asm
@@ -94,7 +94,7 @@ PalletTownOakNotSafeComeWithMeScript:
 	ld a, [wStatusFlags5]
 	bit BIT_SCRIPTED_NPC_MOVEMENT, a
 	ret nz
-	xor a ; ld a, SPRITE_FACING_DOWN
+	xor a ; SPRITE_FACING_DOWN
 	ld [wSpritePlayerStateData1FacingDirection], a
 	ld a, TRUE
 	ld [wOakWalkedToPlayer], a

--- a/scripts/SilphCo11F.asm
+++ b/scripts/SilphCo11F.asm
@@ -261,8 +261,8 @@ SilphCo11FGiovanniStartBattleScript:
 	ld hl, wStatusFlags3
 	set BIT_TALKED_TO_TRAINER, [hl]
 	set BIT_PRINT_END_BATTLE_TEXT, [hl]
-	ld hl, SilphCo10FGiovanniILostAgainText
-	ld de, SilphCo10FGiovanniILostAgainText
+	ld hl, SilphCo11FGiovanniILostAgainText
+	ld de, SilphCo11FGiovanniILostAgainText
 	call SaveEndBattleTextPointers
 	ldh a, [hSpriteIndex]
 	ld [wSpriteIndex], a
@@ -338,8 +338,8 @@ SilphCo11FGiovanniText:
 	text_far _SilphCo11FGiovanniText
 	text_end
 
-SilphCo10FGiovanniILostAgainText:
-	text_far _SilphCo10FGiovanniILostAgainText
+SilphCo11FGiovanniILostAgainText:
+	text_far _SilphCo11FGiovanniILostAgainText
 	text_end
 
 SilphCo11FGiovanniYouRuinedOurPlansText:
@@ -382,7 +382,7 @@ SilphCo11FRocket2AfterBattleText:
 	text_far _SilphCo11FRocket2AfterBattleText
 	text_end
 
-SilphCo10FPorygonText: ; unreferenced
+SilphCo11FPorygonText: ; unreferenced
 	text_asm
 	ld hl, .Text
 	call PrintText
@@ -391,5 +391,5 @@ SilphCo10FPorygonText: ; unreferenced
 	jp TextScriptEnd
 
 .Text:
-	text_far _SilphCo10FPorygonText
+	text_far _SilphCo11FPorygonText
 	text_end

--- a/text/FuchsiaGym_2.asm
+++ b/text/FuchsiaGym_2.asm
@@ -33,6 +33,7 @@ _FuchsiaGymKogaReceivedTM06Text::
 
 _FuchsiaGymKogaTM06ExplanationText::
 	text_start
+
 	para "TM06 contains"
 	line "TOXIC!"
 

--- a/text/OaksLab.asm
+++ b/text/OaksLab.asm
@@ -102,6 +102,7 @@ _OaksLabOak1DeliverParcelText::
 
 _OaksLabOak1ParcelThanksText::
 	text_start
+
 	para "Ah! This is the"
 	line "custom # BALL"
 	cont "I ordered!"
@@ -131,6 +132,7 @@ _OaksLabOak1ReceivedPokeballsText::
 
 _OaksLabGivePokeballsExplanationText::
 	text_start
+
 	para "When a wild"
 	line "#MON appears,"
 	cont "it's fair game."

--- a/text/SilphCo11F.asm
+++ b/text/SilphCo11F.asm
@@ -75,7 +75,7 @@ _SilphCo11FGiovanniText::
 	line "world of pain!"
 	done
 
-_SilphCo10FGiovanniILostAgainText::
+_SilphCo11FGiovanniILostAgainText::
 	text "Arrgh!!"
 	line "I lost again!?"
 	prompt
@@ -129,7 +129,7 @@ _SilphCo11FRocket2AfterBattleText::
 	cont "#MON tough!"
 	done
 
-_SilphCo10FPorygonText::
+_SilphCo11FPorygonText::
 	text "The monitor has"
 	line "#MON on it!"
 	done

--- a/text/VermilionCity.asm
+++ b/text/VermilionCity.asm
@@ -73,6 +73,7 @@ _VermilionCityMachopText::
 
 _VermilionCityMachopStompingTheLandFlatText::
 	text_start
+
 	para "A MACHOP is"
 	line "stomping the land"
 	cont "flat."


### PR DESCRIPTION
There usually is a blank line before `para`, including if the previous line is a single `text_start`.
Fix some incorrect labels in `SilphCo11F.asm` (this was first found in https://github.com/pret/pokeyellow/pull/134)
Remove more of the redundant comments `DoThis:: ; function that does this`